### PR TITLE
chore(release): finalize CHANGELOG for v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
-## [Unreleased] — v1.0.2
+## [v1.0.2] — 2026-05-01
 
 ### Added
 


### PR DESCRIPTION
Moves `[Unreleased] — v1.0.2` heading to `[v1.0.2] — 2026-05-01` in CHANGELOG. Final step before merging develop → main and tagging v1.0.2.