### PR TITLE
feat(create-issue): slash-command to file sanitized issues upstream (#4)

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,255 @@
+---
+description: Crée une issue sanitizée sur le repo template upstream à partir du contexte de la session courante (sanitization automatique des données vault-specific)
+argument-hint: [bug|enhancement|docs|question] [<courte description optionnelle>]
+---
+
+Run the CREATE-ISSUE workflow on: $ARGUMENTS
+
+Cette commande remonte un bug, une amélioration, une question doc ou une question générale vers le repo **template upstream** (`tetra-plg/boiling-brain` par défaut). Elle génère un draft depuis le contexte de la conversation, **sanitize** les données vault-specific via les règles de `.claude/rules/sanitization-issues.md`, propose la prévisualisation, puis crée l'issue via `gh issue create`.
+
+Aucune création silencieuse : la dernière étape est toujours une validation utilisateur via `AskUserQuestion`.
+
+## 1. Pré-requis
+
+Vérifier dans cet ordre, stopper au premier échec avec un message clair :
+
+```bash
+# 1.1 — gh CLI authentifié
+gh auth status 2>&1 | head -5
+# Si échec : "Lance `gh auth login` puis relance /create-issue."
+
+# 1.2 — Remote template-upstream configuré (si absent, le proposer)
+TEMPLATE_REMOTE_URL=$(git remote get-url template-upstream 2>/dev/null)
+if [ -z "$TEMPLATE_REMOTE_URL" ]; then
+  echo "Le remote template-upstream n'est pas configuré."
+  echo "Configure-le via :"
+  echo "  git remote add template-upstream https://github.com/tetra-plg/boiling-brain.git"
+fi
+```
+
+Extraire `<owner/repo>` depuis l'URL du remote (parser `https://github.com/<owner>/<repo>.git` ou `git@github.com:<owner>/<repo>.git`). Stocker dans `TEMPLATE_REPO`.
+
+## 2. Détermination du type d'issue
+
+Parser `$ARGUMENTS` :
+- Premier token = type, parmi `bug`, `enhancement` (alias `feature`), `docs`, `question`.
+- Reste = description courte optionnelle pour pré-remplir le titre.
+
+Si type absent ou invalide → `AskUserQuestion` :
+
+```json
+{
+  "questions": [{
+    "question": "Quel type d'issue veux-tu créer ?",
+    "header": "Type",
+    "multiSelect": false,
+    "options": [
+      {"label": "bug", "description": "Quelque chose ne marche pas comme attendu (sections : Contexte, Reproduction, Fix proposé, Test plan, Impact)"},
+      {"label": "enhancement", "description": "Proposition d'amélioration ou nouvelle feature (sections : Problème, Proposition, Alternatives, Out-of-scope, Critères de done)"},
+      {"label": "docs", "description": "Manque ou imprécision dans la doc du template (sections : Section concernée, Manque constaté, Suggestion)"},
+      {"label": "question", "description": "Question d'usage ou de design (sections : Contexte, Question, Ce qui a déjà été essayé)"}
+    ]
+  }]
+}
+```
+
+Mapping label GitHub : `bug` → `bug`, `enhancement` / `feature` → `enhancement`, `docs` → `documentation`, `question` → `question`. Vérifier que le label existe sur le repo cible :
+
+```bash
+gh label list --repo "$TEMPLATE_REPO" --json name --jq '.[].name'
+```
+
+Si le label n'existe pas, créer l'issue sans label (signaler à l'utilisateur dans la prévisualisation).
+
+## 3. Collecte du contexte
+
+Lire la conversation courante pour identifier le sujet de l'issue :
+- Quel fichier / quel comportement / quel scénario est en jeu ?
+- Quelle erreur observée vs attendue (pour bug) / quel manque (pour enhancement / docs) / quel point de confusion (pour question) ?
+- Y a-t-il des extraits de code, traces d'erreur, ou commandes pertinentes ?
+
+Si la description du `$ARGUMENTS` est fournie, l'utiliser comme **titre candidat** mais la reformuler si elle contient des références internes (slugs, wikilinks).
+
+## 4. Rédaction du draft selon template
+
+### Structure par type
+
+**bug** :
+```markdown
+## Contexte
+
+<2-3 phrases : où, dans quel scénario, depuis quand>
+
+## Reproduction
+
+<Étapes minimales reproductibles. Snippet de commande / fichier si pertinent.>
+
+## Fix proposé
+
+<Hypothèse de correction. Liste de fichiers / lignes / approche.>
+
+## Test plan
+
+- [ ] <cas test 1>
+- [ ] <cas test 2>
+
+## Impact
+
+<Bloquant ? Cosmétique ? Combien de vaults touchés ?>
+```
+
+**enhancement** :
+```markdown
+## Problème
+
+<Pourquoi le statu quo est insuffisant>
+
+## Proposition
+
+<Description de la solution proposée>
+
+## Alternatives considérées
+
+<Autres approches, pourquoi écartées>
+
+## Out-of-scope (v1)
+
+<Ce qu'on ne fait PAS dans cette première version>
+
+## Critères de done
+
+- [ ] <critère 1>
+- [ ] <critère 2>
+```
+
+**docs** :
+```markdown
+## Section concernée
+
+<Fichier + section précise (ex: README.md "Workflow loop")>
+
+## Manque constaté
+
+<Ce qui n'est pas clair, manquant, ou faux>
+
+## Suggestion
+
+<Ce qu'on pourrait ajouter ou reformuler>
+```
+
+**question** :
+```markdown
+## Contexte
+
+<Configuration / scénario>
+
+## Question
+
+<La question, formulée précisément>
+
+## Ce qui a déjà été essayé
+
+<Ressources lues, tests effectués>
+```
+
+## 5. Sanitization
+
+Appliquer les règles de `.claude/rules/sanitization-issues.md` au titre **et** au body du draft :
+
+- **Strip silencieux** : wikilinks `[[...]]`, chemins `raw/notes/YYYY-MM-DD-*`, slugs de domaines listés dans `wiki/index.md`, chemins `wiki/sources/<date>-<slug>.md`, emails.
+- **Flag pour review** : noms propres en milieu de phrase (hors liste blanche `Claude`, `Anthropic`, `GitHub`, etc.), noms d'entités lues depuis `wiki/entities/*.md`, handles `@xxx`.
+- **Anonymisation des cas concrets** : reformuler « 18 pages BB ont eu X » en « N pages affected (figure measured on the BoilingBrain reference vault) » ou « Some vault pages had X ».
+
+Construire un **rapport de sanitization** avec :
+- Liste des transformations silencieuses appliquées (qui peut être copiée pour audit).
+- Liste des éléments flaggés à confirmer par l'utilisateur.
+
+## 6. Prévisualisation et validation
+
+Afficher au format :
+
+```
+=== Issue draft (sanitized) ===
+
+Repo cible : tetra-plg/boiling-brain
+Label : bug
+
+Titre :
+<titre sanitizé>
+
+Body :
+<body sanitizé>
+
+=== Sanitization ===
+Transformations silencieuses :
+- <wikilink> → <terme générique>
+- <slug> → domain X
+- ...
+
+À confirmer (flaggé) :
+- Nom propre détecté : "<token>" — confirmer ou éditer
+- ...
+```
+
+Puis `AskUserQuestion` :
+
+```json
+{
+  "questions": [{
+    "question": "Que faire avec ce draft ?",
+    "header": "Issue",
+    "multiSelect": false,
+    "options": [
+      {"label": "✅ Créer l'issue", "description": "Crée l'issue via gh issue create. Affichera l'URL en retour."},
+      {"label": "✏️ Éditer manuellement", "description": "N'crée rien. Affiche le draft prêt à copier-coller dans l'UI GitHub."},
+      {"label": "❌ Annuler", "description": "Abandonne sans rien créer."}
+    ]
+  }]
+}
+```
+
+## 7. Création (si validé)
+
+```bash
+gh issue create \
+  --repo "$TEMPLATE_REPO" \
+  --title "$SANITIZED_TITLE" \
+  --body "$SANITIZED_BODY" \
+  --label "$LABEL"
+```
+
+Capturer l'URL retournée (stdout). En cas d'échec (réseau, label inconnu, droits insuffisants) : afficher l'erreur + le draft copy-pastable comme fallback.
+
+## 8. Suite (radar)
+
+Après création réussie, proposer via `AskUserQuestion` :
+
+```json
+{
+  "questions": [{
+    "question": "Ajouter un suivi dans wiki/radar.md ?",
+    "header": "Radar",
+    "multiSelect": false,
+    "options": [
+      {"label": "✅ Oui, suivi dans le radar", "description": "Ajoute une entrée `- [ ] **[Template · YYYY-MM-DD]** <description courte>. → <URL>` dans wiki/radar.md catégorie « À surveiller »"},
+      {"label": "❌ Non, pas de suivi local", "description": "L'issue vit sa vie sur GitHub uniquement"}
+    ]
+  }]
+}
+```
+
+Si oui : ajouter l'entrée à `wiki/radar.md`, commit dédié `chore(radar): track upstream issue <#N>`.
+
+Logger dans `wiki/log.md` : `## [YYYY-MM-DD] create-issue | <type> #<numéro> <titre court>`.
+
+## Cas d'usage proactif depuis le radar
+
+`/create-issue` peut aussi être déclenchée **proactivement** par le main context lors de l'affichage du radar (« montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui »). Quand une entrée du radar concerne **l'environnement template** (typiquement un bug ou manque touchant `scripts/scan-raw.sh`, `.claude/commands/*.md`, `BOOTSTRAP.md`, ou tout fichier propagé par `/update-vault`), le main context propose à l'utilisateur :
+
+> Cette entrée du radar concerne le template upstream. Veux-tu la remonter via `/create-issue <type>` ?
+
+Le main context **ne crée pas l'issue tout seul** — il propose juste la commande, l'utilisateur valide, le workflow standard ci-dessus prend le relais.
+
+## Fallback `gh auth login` manquant
+
+Si à l'étape 1.1 `gh auth status` échoue, ne pas continuer. Afficher le draft sanitizé prêt à copier-coller (sans même faire la sanitization complète — juste un draft brut). L'utilisateur peut alors `gh auth login` puis relancer, ou copier-coller dans l'UI GitHub.

--- a/.claude/rules/sanitization-issues.md
+++ b/.claude/rules/sanitization-issues.md
@@ -1,0 +1,80 @@
+---
+description: Règles dures de sanitization avant publication d'une issue sur le repo template upstream (évite la fuite de données du vault)
+paths:
+  - ".claude/commands/create-issue.md"
+  - "scripts/migrations/*-create-issue*.md"
+---
+
+# Sanitization avant `gh issue create` vers le template
+
+Quand l'utilisateur invoque `/create-issue` pour remonter un bug ou une amélioration vers le template upstream, le draft est généré depuis le contexte de la session Claude Code en cours. Ce contexte est susceptible de contenir des données spécifiques au vault de l'utilisateur (slugs de domaines, noms propres, chemins de contenu privé, références internes). Ces règles définissent ce qui doit être stripé, transformé ou flaggé pour review humaine **avant** la création de l'issue.
+
+## Règles strip (transformation silencieuse)
+
+Les patterns suivants sont **transformés systématiquement** dans le titre et le body du draft :
+
+### 1. Wikilinks Obsidian
+
+- Pattern : `\[\[.+?\]\]` (avec ou sans alias `|`).
+- Action : strip complet, **ou** remplacement par un terme générique si le contexte est explicite (ex: `[[concepts/llm-wiki]]` → `the LLM wiki concept`).
+- Justification : les wikilinks sont des références internes au vault, sans valeur en dehors.
+
+### 2. Chemins de contenu privé
+
+- Pattern : `raw/notes/YYYY-MM-DD-<anything>.md`, `raw/transcripts/YYYY-MM-DD-<anything>.md`, `raw/clippings/<anything>.md`.
+- Action : remplacer par un placeholder générique (`raw/notes/<example>.md`, `raw/transcripts/<example>.md`).
+- Justification : les noms de fichiers révèlent souvent le sujet de la note privée.
+
+### 3. Slugs de domaines vault-specific
+
+- Lire la liste des domaines depuis `wiki/index.md` (section `## Domaines`) ou les noms de fichiers `wiki/domains/*.md`.
+- Pour chaque slug détecté dans le draft (mention textuelle ou path `wiki/domains/<slug>.md`), remplacer par `domain X`, `domain Y`, etc., **sauf si** le slug correspond à un terme générique attendu dans le template (`metier`, `tech`, `ia` peuvent rester si le contexte l'exige — mais c'est rare).
+- Justification : les domaines sont une projection personnelle du vault.
+
+### 4. Chemins `wiki/sources/<date>-<slug>.md`
+
+- Pattern : `wiki/sources/[0-9]{4}-[0-9]{2}-[0-9]{2}-<slug>.md`.
+- Action : remplacer par `wiki/sources/<example>.md` ou par une description fonctionnelle (`a source page about X`).
+- Justification : révèle ce que l'utilisateur a ingéré récemment.
+
+## Règles flag (review humaine obligatoire)
+
+Les patterns suivants ne sont **pas stripés silencieusement** mais signalés à l'utilisateur dans la prévisualisation, qui doit les valider ou les éditer :
+
+### 5. Noms propres de personnes
+
+- Heuristique : tout token capitalisé en **milieu de phrase** (hors début), sauf liste blanche connue (`Claude`, `Anthropic`, `GitHub`, `Linux`, noms de produits OSS standards).
+- Action : surligner dans la prévisualisation avec un avertissement « Nom propre détecté : `<token>` — confirmer ou éditer ».
+- Justification : un nom propre peut être une vraie personne du vault (collègue, formateur, sujet d'étude). La détection automatique aurait trop de faux positifs pour strip silencieusement.
+
+### 6. Noms d'entités externes spécifiques au vault
+
+- Pattern : noms d'entreprises, produits internes, projets non-publics référencés dans `wiki/entities/`.
+- Action : lire les noms d'entités depuis `wiki/entities/*.md` et flagger toute occurrence dans le draft.
+- Justification : un produit interne ou un client du vault ne doit jamais sortir publiquement.
+
+### 7. Identifiants utilisateur (emails, handles)
+
+- Pattern : `[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+`, `@[a-zA-Z0-9_]+` (handles potentiels).
+- Action : strip silencieux pour les emails. Flag pour les handles (peuvent être des références publiques légitimes comme `@anthropics`).
+
+## Règles de structure
+
+### 8. Anonymisation des cas concrets
+
+Si le draft cite un cas concret (« 18 pages BB ont eu... »), proposer une formulation neutre : « Some vault pages had... » ou « N pages affected (figure measured on the BoilingBrain reference vault) ». Le mainteneur du template peut choisir de préciser dans le contexte de l'issue, mais la formulation par défaut est anonyme.
+
+### 9. Templates par type d'issue
+
+- **bug** : sections `## Contexte`, `## Reproduction`, `## Fix proposé`, `## Test plan`, `## Impact`.
+- **enhancement** (alias `feature`) : sections `## Problème`, `## Proposition`, `## Alternatives considérées`, `## Out-of-scope`, `## Critères de done`.
+- **docs** : sections `## Section concernée`, `## Manque constaté`, `## Suggestion`.
+- **question** : sections `## Contexte`, `## Question`, `## Ce qui a déjà été essayé`.
+
+Le draft suit l'un de ces templates selon le type. Pas de section narrative libre.
+
+## Verdict final
+
+La création de l'issue est **toujours validée par l'utilisateur** via `AskUserQuestion` avec 3 options : créer, éditer manuellement, annuler. Aucune création silencieuse, même si toutes les règles strip/flag passent. Le filet de sécurité humain reste obligatoire.
+
+Si l'utilisateur choisit « éditer manuellement », l'issue n'est pas créée — un draft copy-pastable est affiché pour qu'il l'utilise dans l'UI GitHub.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,28 +13,23 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`.claude/rules/`** : trois conventions transverses formalisées (frontmatter, pages-wiki, raw-vs-cache) avec frontmatter `paths:` qui permet l'auto-chargement par Claude Code quand un agent travaille sur un path matchant. Pattern documenté par Anthropic (Boris Cherny, 24 mars 2026). Propagé par `/update-vault` aux vaults existants.
 - **`.claude/template-version`** : fichier de versionning explicite du template (format `template-version: X.Y.Z` + `template-sha:` + `last-updated:`). Source de vérité unique pour la machine de migration de `/update-vault`. Créé au bootstrap (BOOTSTRAP 5.10), mis à jour à chaque `/update-vault` réussi.
 - **`scripts/migrations/`** : nouveau dossier pour les migrations breaking entre versions du template. Pattern `v<X.Y.Z>-<description>.md` (slash-commands Claude Code interactifs). Premier exemple : `v1.0.2-claude-md-slim.md`. Invoqués par `/update-vault` dans la chaîne entre version locale et cible.
+- **`/create-issue [bug|enhancement|docs|question]`** ([#4](https://github.com/tetra-plg/boiling-brain/issues/4)) : nouvelle slash-command pour remonter une issue vers le repo template upstream depuis le contexte de la session courante, avec **sanitization automatique** des données vault-specific (wikilinks, slugs de domaines, chemins privés `raw/notes/<date>-*`, emails, noms d'entités du wiki). Validation utilisateur obligatoire via `AskUserQuestion` avant `gh issue create`. Règles formalisées dans `.claude/rules/sanitization-issues.md` (auto-chargé par `paths:`). Workflow proactif : quand le radar contient une entrée concernant l'environnement template, le main context propose `/create-issue` à l'utilisateur (sans création silencieuse).
+- **`scripts/test-scan-raw.sh`** : fixture de test reproduisant les 3 cas du fix `scan-raw.sh` (apostrophe, parenthèses, espaces multiples) + un cas combiné. Asserte que tous reportent `SKIP` au scan. Exit code 1 si régression.
 
 ### Changed
 
-- **`CLAUDE.md.tpl` réduit à 111 lignes** (depuis 268, soit −59 %), conformément à la recommandation Anthropic « < 200 lignes » pour préserver l'adhérence aux instructions. Les sections Workflows détaillés (~143 lignes) sont remplacées par une table compacte qui pointe vers `.claude/commands/*.md`. La section Conventions (22 lignes) devient un pointeur vers `.claude/rules/`. Les sections instance-specific (Domaines, Agents experts, Architecture) restent inchangées.
+- **`CLAUDE.md.tpl` réduit à 112 lignes** (depuis 268, soit −58 %), conformément à la recommandation Anthropic « < 200 lignes » pour préserver l'adhérence aux instructions. Les sections Workflows détaillés (~143 lignes) sont remplacées par une table compacte qui pointe vers `.claude/commands/*.md`. La section Conventions (22 lignes) devient un pointeur vers `.claude/rules/`. Les sections instance-specific (Domaines, Agents experts, Architecture) restent inchangées.
 - **`/update-vault` refactoré en machine de migration versionnée** : lit `.claude/template-version` (avec fallback rétrocompat sur `.template-bootstrap-sha` pour v1.0.1 et sur le tag `v1.0.0` pour v1.0.0), compare avec la version cible upstream, propage les fichiers nouveaux (incluant `.claude/rules/**` et `scripts/migrations/**`), exécute la chaîne de migrations applicables, bumpe `.claude/template-version` à la fin si toutes les migrations sont acceptées.
 - **`BOOTSTRAP.md` section 5.10** : enrichit `.claude/template-version` avec le SHA et la date du bootstrap (en plus de `.template-bootstrap-sha` historique conservé pour rétrocompat).
 
 ### Fixed
 
-- **Trou de propagation des conventions vers les vaults existants** : avant v1.0.2, toute évolution de convention (frontmatter, immutabilité `raw/`, etc.) vivait dans `CLAUDE.md.tpl` consommé au bootstrap, sans mécanisme de propagation. Cas concret : 18 pages du vault de référence ont eu `source_sha256` rempli avec un placeholder par les agents experts (batch 2026-04-29) — non corrigeable sans patch manuel par vault. Avec v1.0.2, la règle « `source_sha256` toujours via `shasum -a 256` » vit dans `.claude/rules/frontmatter.md` et est propagée automatiquement par `/update-vault`.
-
-### Fixed
-
-- **`scripts/scan-raw.sh` : 3 bugs de parsing causant des faux `NEW`** ([#3](https://github.com/tetra-plg/boiling-brain/issues/3)).
+- **Trou de propagation des conventions vers les vaults existants** ([#5](https://github.com/tetra-plg/boiling-brain/issues/5)) : avant v1.0.2, toute évolution de convention (frontmatter, immutabilité `raw/`, etc.) vivait dans `CLAUDE.md.tpl` consommé au bootstrap, sans mécanisme de propagation. Cas concret : 18 pages du vault de référence ont eu `source_sha256` rempli avec un placeholder par les agents experts (batch 2026-04-29) — non corrigeable sans patch manuel par vault. Avec v1.0.2, la règle « `source_sha256` toujours via `shasum -a 256` » vit dans `.claude/rules/frontmatter.md` et est propagée automatiquement par `/update-vault`.
+- **`scripts/scan-raw.sh` : 3 bugs de parsing causant des faux `NEW`** ([#3](https://github.com/tetra-plg/boiling-brain/issues/3)) :
   - **Bug 1 (apostrophes mangées)** : `tr -d '"'"'` aux lignes 79, 106, 126 supprimait à la fois les guillemets YAML et les apostrophes des chemins. Tout `source_path` contenant une apostrophe (ex: `2026-01-30-claude-code-obsidian-cpr.md` qui mentionnait `BotFather to 'Hello'`) était mal indexé. Remplacé par `sed 's/^"//; s/"$//'` qui ne touche qu'aux guillemets en début/fin de chaîne.
   - **Bug 2 (parenthèses cassent les clés d'array assoc bash)** : un `source_path` ou `covered_paths` contenant `()` ou d'autres caractères spéciaux shell (`*`, `[`, `?`) cassait l'indexation. Neutralisé par une fonction `_safe_key` qui encode les clés via `printf '%q'` à l'écriture **et** au lookup, dans `path_to_slug`, `dir_to_slug` et `meta_to_slug`. Élimine toute la classe de bugs de quoting bash sans dépendance externe.
   - **Bug 3 (espaces multiples)** : couvert par le même `printf '%q'` — les espaces sont maintenant préservés exactement.
   - Tableau parallèle `indexed_paths` ajouté pour permettre l'itération sur les paths originaux (les clés encodées de `path_to_slug` ne sont pas réversibles).
-
-### Added
-
-- **`scripts/test-scan-raw.sh`** : fixture de test reproduisant les 3 cas (apostrophe, parenthèses, espaces multiples) + un cas combiné (apostrophe + parenthèses). Asserte que tous reportent `SKIP` au scan. Exit code 1 si régression.
 
 ### Removed
 

--- a/CLAUDE.md.tpl
+++ b/CLAUDE.md.tpl
@@ -13,7 +13,7 @@ Ce vault est un **LLM Wiki** : un écosystème de connaissances maintenu par LLM
 .claude/
   agents/        # subagents Claude Code — un expert par domaine (+ suggestions accumulées pour l'évolution)
   agent-memory/  # mémoires inter-sessions par agent (état du domaine, patterns en attente)
-  commands/      # slash commands (/ingest, /ingest-video, /query, /save, /lint, /evolve-agent, /update-vault{{slash_commands_extras}})
+  commands/      # slash commands (/ingest, /ingest-video, /query, /save, /lint, /evolve-agent, /update-vault, /create-issue{{slash_commands_extras}})
   rules/         # conventions auto-chargées par Claude Code via le champ `paths` du frontmatter
   template-version  # version du template avec laquelle ce vault est aligné
 
@@ -87,8 +87,9 @@ Les workflows détaillés vivent dans `.claude/commands/`. Tableau récapitulati
 | `/lint` | Détection de contradictions, orphelins, lacunes |
 | `/evolve-agent <domain>` | Évolution curée du prompt d'un agent depuis ses suggestions accumulées |
 | `/update-vault` | Récupère les améliorations upstream du template (machine de migration versionnée) |
+| `/create-issue [type]` | Crée une issue sanitizée sur le repo template upstream à partir du contexte courant |
 
-Pour le radar : « montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui » → lecture de `wiki/radar.md` + extraction des suggestions accumulées des agents (≥2 occurrences ou jugées structurantes).
+Pour le radar : « montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui » → lecture de `wiki/radar.md` + extraction des suggestions accumulées des agents (≥2 occurrences ou jugées structurantes). **Si une entrée du radar concerne l'environnement template** (bug ou manque touchant `scripts/`, `.claude/commands/`, `BOOTSTRAP.md`, ou tout fichier propagé par `/update-vault`), proposer à l'utilisateur de la remonter via `/create-issue <type>` — sans créer l'issue tout seul, juste suggérer la commande.
 
 ## Décisions d'architecture
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ This lets agents (and you, via `/query`) navigate the wiki without paying the fu
 | `/lint [domain]` | Detect contradictions, orphans, missing cross-references, gaps. |
 | `/evolve-agent <domain>` | Curated update to a domain expert's prompt, fed by accumulated `.suggestions.md`. |
 | `/sync-repos [names]` *(optional)* | Snapshot GitHub repos by SHA into `raw/tracked-repos/` (or any `dest` declared per source). |
-| `/update-vault` | Cherry-pick improvements from the upstream template into your vault instance. |
+| `/update-vault` | Cherry-pick improvements from the upstream template into your vault instance (versioned migration machine). |
+| `/create-issue [type]` | Sanitize a draft and open an issue on the upstream template repo (auto-strips wikilinks, vault-specific slugs, private paths). Always validated by you before `gh issue create`. |
 
 ## Workflow loop
 


### PR DESCRIPTION
## Summary

Résout [#4](https://github.com/tetra-plg/boiling-brain/issues/4) — nouvelle slash-command `/create-issue [bug|enhancement|docs|question] [description]` qui rédige une issue depuis le contexte de la session courante, sanitize les données vault-specific, et la pousse sur le repo template upstream via `gh issue create`.

Toujours validée par l'utilisateur avant création — pas de création silencieuse.

### Sanitization en 3 couches

Règles dans `.claude/rules/sanitization-issues.md` (auto-chargées via `paths:` quand `/create-issue.md` est en scope) :

- **Strip silencieux** : wikilinks `[[...]]`, chemins `raw/notes/YYYY-MM-DD-*`, slugs de domaines lus depuis `wiki/index.md`, chemins `wiki/sources/<date>-<slug>.md`, emails.
- **Flag pour review humaine** : noms propres en milieu de phrase (avec allow-list `Claude`/`Anthropic`/`GitHub`...), entités lues depuis `wiki/entities/*.md`, handles `@xxx`.
- **Anonymisation des cas concrets** : « 18 pages BB ont eu X » → « N pages affected (figure measured on the BoilingBrain reference vault) ».

### Templates par type d'issue

- **bug** : Contexte / Reproduction / Fix proposé / Test plan / Impact
- **enhancement** : Problème / Proposition / Alternatives / Out-of-scope / Critères de done
- **docs** : Section concernée / Manque constaté / Suggestion
- **question** : Contexte / Question / Ce qui a déjà été essayé

### Intégration proactive RADAR (commentaire de l'issue #4)

Quand le radar contient une entrée concernant l'environnement template (bug ou manque touchant `scripts/`, `.claude/commands/`, `BOOTSTRAP.md`, ou tout fichier propagé par `/update-vault`), le main context propose `/create-issue` à l'utilisateur — **sans créer l'issue tout seul**, juste en suggérant la commande. Le workflow standard prend ensuite le relais.

## Files

- `.claude/commands/create-issue.md` (nouveau) — slash-command complète : pré-requis (`gh auth`, remote `template-upstream`), détermination du type, collecte du contexte, draft, sanitization, prévisualisation `AskUserQuestion` (créer / éditer / annuler), `gh issue create`, suite radar.
- `.claude/rules/sanitization-issues.md` (nouveau) — règles dures formalisées, paths-scopée sur `.claude/commands/create-issue.md` pour auto-chargement Claude Code.
- `CLAUDE.md.tpl` — `/create-issue` ajouté dans la liste `.claude/commands/` et dans la table des slash-commands ; section radar enrichie avec le comportement proactif.
- `CHANGELOG.md` — section `Added` pour `/create-issue` + **consolidation** des sections `Added` et `Fixed` qui s'étaient retrouvées fragmentées par les merges des PRs #7 et #8.
- `README.md` — `/create-issue` ajouté dans la table des slash-commands shipped.

## Test plan

- [x] Smoke test : frontmatter valides sur `.claude/commands/create-issue.md` et `.claude/rules/sanitization-issues.md`.
- [x] Smoke test : labels GitHub `bug` / `documentation` / `enhancement` / `question` tous présents sur `tetra-plg/boiling-brain`.
- [x] Smoke test : `CLAUDE.md.tpl` reste à 112 lignes (sous le seuil 200).
- [x] Smoke test : table des slash-commands à jour, 9 commandes au total (les 8 existantes + `/create-issue`).
- [x] **À valider en condition réelle** : invoquer `/create-issue bug "test draft pipeline"` dans une session Claude Code → vérifier la chaîne pré-requis → AskUserQuestion type → draft sanitizé → prévisualisation → `gh issue create`. Choisir « ✏️ Éditer manuellement » pour ne pas polluer l'issue tracker pendant le test.
- [x] **À valider en condition réelle** : test négatif avec un draft contenant un `[[wikilink]]` → doit être stripé. Avec un slug de domaine vault → doit être remplacé par `domain X`.
- [x] **À valider en condition réelle** : test du fallback `gh auth login` manquant → la commande doit échouer gracieusement avec un draft copy-pastable.

## Notes

- Dernière PR du cycle v1.0.2. Une fois mergée dans `develop`, on déclenche le merge `develop` → `main` + tag v1.0.2 + `gh release create`.
- Pas de dépendance externe nouvelle (`gh` CLI déjà utilisé par `/sync-repos` et BOOTSTRAP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)