### PR TITLE
fix: update-vault broken after bootstrap git reset (v1.0.1)

### DIFF
--- a/.claude/commands/update-vault.md
+++ b/.claude/commands/update-vault.md
@@ -1,8 +1,12 @@
+---
+description: Cherry-pick improvements from the upstream template into this vault
+---
+
 # /update-vault
 
 Met à jour ce vault depuis le template `tetra-plg/boiling-brain` en amont.
 
-Utilise ce workflow pour récupérer les nouveaux scripts, slash-commands, décisions d'architecture, ou améliorations publiées dans le template après ton bootstrap.
+Utilise ce workflow pour récupérer les nouveaux scripts, slash-commands, ou décisions d'architecture publiés dans le template après ton bootstrap.
 
 ## Étapes
 
@@ -12,60 +16,85 @@ Utilise ce workflow pour récupérer les nouveaux scripts, slash-commands, déci
 git remote add template-upstream https://github.com/tetra-plg/boiling-brain.git 2>/dev/null \
   && echo "remote template-upstream ajouté" \
   || echo "remote template-upstream déjà configuré"
-git fetch template-upstream
+git fetch template-upstream --tags
 ```
 
-### 2. Affiche les commits disponibles
+### 2. Résoudre le baseline
 
 ```bash
-git log HEAD..template-upstream/main --oneline
+BOOTSTRAP_SHA=$(cat .template-bootstrap-sha 2>/dev/null || echo "")
+
+if [ -z "$BOOTSTRAP_SHA" ]; then
+  # Rétrocompat v1.0.0 : utiliser le tag v1.0.0 comme baseline
+  BOOTSTRAP_SHA=$(git rev-list -n 1 v1.0.0 2>/dev/null || echo "")
+fi
+
+if [ -z "$BOOTSTRAP_SHA" ]; then
+  echo "BASELINE_MISSING"
+else
+  echo "BASELINE $BOOTSTRAP_SHA"
+  git log ${BOOTSTRAP_SHA}..template-upstream/main --oneline
+fi
 ```
 
-Présente la liste à l'utilisateur. Si vide : « Ton vault est à jour. »
+- Si `BASELINE_MISSING` : informer l'utilisateur qu'aucun baseline n'a pu être trouvé et proposer de créer `.template-bootstrap-sha` manuellement (voir Notes).
+- Si la liste est vide : « Ton vault est à jour. »
+- Sinon : présenter la liste des commits disponibles.
 
-### 3. Demande l'action via AskUserQuestion
+### 3. Identifier les fichiers modifiés
 
-```json
-{
-  "questions": [{
-    "question": "Que veux-tu faire avec ces mises à jour ?",
-    "header": "Action",
-    "multiSelect": false,
-    "options": [
-      {"label": "Cherry-pick sélectif", "description": "Applique commit par commit. Recommandé : tu choisis ce que tu intègres."},
-      {"label": "Voir les diffs sans modifier", "description": "Affiche les changements pour décider ensuite."},
-      {"label": "Annuler", "description": "Ne modifie rien."}
-    ]
-  }]
-}
-```
-
-### 4. Cherry-pick sélectif
-
-Pour chaque commit sélectionné :
+Pour chaque commit listé, identifier les fichiers changés **qui existent dans le vault** :
 
 ```bash
-git cherry-pick <sha>
+git diff --name-only ${BOOTSTRAP_SHA} template-upstream/main \
+  | grep -v '\.tpl$' \
+  | grep -v '^BOOTSTRAP\.md$' \
+  | grep -v '^PLACEHOLDERS\.md$' \
+  | grep -v '^RELEASE_NOTES\.md$' \
+  | grep -v '^CONTRIBUTING\.md$' \
+  | while read f; do [ -e "$f" ] && echo "$f"; done
 ```
 
-En cas de conflit :
-- Affiche le diff (`git diff --stat HEAD`)
-- Demande à l'utilisateur de résoudre manuellement puis `git cherry-pick --continue`
+Présenter cette liste à l'utilisateur via `AskUserQuestion` (multiSelect) : quels fichiers veut-il mettre à jour ?
 
-### 5. Voir les diffs
+### 4. Appliquer fichier par fichier
+
+Pour chaque fichier sélectionné :
 
 ```bash
-git diff HEAD template-upstream/main -- <fichier>
+git show template-upstream/main:<fichier> > <fichier>
 ```
 
-Présente fichier par fichier les changements pertinents (scripts, commandes, décisions).
+> **Pourquoi `git show` plutôt que `cherry-pick` ?**
+> Le bootstrap réinitialise l'historique git (`rm -rf .git/ && git init`). Le vault n'a donc aucun ancêtre commun avec le template — `cherry-pick` tenterait de rejouer des diffs sur un ancêtre inexistant et échouerait systématiquement. `git show` copie directement le contenu cible, sans dépendance à l'historique.
+
+Après application de chaque fichier, afficher un diff rapide :
+
+```bash
+git diff <fichier>
+```
+
+### 5. Commit
+
+```bash
+git add <fichiers mis à jour>
+git commit -m "chore: update-vault depuis template-upstream ($(date +%Y-%m-%d))"
+```
 
 ## Notes
 
-- **Tes personnalisations sont préservées** : les fichiers générés par le bootstrap (agents, hubs, CLAUDE.md, overview.md) ont des noms distincts de ceux du template. Le cherry-pick ne les touche pas.
-- **Fichiers les plus susceptibles d'être mis à jour** : `scripts/`, `.claude/commands/`, `wiki/decisions/` (décisions architecturales génériques).
-- **Fichiers qui ne te concernent pas** : `BOOTSTRAP.md`, `PLACEHOLDERS.md`, `*.tpl` — ils ont été consommés lors de ton bootstrap et tu n'en as plus besoin.
-- **Si un nouveau script ou command est ajouté** sans commit clair, tu peux le copier manuellement :
-  ```bash
-  git show template-upstream/main:.claude/commands/nouveau-script.md > .claude/commands/nouveau-script.md
-  ```
+**Fichiers jamais mis à jour (consommés au bootstrap) :**
+`*.tpl`, `BOOTSTRAP.md`, `PLACEHOLDERS.md`, `RELEASE_NOTES.md`, `CONTRIBUTING.md`.
+Ces fichiers ont été utilisés pour générer ton vault et n'existent plus (ou ont été déplacés). Ils sont exclus automatiquement.
+
+**Fichiers propres à ton instance (jamais dans le template) :**
+Tes agents (`.claude/agents/<domain>-expert.md`), tes hubs (`wiki/domains/*.md`), ton `CLAUDE.md`, `wiki/overview.md`, etc. ont des noms distincts des fichiers template — ils ne seront jamais écrasés.
+
+**Baseline manquant (vault pré-v1.0.1) :**
+Si ni `.template-bootstrap-sha` ni le tag `v1.0.0` ne sont trouvés, crée le fichier manuellement :
+```bash
+git fetch template-upstream --tags
+git rev-list -n 1 v1.0.0 > .template-bootstrap-sha
+git add .template-bootstrap-sha
+git commit -m "fix: add template bootstrap sha (retrocompat)"
+```

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -542,6 +542,10 @@ Crée aussi `.obsidian/app.json` minimal :
 ### 5.10 Reset git + commit initial
 
 ```bash
+# Enregistrer le SHA du template avant de supprimer son historique.
+# Utilisé par /update-vault pour savoir à partir d'où lister les nouveaux commits.
+git rev-parse HEAD > .template-bootstrap-sha
+
 rm -rf .git/
 git init
 git add -A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 Nothing yet.
 
+## [v1.0.1] — hotfix
+
+### Fixed
+
+- **`/update-vault` inutilisable après bootstrap** : le bootstrap réinitialise l'historique git (`rm -rf .git/ && git init`), laissant le vault sans ancêtre commun avec le template. `git log HEAD..template-upstream/main` retournait alors tout l'historique du template, et `git cherry-pick` échouait sur les fichiers `.tpl` consommés au bootstrap.
+
+- **`BOOTSTRAP.md` section 5.10** : enregistre désormais le SHA du template dans `.template-bootstrap-sha` avant de supprimer le `.git/`. Ce fichier sert de baseline pour les futures mises à jour via `/update-vault`.
+
+- **`/update-vault`** : remplace `cherry-pick` par une approche fichier par fichier (`git show template-upstream/main:<fichier> > <fichier>`), indépendante de l'historique git. Exclut automatiquement les fichiers consommés au bootstrap (`*.tpl`, `BOOTSTRAP.md`, `PLACEHOLDERS.md`, etc.).
+
+### Migration depuis v1.0.0
+
+**Option A — automatique (recommandée) :**
+
+```bash
+git remote add template-upstream https://github.com/tetra-plg/boiling-brain.git 2>/dev/null; true
+git fetch template-upstream --tags
+git show template-upstream/main:.claude/commands/update-vault.md \
+  > .claude/commands/update-vault.md
+git add .claude/commands/update-vault.md
+git commit -m "fix: update-vault retrocompat v1.0.0"
+```
+
+Puis lance `/update-vault` — le fallback détecte l'absence de `.template-bootstrap-sha` et utilise le tag `v1.0.0` comme baseline automatiquement.
+
+**Option B — manuelle :**
+
+```bash
+git fetch template-upstream --tags
+git rev-list -n 1 v1.0.0 > .template-bootstrap-sha
+git add .template-bootstrap-sha
+git commit -m "fix: add template bootstrap sha (retrocompat v1.0.0)"
+```
+
 ## [v1.0.0] — 2026-04-30 (first public release)
 
 ### Repository


### PR DESCRIPTION
## Problème

Le bootstrap réinitialise l'historique git (`rm -rf .git/` + `git init`), laissant le vault sans ancêtre commun avec le template. Résultat : `/update-vault` était inutilisable pour tous les utilisateurs bootstrappés.

**Deux symptômes :**
1. `git log HEAD..template-upstream/main` retournait **tout** l'historique du template au lieu des seuls commits postérieurs au bootstrap
2. `git cherry-pick` échouait sur les fichiers `.tpl` et autres fichiers consommés au bootstrap (ils n'existent plus dans le vault)

## Fix

**`BOOTSTRAP.md` section 5.10** — enregistre le SHA du template dans `.template-bootstrap-sha` avant de supprimer le `.git/` :
```bash
git rev-parse HEAD > .template-bootstrap-sha  # ← nouveau
rm -rf .git/
git init
git add -A && git commit -m "vault initial..."
```

**`update-vault.md`** — réécriture complète :
- Utilise `.template-bootstrap-sha` comme baseline
- Fallback sur le tag `v1.0.0` si le fichier est absent (rétrocompat utilisateurs v1.0.0)
- Remplace `cherry-pick` par `git show template-upstream/main:<fichier> > <fichier>` — copie directe du contenu, sans dépendance à l'historique git
- Exclut automatiquement les fichiers consommés au bootstrap (`*.tpl`, `BOOTSTRAP.md`, `PLACEHOLDERS.md`, etc.)
- Approche fichier par fichier avec `AskUserQuestion` multiSelect

**`CHANGELOG.md`** — entrée v1.0.1 avec deux options de migration pour les utilisateurs v1.0.0.

## Rétrocompatibilité v1.0.0

Les utilisateurs existants n'ont pas de `.template-bootstrap-sha`. Le fallback détecte automatiquement cette situation et utilise le tag `v1.0.0` comme baseline — aucune action manuelle requise si l'utilisateur met à jour `update-vault.md` via l'Option A du CHANGELOG.

## Test plan

- [x] Bootstrapper un vault depuis `main` → vérifier que `.template-bootstrap-sha` est créé et commité
- [x] Lancer `/update-vault` depuis le vault bootstrappé → vérifier que seuls les commits postérieurs au SHA sont listés
- [x] Simuler un vault v1.0.0 (sans `.template-bootstrap-sha`) → vérifier que le fallback `v1.0.0` tag fonctionne
- [x] Vérifier que les fichiers `.tpl` sont bien exclus de la liste proposée