### PR TITLE
fix(scan-raw): handle special chars in source_path and covered_paths (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ## [Unreleased]
 
+### Fixed
+
+- **`scripts/scan-raw.sh` : 3 bugs de parsing causant des faux `NEW`** ([#3](https://github.com/tetra-plg/boiling-brain/issues/3)).
+  - **Bug 1 (apostrophes mangées)** : `tr -d '"'"'` aux lignes 79, 106, 126 supprimait à la fois les guillemets YAML et les apostrophes des chemins. Tout `source_path` contenant une apostrophe (ex: `2026-01-30-claude-code-obsidian-cpr.md` qui mentionnait `BotFather to 'Hello'`) était mal indexé. Remplacé par `sed 's/^"//; s/"$//'` qui ne touche qu'aux guillemets en début/fin de chaîne.
+  - **Bug 2 (parenthèses cassent les clés d'array assoc bash)** : un `source_path` ou `covered_paths` contenant `()` ou d'autres caractères spéciaux shell (`*`, `[`, `?`) cassait l'indexation. Neutralisé par une fonction `_safe_key` qui encode les clés via `printf '%q'` à l'écriture **et** au lookup, dans `path_to_slug`, `dir_to_slug` et `meta_to_slug`. Élimine toute la classe de bugs de quoting bash sans dépendance externe.
+  - **Bug 3 (espaces multiples)** : couvert par le même `printf '%q'` — les espaces sont maintenant préservés exactement.
+  - Tableau parallèle `indexed_paths` ajouté pour permettre l'itération sur les paths originaux (les clés encodées de `path_to_slug` ne sont pas réversibles).
+
+### Added
+
+- **`scripts/test-scan-raw.sh`** : fixture de test reproduisant les 3 cas (apostrophe, parenthèses, espaces multiples) + un cas combiné (apostrophe + parenthèses). Asserte que tous reportent `SKIP` au scan. Exit code 1 si régression.
+
 ### Removed
 
 - **`RELEASE_NOTES.md`** : fichier supprimé. Il dupliquait le `CHANGELOG.md` et le body des releases GitHub, ce qui créait du drift à chaque release. La source unique pour les notes de release est désormais `CHANGELOG.md`. Le body GitHub est rédigé directement via `gh release create --notes-file <(extrait du CHANGELOG)` ou édité depuis l'interface.

--- a/scripts/scan-raw.sh
+++ b/scripts/scan-raw.sh
@@ -57,11 +57,20 @@ if [ ${#files[@]} -eq 0 ]; then
   exit 0
 fi
 
+# --- Encodage des clés d'array associatif ---
+# Les arrays associatifs bash mishandlent les caractères spéciaux dans les clés
+# (parenthèses, globs, espaces multiples, etc.). printf %q neutralise toute
+# la classe de bugs de quoting en encodant la clé une fois pour toutes.
+_safe_key() {
+  printf '%q' "$1"
+}
+
 # --- Construction de l'index : raw_path → (slug, sha256) ---
 # Charge une fois tous les wiki/sources pour éviter O(N×M) grep
 
-declare -A path_to_slug   # raw_path (ou raw_dir/) → slug
-declare -A path_to_sha    # raw_path → source_sha256 stocké dans la page
+declare -A path_to_slug   # safe_key(raw_path) → slug
+declare -A path_to_sha    # safe_key(raw_path) → source_sha256 stocké dans la page
+declare -a indexed_paths  # paths originaux (pour itération — les clés encodées de path_to_slug ne le permettent pas)
 
 while IFS= read -r source_file; do
   slug=$(basename "$source_file" .md)
@@ -76,10 +85,11 @@ while IFS= read -r source_file; do
   while IFS= read -r line; do
     # Début source_path
     if echo "$line" | grep -q "^source_path:"; then
-      val=$(echo "$line" | sed 's/^source_path:[[:space:]]*//' | tr -d '"'"'")
+      val=$(echo "$line" | sed 's/^source_path:[[:space:]]*//' | sed 's/^"//; s/"$//')
       if [ -n "$val" ]; then
         # Scalaire
-        path_to_slug["$val"]="$slug"
+        path_to_slug["$(_safe_key "$val")"]="$slug"
+        indexed_paths+=("$val")
         [ -z "$first_sp" ] && first_sp="$val"
         in_sp=0
       else
@@ -103,9 +113,10 @@ while IFS= read -r source_file; do
         in_covered=0
         continue
       fi
-      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | tr -d '"'"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | sed 's/^"//; s/"$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
       if [ -n "$item" ]; then
-        path_to_slug["$item"]="$slug"
+        path_to_slug["$(_safe_key "$item")"]="$slug"
+        indexed_paths+=("$item")
         [ $in_sp -eq 1 ] && [ -z "$first_sp" ] && first_sp="$item"
       fi
     fi
@@ -123,8 +134,11 @@ while IFS= read -r source_file; do
         in_sources=0
         continue
       fi
-      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | tr -d '"'"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-      [ -n "$item" ] && path_to_slug["$item"]="$slug"
+      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | sed 's/^"//; s/"$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      if [ -n "$item" ]; then
+        path_to_slug["$(_safe_key "$item")"]="$slug"
+        indexed_paths+=("$item")
+      fi
     fi
   done < "$source_file"
 
@@ -133,7 +147,7 @@ while IFS= read -r source_file; do
     sha_line=$(grep "^source_sha256:" "$source_file" 2>/dev/null | head -1 | sed 's/^source_sha256:[[:space:]]*//')
     # Ignore si c'est aussi une liste YAML (commence par vide → valeur vide)
     if [ -n "$sha_line" ] && [[ "$sha_line" != -* ]]; then
-      path_to_sha["$first_sp"]="$sha_line"
+      path_to_sha["$(_safe_key "$first_sp")"]="$sha_line"
     fi
   fi
 
@@ -143,17 +157,19 @@ done < <(find "$WIKI_SOURCES" -name "*.md" -type f)
 # Pour chaque source_path indexé, on note son répertoire parent → slug
 # Cela permet de SKIP un fichier si un autre fichier du même dossier est déjà couvert.
 
-declare -A dir_to_slug   # raw/foo/bar/ → slug (premier slug rencontré pour ce dossier)
-declare -A meta_to_slug  # raw/videos-meta/SLUG.meta.md → slug via transcript
+declare -A dir_to_slug   # safe_key(raw/foo/bar/) → slug (premier slug rencontré pour ce dossier)
+declare -A meta_to_slug  # safe_key(raw/videos-meta/SLUG.meta.md) → slug via transcript
 
-for indexed_path in "${!path_to_slug[@]}"; do
+for indexed_path in "${indexed_paths[@]}"; do
   [ -z "$indexed_path" ] && continue
+  ip_key=$(_safe_key "$indexed_path")
 
   # Index des répertoires implicites (≥4 niveaux de profondeur requis)
   idir="${indexed_path%/*}/"
+  idir_key=$(_safe_key "$idir")
   depth=$(printf '%s' "$idir" | tr -cd '/' | wc -c | tr -d ' ')
-  if [ "$depth" -ge 4 ] && [ -z "${dir_to_slug[$idir]+_}" ]; then
-    dir_to_slug["$idir"]="${path_to_slug[$indexed_path]}"
+  if [ "$depth" -ge 4 ] && [ -z "${dir_to_slug[$idir_key]+_}" ]; then
+    dir_to_slug["$idir_key"]="${path_to_slug[$ip_key]}"
   fi
 
   # Index videos-meta → transcript
@@ -161,7 +177,8 @@ for indexed_path in "${!path_to_slug[@]}"; do
     filename="${indexed_path##*/}"
     filename="${filename%.md}"
     meta_path="raw/videos-meta/${filename}.meta.md"
-    [ -z "${meta_to_slug[$meta_path]+_}" ] && meta_to_slug["$meta_path"]="${path_to_slug[$indexed_path]}"
+    meta_key=$(_safe_key "$meta_path")
+    [ -z "${meta_to_slug[$meta_key]+_}" ] && meta_to_slug["$meta_key"]="${path_to_slug[$ip_key]}"
   fi
 done
 
@@ -170,11 +187,12 @@ done
 for abs_path in "${files[@]}"; do
   # Chemin relatif depuis la racine du vault
   rel="${abs_path#$VAULT_ROOT/}"
+  rel_key=$(_safe_key "$rel")
 
   # 1. Match exact sur source_path ou covered_paths
-  if [ -n "${path_to_slug[$rel]+_}" ]; then
-    slug="${path_to_slug[$rel]}"
-    stored_sha="${path_to_sha[$rel]:-}"
+  if [ -n "${path_to_slug[$rel_key]+_}" ]; then
+    slug="${path_to_slug[$rel_key]}"
+    stored_sha="${path_to_sha[$rel_key]:-}"
     if [ -n "$stored_sha" ]; then
       current_sha=$(sha256sum "$abs_path" 2>/dev/null | cut -d' ' -f1)
       if [ "$current_sha" != "$stored_sha" ]; then
@@ -193,8 +211,9 @@ for abs_path in "${files[@]}"; do
     parent=$(dirname "$parent")
     [ "$parent" = "." ] || [ "$parent" = "raw" ] || [ "$parent" = "" ] && break
     parent_slash="${parent}/"
-    if [ -n "${path_to_slug[$parent_slash]+_}" ]; then
-      covered="${path_to_slug[$parent_slash]}"
+    parent_key=$(_safe_key "$parent_slash")
+    if [ -n "${path_to_slug[$parent_key]+_}" ]; then
+      covered="${path_to_slug[$parent_key]}"
       break
     fi
   done
@@ -206,14 +225,15 @@ for abs_path in "${files[@]}"; do
 
   # 3. Match implicite : même répertoire qu'un fichier déjà indexé (≥4 niveaux de profondeur)
   rel_dir="$(dirname "$rel")/"
-  if [ -n "${dir_to_slug[$rel_dir]+_}" ]; then
-    echo "SKIP     $rel  (covered-by-dir-implicit: ${dir_to_slug[$rel_dir]})"
+  rel_dir_key=$(_safe_key "$rel_dir")
+  if [ -n "${dir_to_slug[$rel_dir_key]+_}" ]; then
+    echo "SKIP     $rel  (covered-by-dir-implicit: ${dir_to_slug[$rel_dir_key]})"
     continue
   fi
 
   # 4. Correspondance videos-meta → transcript déjà ingéré
-  if [ -n "${meta_to_slug[$rel]+_}" ]; then
-    echo "SKIP     $rel  (covered-by-transcript: ${meta_to_slug[$rel]})"
+  if [ -n "${meta_to_slug[$rel_key]+_}" ]; then
+    echo "SKIP     $rel  (covered-by-transcript: ${meta_to_slug[$rel_key]})"
     continue
   fi
 

--- a/scripts/test-scan-raw.sh
+++ b/scripts/test-scan-raw.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# test-scan-raw.sh — Vérifie que scan-raw.sh gère correctement les caractères
+# spéciaux dans les chemins (apostrophes, parenthèses, espaces multiples).
+#
+# Usage:
+#   bash scripts/test-scan-raw.sh
+#
+# Codes de sortie : 0 = tous les cas SKIP, 1 = au moins un cas en NEW (régression).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCAN_RAW="$SCRIPT_DIR/scan-raw.sh"
+
+# --- Préparation d'un vault temporaire avec fichiers raw piégés ---
+
+TESTDIR=$(mktemp -d /tmp/test-scan-raw.XXXXXX)
+trap 'rm -rf "$TESTDIR"' EXIT
+
+mkdir -p "$TESTDIR/raw/notes" "$TESTDIR/wiki/sources"
+
+# Fichier 1 : apostrophe dans le nom (cas réel BB : `2026-01-30-claude-code-obsidian-cpr.md`
+# qui mentionnait `BotFather to 'Hello'` dans son source_path original)
+APOSTROPHE_FILE="$TESTDIR/raw/notes/2026-01-30-claude's-note.md"
+echo "Note avec apostrophe dans le nom" > "$APOSTROPHE_FILE"
+
+# Fichier 2 : parenthèses dans le nom
+PARENS_FILE="$TESTDIR/raw/notes/foo (bar).md"
+echo "Note avec parenthèses dans le nom" > "$PARENS_FILE"
+
+# Fichier 3 : espaces multiples dans le nom
+SPACES_FILE="$TESTDIR/raw/notes/multi  space.md"
+echo "Note avec doubles espaces dans le nom" > "$SPACES_FILE"
+
+# Fichier 4 : caractères composés (parenthèses + apostrophe)
+COMBO_FILE="$TESTDIR/raw/notes/it's (composite).md"
+echo "Note combinant apostrophe et parenthèses" > "$COMBO_FILE"
+
+# Calcul du sha256 de chaque fichier
+APOSTROPHE_SHA=$(sha256sum "$APOSTROPHE_FILE" | cut -d' ' -f1)
+PARENS_SHA=$(sha256sum "$PARENS_FILE" | cut -d' ' -f1)
+SPACES_SHA=$(sha256sum "$SPACES_FILE" | cut -d' ' -f1)
+COMBO_SHA=$(sha256sum "$COMBO_FILE" | cut -d' ' -f1)
+
+# Page wiki qui couvre les 4 raw via source_path (scalaire) + covered_paths (liste)
+cat > "$TESTDIR/wiki/sources/2026-05-01-trapped-paths.md" <<EOF
+---
+type: source
+source_path: "raw/notes/2026-01-30-claude's-note.md"
+source_sha256: $APOSTROPHE_SHA
+covered_paths:
+  - "raw/notes/foo (bar).md"
+  - "raw/notes/multi  space.md"
+  - "raw/notes/it's (composite).md"
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Trapped paths — fixture pour test-scan-raw.sh
+EOF
+
+# --- Exécution du scan ---
+
+# scan-raw.sh attend un layout vault avec wiki/sources et raw/ relatif au script.
+# On copie le script dans le testdir et on l'exécute depuis là.
+mkdir -p "$TESTDIR/scripts"
+cp "$SCAN_RAW" "$TESTDIR/scripts/scan-raw.sh"
+
+# Le script utilise SCRIPT_DIR/.. comme VAULT_ROOT.
+output=$(bash "$TESTDIR/scripts/scan-raw.sh" 2>&1)
+
+echo "=== Sortie du scan ==="
+echo "$output"
+echo ""
+
+# --- Vérifications ---
+
+errors=0
+
+check_skip() {
+  local pattern="$1"
+  local label="$2"
+  if echo "$output" | grep -qE "^SKIP\s+.*${pattern}"; then
+    echo "✅ $label : SKIP"
+  else
+    echo "❌ $label : devrait être SKIP, vérifie la sortie"
+    errors=$((errors + 1))
+  fi
+}
+
+# Bug 1 — apostrophe (source_path scalaire)
+check_skip "claude.s-note" "Bug 1 (apostrophe, source_path)"
+
+# Bug 2 — parenthèses (covered_paths liste)
+check_skip "foo \(bar\)" "Bug 2 (parenthèses, covered_paths)"
+
+# Bug 3 — espaces multiples (covered_paths liste)
+check_skip "multi  space" "Bug 3 (espaces multiples, covered_paths)"
+
+# Cas combiné (apostrophe + parenthèses)
+check_skip "it.s \(composite\)" "Cas combiné (apostrophe + parenthèses)"
+
+# Vérification : aucun NEW dans la sortie
+if echo "$output" | grep -qE "^NEW\s+raw/notes"; then
+  echo "❌ Au moins un fichier reporté NEW alors qu'il devrait être SKIP :"
+  echo "$output" | grep "^NEW"
+  errors=$((errors + 1))
+fi
+
+if [ "$errors" -eq 0 ]; then
+  echo ""
+  echo "🎉 Tous les cas reportent correctement SKIP."
+  exit 0
+else
+  echo ""
+  echo "❌ $errors erreur(s) détectée(s)."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Résout [#3](https://github.com/tetra-plg/boiling-brain/issues/3) — 3 bugs de parsing dans `scripts/scan-raw.sh` causant des faux `NEW` à chaque scan.

**Approche hybride** validée dans le plan : plug-in fixes pour Bug 1 (apostrophes) + neutralisation `printf %q` pour Bug 2 (parenthèses) qui couvre aussi Bug 3 (espaces multiples) et toute la classe de bugs de quoting bash.

### Détail des fixes

- **Bug 1 (apostrophes mangées)** : `tr -d '"'"'` aux lignes 79, 106, 126 supprimait à la fois les guillemets YAML et les apostrophes des chemins. Tout `source_path` contenant une apostrophe (cas réel BB : `2026-01-30-claude-code-obsidian-cpr.md`) était mal indexé. Remplacé par `sed 's/^"//; s/"$//'` qui ne touche qu'aux guillemets en début/fin de chaîne.
- **Bug 2 (parenthèses cassent les clés d'array assoc bash)** : neutralisé par une fonction `_safe_key` qui encode les clés via `printf '%q'` à l'écriture **et** au lookup, dans `path_to_slug`, `dir_to_slug` et `meta_to_slug`. Élimine toute la classe de bugs de quoting (`(`, `)`, `*`, `[`, `?`, `;`, etc.) sans dépendance externe.
- **Bug 3 (espaces multiples)** : couvert par le même `printf '%q'` — les espaces sont préservés exactement.

Tableau parallèle `indexed_paths` ajouté pour permettre l'itération sur les paths originaux (les clés encodées de `path_to_slug` ne sont pas réversibles).

## Test plan

- [x] `bash scripts/test-scan-raw.sh` (fixture nouvelle) — apostrophe + parenthèses + espaces multiples + cas combiné → tous `SKIP` au scan.
- [x] Test régression manuel : `SKIP` / `MODIFIED` / `NEW` fonctionnent toujours sur cas standard.
- [x] `bash -n scripts/scan-raw.sh` — syntaxe OK.
- [ ] **À valider en condition réelle** sur le BoilingBrain : exécuter `bash scripts/scan-raw.sh raw/` après merge → vérifier que les pages affectées (notamment `2026-01-30-claude-code-obsidian-cpr.md`, `2026-04-24-claude-code-costs-karpathy.md` mentionnées dans le radar BB du 2026-05-01) passent de `NEW` à `SKIP`.

## Notes

- PR indépendante de PR #7 (split CLAUDE.md.tpl). Les deux ciblent `develop` et seront mergées dans l'ordre arbitraire.
- Pas de nouvelle dépendance externe (pas de `jq`, pas de refonte structurelle du parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)