### PR TITLE
release: v1.0.2

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,255 @@
+---
+description: Crée une issue sanitizée sur le repo template upstream à partir du contexte de la session courante (sanitization automatique des données vault-specific)
+argument-hint: [bug|enhancement|docs|question] [<courte description optionnelle>]
+---
+
+Run the CREATE-ISSUE workflow on: $ARGUMENTS
+
+Cette commande remonte un bug, une amélioration, une question doc ou une question générale vers le repo **template upstream** (`tetra-plg/boiling-brain` par défaut). Elle génère un draft depuis le contexte de la conversation, **sanitize** les données vault-specific via les règles de `.claude/rules/sanitization-issues.md`, propose la prévisualisation, puis crée l'issue via `gh issue create`.
+
+Aucune création silencieuse : la dernière étape est toujours une validation utilisateur via `AskUserQuestion`.
+
+## 1. Pré-requis
+
+Vérifier dans cet ordre, stopper au premier échec avec un message clair :
+
+```bash
+# 1.1 — gh CLI authentifié
+gh auth status 2>&1 | head -5
+# Si échec : "Lance `gh auth login` puis relance /create-issue."
+
+# 1.2 — Remote template-upstream configuré (si absent, le proposer)
+TEMPLATE_REMOTE_URL=$(git remote get-url template-upstream 2>/dev/null)
+if [ -z "$TEMPLATE_REMOTE_URL" ]; then
+  echo "Le remote template-upstream n'est pas configuré."
+  echo "Configure-le via :"
+  echo "  git remote add template-upstream https://github.com/tetra-plg/boiling-brain.git"
+fi
+```
+
+Extraire `<owner/repo>` depuis l'URL du remote (parser `https://github.com/<owner>/<repo>.git` ou `git@github.com:<owner>/<repo>.git`). Stocker dans `TEMPLATE_REPO`.
+
+## 2. Détermination du type d'issue
+
+Parser `$ARGUMENTS` :
+- Premier token = type, parmi `bug`, `enhancement` (alias `feature`), `docs`, `question`.
+- Reste = description courte optionnelle pour pré-remplir le titre.
+
+Si type absent ou invalide → `AskUserQuestion` :
+
+```json
+{
+  "questions": [{
+    "question": "Quel type d'issue veux-tu créer ?",
+    "header": "Type",
+    "multiSelect": false,
+    "options": [
+      {"label": "bug", "description": "Quelque chose ne marche pas comme attendu (sections : Contexte, Reproduction, Fix proposé, Test plan, Impact)"},
+      {"label": "enhancement", "description": "Proposition d'amélioration ou nouvelle feature (sections : Problème, Proposition, Alternatives, Out-of-scope, Critères de done)"},
+      {"label": "docs", "description": "Manque ou imprécision dans la doc du template (sections : Section concernée, Manque constaté, Suggestion)"},
+      {"label": "question", "description": "Question d'usage ou de design (sections : Contexte, Question, Ce qui a déjà été essayé)"}
+    ]
+  }]
+}
+```
+
+Mapping label GitHub : `bug` → `bug`, `enhancement` / `feature` → `enhancement`, `docs` → `documentation`, `question` → `question`. Vérifier que le label existe sur le repo cible :
+
+```bash
+gh label list --repo "$TEMPLATE_REPO" --json name --jq '.[].name'
+```
+
+Si le label n'existe pas, créer l'issue sans label (signaler à l'utilisateur dans la prévisualisation).
+
+## 3. Collecte du contexte
+
+Lire la conversation courante pour identifier le sujet de l'issue :
+- Quel fichier / quel comportement / quel scénario est en jeu ?
+- Quelle erreur observée vs attendue (pour bug) / quel manque (pour enhancement / docs) / quel point de confusion (pour question) ?
+- Y a-t-il des extraits de code, traces d'erreur, ou commandes pertinentes ?
+
+Si la description du `$ARGUMENTS` est fournie, l'utiliser comme **titre candidat** mais la reformuler si elle contient des références internes (slugs, wikilinks).
+
+## 4. Rédaction du draft selon template
+
+### Structure par type
+
+**bug** :
+```markdown
+## Contexte
+
+<2-3 phrases : où, dans quel scénario, depuis quand>
+
+## Reproduction
+
+<Étapes minimales reproductibles. Snippet de commande / fichier si pertinent.>
+
+## Fix proposé
+
+<Hypothèse de correction. Liste de fichiers / lignes / approche.>
+
+## Test plan
+
+- [ ] <cas test 1>
+- [ ] <cas test 2>
+
+## Impact
+
+<Bloquant ? Cosmétique ? Combien de vaults touchés ?>
+```
+
+**enhancement** :
+```markdown
+## Problème
+
+<Pourquoi le statu quo est insuffisant>
+
+## Proposition
+
+<Description de la solution proposée>
+
+## Alternatives considérées
+
+<Autres approches, pourquoi écartées>
+
+## Out-of-scope (v1)
+
+<Ce qu'on ne fait PAS dans cette première version>
+
+## Critères de done
+
+- [ ] <critère 1>
+- [ ] <critère 2>
+```
+
+**docs** :
+```markdown
+## Section concernée
+
+<Fichier + section précise (ex: README.md "Workflow loop")>
+
+## Manque constaté
+
+<Ce qui n'est pas clair, manquant, ou faux>
+
+## Suggestion
+
+<Ce qu'on pourrait ajouter ou reformuler>
+```
+
+**question** :
+```markdown
+## Contexte
+
+<Configuration / scénario>
+
+## Question
+
+<La question, formulée précisément>
+
+## Ce qui a déjà été essayé
+
+<Ressources lues, tests effectués>
+```
+
+## 5. Sanitization
+
+Appliquer les règles de `.claude/rules/sanitization-issues.md` au titre **et** au body du draft :
+
+- **Strip silencieux** : wikilinks `[[...]]`, chemins `raw/notes/YYYY-MM-DD-*`, slugs de domaines listés dans `wiki/index.md`, chemins `wiki/sources/<date>-<slug>.md`, emails.
+- **Flag pour review** : noms propres en milieu de phrase (hors liste blanche `Claude`, `Anthropic`, `GitHub`, etc.), noms d'entités lues depuis `wiki/entities/*.md`, handles `@xxx`.
+- **Anonymisation des cas concrets** : reformuler « 18 pages BB ont eu X » en « N pages affected (figure measured on the BoilingBrain reference vault) » ou « Some vault pages had X ».
+
+Construire un **rapport de sanitization** avec :
+- Liste des transformations silencieuses appliquées (qui peut être copiée pour audit).
+- Liste des éléments flaggés à confirmer par l'utilisateur.
+
+## 6. Prévisualisation et validation
+
+Afficher au format :
+
+```
+=== Issue draft (sanitized) ===
+
+Repo cible : tetra-plg/boiling-brain
+Label : bug
+
+Titre :
+<titre sanitizé>
+
+Body :
+<body sanitizé>
+
+=== Sanitization ===
+Transformations silencieuses :
+- <wikilink> → <terme générique>
+- <slug> → domain X
+- ...
+
+À confirmer (flaggé) :
+- Nom propre détecté : "<token>" — confirmer ou éditer
+- ...
+```
+
+Puis `AskUserQuestion` :
+
+```json
+{
+  "questions": [{
+    "question": "Que faire avec ce draft ?",
+    "header": "Issue",
+    "multiSelect": false,
+    "options": [
+      {"label": "✅ Créer l'issue", "description": "Crée l'issue via gh issue create. Affichera l'URL en retour."},
+      {"label": "✏️ Éditer manuellement", "description": "N'crée rien. Affiche le draft prêt à copier-coller dans l'UI GitHub."},
+      {"label": "❌ Annuler", "description": "Abandonne sans rien créer."}
+    ]
+  }]
+}
+```
+
+## 7. Création (si validé)
+
+```bash
+gh issue create \
+  --repo "$TEMPLATE_REPO" \
+  --title "$SANITIZED_TITLE" \
+  --body "$SANITIZED_BODY" \
+  --label "$LABEL"
+```
+
+Capturer l'URL retournée (stdout). En cas d'échec (réseau, label inconnu, droits insuffisants) : afficher l'erreur + le draft copy-pastable comme fallback.
+
+## 8. Suite (radar)
+
+Après création réussie, proposer via `AskUserQuestion` :
+
+```json
+{
+  "questions": [{
+    "question": "Ajouter un suivi dans wiki/radar.md ?",
+    "header": "Radar",
+    "multiSelect": false,
+    "options": [
+      {"label": "✅ Oui, suivi dans le radar", "description": "Ajoute une entrée `- [ ] **[Template · YYYY-MM-DD]** <description courte>. → <URL>` dans wiki/radar.md catégorie « À surveiller »"},
+      {"label": "❌ Non, pas de suivi local", "description": "L'issue vit sa vie sur GitHub uniquement"}
+    ]
+  }]
+}
+```
+
+Si oui : ajouter l'entrée à `wiki/radar.md`, commit dédié `chore(radar): track upstream issue <#N>`.
+
+Logger dans `wiki/log.md` : `## [YYYY-MM-DD] create-issue | <type> #<numéro> <titre court>`.
+
+## Cas d'usage proactif depuis le radar
+
+`/create-issue` peut aussi être déclenchée **proactivement** par le main context lors de l'affichage du radar (« montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui »). Quand une entrée du radar concerne **l'environnement template** (typiquement un bug ou manque touchant `scripts/scan-raw.sh`, `.claude/commands/*.md`, `BOOTSTRAP.md`, ou tout fichier propagé par `/update-vault`), le main context propose à l'utilisateur :
+
+> Cette entrée du radar concerne le template upstream. Veux-tu la remonter via `/create-issue <type>` ?
+
+Le main context **ne crée pas l'issue tout seul** — il propose juste la commande, l'utilisateur valide, le workflow standard ci-dessus prend le relais.
+
+## Fallback `gh auth login` manquant
+
+Si à l'étape 1.1 `gh auth status` échoue, ne pas continuer. Afficher le draft sanitizé prêt à copier-coller (sans même faire la sanitization complète — juste un draft brut). L'utilisateur peut alors `gh auth login` puis relancer, ou copier-coller dans l'UI GitHub.

--- a/.claude/commands/update-vault.md
+++ b/.claude/commands/update-vault.md
@@ -1,16 +1,16 @@
 ---
-description: Cherry-pick improvements from the upstream template into this vault
+description: Cherry-pick improvements from the upstream template into this vault, with versioned migrations
 ---
 
 # /update-vault
 
-Met à jour ce vault depuis le template `tetra-plg/boiling-brain` en amont.
+Met à jour ce vault depuis le template `tetra-plg/boiling-brain` en amont. Depuis la v1.0.2, `/update-vault` est une **machine de migration versionnée** : il détecte la version du vault (via `.claude/template-version`), la compare à la version cible, propage les nouveaux fichiers, et exécute les migrations breaking entre les deux versions si nécessaire.
 
-Utilise ce workflow pour récupérer les nouveaux scripts, slash-commands, ou décisions d'architecture publiés dans le template après ton bootstrap.
+Utilise ce workflow pour récupérer les nouveaux scripts, slash-commands, rules ou décisions d'architecture publiés dans le template après ton bootstrap.
 
 ## Étapes
 
-### 1. Configure le remote template-upstream (une seule fois)
+### 1. Configure le remote `template-upstream` (une seule fois)
 
 ```bash
 git remote add template-upstream https://github.com/tetra-plg/boiling-brain.git 2>/dev/null \
@@ -19,81 +19,192 @@ git remote add template-upstream https://github.com/tetra-plg/boiling-brain.git 
 git fetch template-upstream --tags
 ```
 
-### 2. Résoudre le baseline
+### 2. Détecter la version locale (avec rétrocompat v1.0.0 et v1.0.1)
 
 ```bash
-BOOTSTRAP_SHA=$(cat .template-bootstrap-sha 2>/dev/null || echo "")
+LOCAL_VERSION=""
+LOCAL_SHA=""
 
-if [ -z "$BOOTSTRAP_SHA" ]; then
-  # Rétrocompat v1.0.0 : utiliser le tag v1.0.0 comme baseline
-  BOOTSTRAP_SHA=$(git rev-list -n 1 v1.0.0 2>/dev/null || echo "")
-fi
-
-if [ -z "$BOOTSTRAP_SHA" ]; then
-  echo "BASELINE_MISSING"
+if [ -f .claude/template-version ]; then
+  # Cas standard : v1.0.2+
+  LOCAL_VERSION=$(grep '^template-version:' .claude/template-version | awk '{print $2}')
+  LOCAL_SHA=$(grep '^template-sha:' .claude/template-version | awk '{print $2}')
+elif [ -f .template-bootstrap-sha ]; then
+  # Rétrocompat v1.0.1 : a .template-bootstrap-sha mais pas .claude/template-version
+  LOCAL_VERSION="1.0.1"
+  LOCAL_SHA=$(cat .template-bootstrap-sha)
+  echo "Vault détecté en v1.0.1 (legacy). .claude/template-version sera créé pendant cette mise à jour."
 else
-  echo "BASELINE $BOOTSTRAP_SHA"
-  git log ${BOOTSTRAP_SHA}..template-upstream/main --oneline
+  # Rétrocompat v1.0.0 : ni l'un ni l'autre. Utiliser le tag v1.0.0 comme baseline.
+  LOCAL_SHA=$(git -C . show template-upstream/main 2>/dev/null && git rev-list -n 1 v1.0.0 2>/dev/null || echo "")
+  if [ -n "$LOCAL_SHA" ]; then
+    LOCAL_VERSION="1.0.0"
+    echo "Vault détecté en v1.0.0 (legacy, pas de .template-bootstrap-sha). Baseline = tag v1.0.0."
+  else
+    echo "BASELINE_MISSING"
+    echo "Aucun baseline trouvé (.claude/template-version, .template-bootstrap-sha, et tag v1.0.0 absents)."
+    echo "Crée le fichier manuellement (voir Notes en bas) puis relance /update-vault."
+    exit 1
+  fi
 fi
+
+echo "Version locale : $LOCAL_VERSION (SHA $LOCAL_SHA)"
 ```
 
-- Si `BASELINE_MISSING` : informer l'utilisateur qu'aucun baseline n'a pu être trouvé et proposer de créer `.template-bootstrap-sha` manuellement (voir Notes).
-- Si la liste est vide : « Ton vault est à jour. »
-- Sinon : présenter la liste des commits disponibles.
-
-### 3. Identifier les fichiers modifiés
-
-Pour chaque commit listé, identifier les fichiers changés **qui existent dans le vault** :
+### 3. Détecter la version cible (depuis le remote)
 
 ```bash
-git diff --name-only ${BOOTSTRAP_SHA} template-upstream/main \
+TARGET_VERSION=$(git show template-upstream/main:.claude/template-version 2>/dev/null \
+  | grep '^template-version:' | awk '{print $2}')
+TARGET_SHA=$(git rev-parse template-upstream/main)
+
+if [ -z "$TARGET_VERSION" ]; then
+  echo "Le template upstream n'a pas de .claude/template-version (probablement < v1.0.2). Fallback sur le SHA."
+  TARGET_VERSION="$TARGET_SHA"
+fi
+
+echo "Version cible : $TARGET_VERSION (SHA $TARGET_SHA)"
+```
+
+### 4. Calculer la chaîne de migrations à appliquer
+
+Lister toutes les migrations dans `template-upstream/main:scripts/migrations/v<X>-*.md` dont la version `X` est strictement supérieure à `LOCAL_VERSION` et inférieure ou égale à `TARGET_VERSION`. Ordonner par version croissante.
+
+```bash
+git ls-tree -r template-upstream/main --name-only \
+  | grep '^scripts/migrations/v[0-9]' \
+  | sort
+```
+
+Pour chaque migration trouvée, extraire la version depuis le nom de fichier (ex: `scripts/migrations/v1.0.2-claude-md-slim.md` → `1.0.2`). Conserver uniquement celles avec `LOCAL_VERSION < migration_version <= TARGET_VERSION` (comparaison sémantique simple : `sort -V`).
+
+Si aucune migration applicable et version locale == cible : « Ton vault est à jour. ».
+
+Si aucune migration applicable mais version locale < cible : on propage seulement les fichiers (étape 5).
+
+### 5. Identifier et propager les fichiers modifiés
+
+Lister les fichiers changés entre `LOCAL_SHA` et `TARGET_SHA`, en excluant les fichiers consommés au bootstrap :
+
+```bash
+git diff --name-only ${LOCAL_SHA} template-upstream/main \
   | grep -v '\.tpl$' \
   | grep -v '^BOOTSTRAP\.md$' \
   | grep -v '^PLACEHOLDERS\.md$' \
   | grep -v '^CONTRIBUTING\.md$' \
-  | while read f; do [ -e "$f" ] && echo "$f"; done
+  | grep -v '^CLAUDE\.md$'
 ```
 
-Présenter cette liste à l'utilisateur via `AskUserQuestion` (multiSelect) : quels fichiers veut-il mettre à jour ?
+Notes :
 
-### 4. Appliquer fichier par fichier
+- **`.claude/rules/**`** est inclus naturellement (pas dans les exclusions).
+- **`scripts/migrations/**`** est inclus aussi : les migrations sont propagées dans le vault pour pouvoir être consommées au prochain `/update-vault`.
+- **`CLAUDE.md`** est exclu : c'est user-owned. Sa migration est gérée par les slash-commands `scripts/migrations/v<X>-*.md` interactifs, jamais par écrasement.
+
+Pour les fichiers nouveaux dans le template (qui n'existent pas encore dans le vault — ex: `.claude/template-version`, `.claude/rules/*`, `scripts/migrations/*`), ne pas filtrer par `[ -e "$f" ]` : ils doivent être créés.
+
+Présenter la liste à l'utilisateur via `AskUserQuestion` (multiSelect) : quels fichiers veut-il mettre à jour ? Pré-cocher tous les fichiers nouveaux et tous les fichiers `.claude/rules/`.
 
 Pour chaque fichier sélectionné :
 
 ```bash
-git show template-upstream/main:<fichier> > <fichier>
+mkdir -p "$(dirname "$f")"
+git show template-upstream/main:"$f" > "$f"
 ```
 
 > **Pourquoi `git show` plutôt que `cherry-pick` ?**
-> Le bootstrap réinitialise l'historique git (`rm -rf .git/ && git init`). Le vault n'a donc aucun ancêtre commun avec le template — `cherry-pick` tenterait de rejouer des diffs sur un ancêtre inexistant et échouerait systématiquement. `git show` copie directement le contenu cible, sans dépendance à l'historique.
+> Le bootstrap réinitialise l'historique git. Le vault n'a aucun ancêtre commun avec le template — `cherry-pick` échouerait. `git show` copie le contenu cible, sans dépendance à l'historique.
 
-Après application de chaque fichier, afficher un diff rapide :
-
-```bash
-git diff <fichier>
-```
-
-### 5. Commit
+Commit dédié :
 
 ```bash
 git add <fichiers mis à jour>
-git commit -m "chore: update-vault depuis template-upstream ($(date +%Y-%m-%d))"
+git commit -m "chore: propagate template files (${LOCAL_VERSION} → ${TARGET_VERSION})"
 ```
+
+### 6. Exécuter la chaîne de migrations
+
+Pour chaque migration identifiée à l'étape 4, dans l'ordre de version croissante, **invoquer le slash-command** correspondant. Ex pour la v1.0.2 :
+
+```
+/v1.0.2-claude-md-slim
+```
+
+Note : les fichiers de migration vivent dans `scripts/migrations/` (pas dans `.claude/commands/`), donc ils ne sont pas exposés comme slash-commands de premier niveau. `/update-vault` les invoque comme **sous-workflow** : tu lis le fichier `scripts/migrations/v<X>-*.md` et tu exécutes son workflow pas-à-pas, en suivant les instructions qu'il contient (lecture, détection, AskUserQuestion, écriture).
+
+Chaque migration peut décider de son propre verdict :
+
+- **Appliquée** : le fichier est mis à jour, commit dédié par la migration elle-même.
+- **Édition manuelle demandée par l'utilisateur** : la migration ne touche rien, l'utilisateur prendra le relais. Dans ce cas, **ne pas bumper `.claude/template-version`** à l'étape 7 — la migration sera reproposée au prochain `/update-vault`.
+- **Skippée** : idem, ne pas bumper.
+
+Tracker l'état de chaque migration appliquée dans une variable mémoire pour décider du bump final.
+
+### 7. Bump `.claude/template-version`
+
+**Seulement si toutes les migrations applicables ont été acceptées (pas d'édition manuelle ni de skip).**
+
+```bash
+TODAY=$(date +%Y-%m-%d)
+cat > .claude/template-version <<EOF
+template-version: ${TARGET_VERSION}
+template-sha: ${TARGET_SHA}
+last-updated: ${TODAY}
+EOF
+
+git add .claude/template-version
+git commit -m "chore: bump template-version to ${TARGET_VERSION}"
+```
+
+Si une migration a été skippée ou édition manuelle : afficher un message clair :
+
+> ⚠️ Certaines migrations n'ont pas été appliquées automatiquement. `.claude/template-version` reste sur `${LOCAL_VERSION}`. Relance `/update-vault` quand tu auras finalisé les migrations manuelles.
+
+### 8. Cas particulier : vault legacy v1.0.0 ou v1.0.1 (pas de `.claude/template-version`)
+
+Si `.claude/template-version` n'existait pas en début de session (rétrocompat détectée à l'étape 2), il faut le **créer** à la fin de cette première mise à jour, même si toutes les migrations n'ont pas été acceptées. La création initiale fixe la baseline.
+
+Cas A — toutes les migrations acceptées : `.claude/template-version` est créé à l'étape 7 avec `template-version: ${TARGET_VERSION}` (cas standard).
+
+Cas B — au moins une migration skippée ou en édition manuelle : créer `.claude/template-version` avec **la version d'avant les migrations skippées** :
+
+```bash
+# Trouver la dernière migration appliquée avec succès, sinon utiliser LOCAL_VERSION
+LAST_APPLIED_VERSION="$LOCAL_VERSION"  # à mettre à jour si migrations partielles appliquées
+TODAY=$(date +%Y-%m-%d)
+cat > .claude/template-version <<EOF
+template-version: ${LAST_APPLIED_VERSION}
+template-sha: ${LOCAL_SHA}
+last-updated: ${TODAY}
+EOF
+git add .claude/template-version
+git commit -m "chore: initialize .claude/template-version (${LAST_APPLIED_VERSION})"
+```
+
+Ainsi le vault legacy bénéficie du nouveau mécanisme de versionning même si la migration n'est pas terminée.
 
 ## Notes
 
-**Fichiers jamais mis à jour (consommés au bootstrap) :**
-`*.tpl`, `BOOTSTRAP.md`, `PLACEHOLDERS.md`, `CONTRIBUTING.md`.
-Ces fichiers ont été utilisés pour générer ton vault et n'existent plus (ou ont été déplacés). Ils sont exclus automatiquement.
+**Fichiers jamais mis à jour automatiquement :**
+
+- `*.tpl`, `BOOTSTRAP.md`, `PLACEHOLDERS.md`, `CONTRIBUTING.md` — consommés au bootstrap.
+- `CLAUDE.md` — user-owned, migré seulement via `scripts/migrations/v<X>-*.md` interactifs.
 
 **Fichiers propres à ton instance (jamais dans le template) :**
-Tes agents (`.claude/agents/<domain>-expert.md`), tes hubs (`wiki/domains/*.md`), ton `CLAUDE.md`, `wiki/overview.md`, etc. ont des noms distincts des fichiers template — ils ne seront jamais écrasés.
 
-**Baseline manquant (vault pré-v1.0.1) :**
-Si ni `.template-bootstrap-sha` ni le tag `v1.0.0` ne sont trouvés, crée le fichier manuellement :
+Tes agents (`.claude/agents/<domain>-expert.md`), tes hubs (`wiki/domains/*.md`), `wiki/overview.md`, `wiki/log.md`, `wiki/radar.md`, `wiki/index.md`, etc. ont des noms distincts des fichiers template — ils ne seront jamais écrasés.
+
+**`.claude/rules/`** est upstream-tracké : tout ajout ou modification d'une rule dans le template sera propagé dans le vault à chaque `/update-vault`.
+
+**Baseline manquant (vault pré-v1.0.0 hypothétique) :**
+
+Si ni `.claude/template-version`, ni `.template-bootstrap-sha`, ni le tag `v1.0.0` ne sont trouvés, crée le fichier manuellement :
+
 ```bash
 git fetch template-upstream --tags
 git rev-list -n 1 v1.0.0 > .template-bootstrap-sha
 git add .template-bootstrap-sha
 git commit -m "fix: add template bootstrap sha (retrocompat)"
 ```
+
+Puis relance `/update-vault` — la rétrocompat v1.0.0 prendra le relais.

--- a/.claude/rules/frontmatter.md
+++ b/.claude/rules/frontmatter.md
@@ -1,0 +1,79 @@
+---
+description: Règles de frontmatter pour les pages du wiki (sources, concepts, syntheses, decisions)
+paths:
+  - "wiki/sources/**"
+  - "wiki/concepts/**"
+  - "wiki/syntheses/**"
+  - "wiki/decisions/**"
+  - "wiki/entities/**"
+  - "wiki/cheatsheets/**"
+  - "wiki/diagrams/**"
+  - "wiki/domains/**"
+---
+
+# Frontmatter — règles dures
+
+Toute page du wiki commence par un frontmatter YAML. Ces règles sont **non-négociables** : un agent expert qui les viole produit une page invalide.
+
+## Champs obligatoires
+
+```yaml
+---
+type: source | entity | concept | synthesis | decision | domain | cheatsheet | diagram | overview
+domains: [<domain1>, <domain2>, ...]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+```
+
+- `type` : exactement une des valeurs ci-dessus, en minuscules.
+- `domains` : tableau YAML, slugs de domaines déclarés dans `wiki/index.md`. Au moins un.
+- `created` / `updated` : format ISO `YYYY-MM-DD`. `updated` reflète la dernière modification matérielle de la page.
+
+## Champs spécifiques aux pages `type: source`
+
+```yaml
+source_path: "raw/<dossier>/<fichier>.md"   # obligatoire, non-vide, chemin réel existant
+source_sha256: "<hash hex 64 caractères>"   # obligatoire, non-vide
+ingested: YYYY-MM-DD                        # date d'ingestion par l'agent
+covered_paths:                              # optionnel : si la page synthétise plusieurs raw
+  - "raw/<dossier>/<fichier1>.md"
+  - "raw/<dossier>/<fichier2>.md"
+```
+
+### Règle dure `source_sha256`
+
+`source_sha256` doit **toujours** être calculé via `shasum -a 256 <file>` sur le fichier réel au moment de l'ingestion. Jamais un placeholder textuel (`see-raw-file`, le slug, un faux hex, `TODO`...). Cette règle s'applique sans exception à tous les agents experts.
+
+Commande de calcul standard :
+
+```bash
+shasum -a 256 raw/<dossier>/<fichier>.md | awk '{print $1}'
+```
+
+Si le fichier ne peut pas être calculé (chemin invalide, erreur d'accès), l'ingestion échoue — pas de fallback silencieux.
+
+## Champs `summary_l0` et `summary_l1` (tiered loading)
+
+Obligatoires pour `domains/`, `cheatsheets/`, `concepts/`, `syntheses/`. Recommandés pour `sources/`, `entities/`.
+
+```yaml
+summary_l0: "≤140 chars, télégraphique, scannable"
+summary_l1: |
+  2-5 phrases, ~50-150 mots, description structurée.
+  Couvre les claims principaux et l'angle.
+```
+
+Ces champs alimentent le **tiered loading** des oracles : un agent peut scanner un domaine entier via les `summary_l0` (TOC L0), puis descendre en `summary_l1` (preview L1) ou body complet (L2) seulement si pertinent.
+
+## Champ `sources` (cross-référence)
+
+Pour les pages non-`source` qui s'appuient sur des sources :
+
+```yaml
+sources:
+  - "[[sources/2026-XX-XX-slug]]"
+  - "[[sources/2026-YY-YY-autre-slug]]"
+```
+
+Wikilinks Obsidian, pas de chemin nu.

--- a/.claude/rules/pages-wiki.md
+++ b/.claude/rules/pages-wiki.md
@@ -1,0 +1,63 @@
+---
+description: Conventions d'écriture des pages du wiki (style, slugs, callouts, structure)
+paths:
+  - "wiki/**"
+---
+
+# Pages wiki — conventions d'écriture
+
+## Slug et nommage
+
+- `kebab-case.md` strict pour tous les fichiers wiki.
+- Pas d'accents, pas de majuscules, pas d'espaces, pas de caractères spéciaux dans les noms de fichiers.
+- Une page = une idée / une entité / un concept / une décision. Si > 400 lignes, scinder.
+- `wiki/sources/` : format `YYYY-MM-DD-slug.md` (date d'acquisition de la source).
+
+## Liens internes
+
+- Tous les liens internes en `[[wikilinks]]` style Obsidian.
+- Format alias : `[[chemin/slug|Texte affiché]]` quand le slug n'est pas explicite.
+- Pas de chemins relatifs `../` pour les pages wiki — toujours wikilinks.
+- Liens externes via syntaxe markdown standard `[texte](url)`.
+
+## Callouts Obsidian
+
+Pour signaler explicitement les contradictions et incertitudes :
+
+```markdown
+> [!warning] Contradiction
+> Source A dit X, source B dit Y. Pas de résolution actuelle.
+
+> [!question] Incertitude
+> Le mécanisme exact de Z n'est pas documenté dans les sources lues.
+```
+
+- `[!warning]` pour une contradiction factuelle entre sources ou avec le wiki existant.
+- `[!question]` pour une incertitude non résolue, à élever vers `wiki/radar.md`.
+
+## Style
+
+- Français pour les titres, le corps, les explications. Termes techniques en VO si l'usage VO est dominant.
+- Ton **neutre** pour `entities/`, `concepts/`, `cheatsheets/`. Plus personnel pour `overview.md`, `wiki/domains/*.md`.
+- Listes et tableaux courts > paragraphes longs.
+- Toujours citer les sources : champ `sources:` du frontmatter + `[[source-slug]]` inline pour un claim précis.
+- Pas de longues introductions. Pas de méta-commentaire ("Cette page va vous expliquer...").
+
+## Cross-références
+
+Une section `## Cross-refs` à la fin de chaque page substantielle, listant les pages connexes :
+
+```markdown
+## Cross-refs
+
+- [[concepts/<lié>]] — angle complémentaire.
+- [[decisions/<liée>]] — choix d'archi qui s'applique.
+- [[sources/<source>]] — source primaire.
+```
+
+## Seuil de création de page
+
+- **≥ 2 sources** mentionnent le concept indépendamment, OU
+- jugé structurant par l'utilisateur (validation explicite).
+
+Pas de page pour chaque concept mentionné en passant.

--- a/.claude/rules/raw-vs-cache.md
+++ b/.claude/rules/raw-vs-cache.md
@@ -1,0 +1,40 @@
+---
+description: Principe d'immutabilité de raw/ et rôle transitoire de cache/
+paths:
+  - "raw/**"
+  - "cache/**"
+---
+
+# raw/ vs cache/ — principe d'immutabilité
+
+## raw/ — strictement immutable
+
+`raw/` contient les **sources brutes** que le wiki référence. Toute page `wiki/sources/<slug>.md` pointe vers un fichier de `raw/` via son frontmatter `source_path`.
+
+Règles dures :
+
+- **Ne jamais modifier un fichier existant dans `raw/`.** Si une source évolue (ex: doc mise à jour), créer un **nouveau fichier** avec un nouveau SHA, jamais réécrire l'ancien.
+- **Ne jamais déplacer un fichier de `raw/`** une fois qu'il est référencé par une page wiki : tu casserais le `source_path` et `source_sha256`.
+- **Snapshots par SHA** pour les sources évolutives (cf. `wiki/decisions/tracked-repos-immutable-snapshots.md`) : chaque version → un nouveau dossier dédié, jamais d'écrasement.
+- **Pas d'agent expert n'écrit dans `raw/`.** Les agents lisent `raw/` et écrivent dans `wiki/`. La seule exception est la promotion de frames (`cache/frames/` → `raw/frames/`) gérée par `/ingest-video`.
+
+## cache/ — transitoire
+
+`cache/` contient les artefacts de traitement **jamais référencés par le wiki**. Purgeable à tout moment sans perte d'information.
+
+Règles dures :
+
+- **Ne jamais référencer `cache/` depuis une page du wiki.** Le contenu peut disparaître. Si un artefact de `cache/` doit persister, il est **promu** vers `raw/` (ex: une frame retenue pour illustration).
+- **Vidéos et audios** transitent par `cache/videos/`, `cache/audio/` le temps de la transcription, puis sont supprimés ou archivés hors-vault.
+- **Frames candidates** vivent dans `cache/frames/`. Seules les frames **réellement utilisées** par une page wiki sont promues vers `raw/frames/<source-slug>-<descriptif>.png`.
+
+## Conséquences pratiques
+
+- Un agent qui veut citer un visuel → s'assurer qu'il est dans `raw/frames/`, sinon demander la promotion.
+- Une vérification de cohérence du wiki (`/lint`) doit signaler toute page qui référence un chemin `cache/` comme erreur.
+- `raw/` est **versionnable git** sans crainte (immutable par construction). `cache/` peut être `.gitignored` si trop volumineux.
+
+## Cross-refs
+
+- `wiki/decisions/tracked-repos-immutable-snapshots.md` — pattern de snapshots par SHA pour les sources externes évolutives.
+- `wiki/decisions/extraction-frames-induction-runbook.md` — workflow de promotion `cache/frames/` → `raw/frames/`.

--- a/.claude/rules/sanitization-issues.md
+++ b/.claude/rules/sanitization-issues.md
@@ -1,0 +1,80 @@
+---
+description: Règles dures de sanitization avant publication d'une issue sur le repo template upstream (évite la fuite de données du vault)
+paths:
+  - ".claude/commands/create-issue.md"
+  - "scripts/migrations/*-create-issue*.md"
+---
+
+# Sanitization avant `gh issue create` vers le template
+
+Quand l'utilisateur invoque `/create-issue` pour remonter un bug ou une amélioration vers le template upstream, le draft est généré depuis le contexte de la session Claude Code en cours. Ce contexte est susceptible de contenir des données spécifiques au vault de l'utilisateur (slugs de domaines, noms propres, chemins de contenu privé, références internes). Ces règles définissent ce qui doit être stripé, transformé ou flaggé pour review humaine **avant** la création de l'issue.
+
+## Règles strip (transformation silencieuse)
+
+Les patterns suivants sont **transformés systématiquement** dans le titre et le body du draft :
+
+### 1. Wikilinks Obsidian
+
+- Pattern : `\[\[.+?\]\]` (avec ou sans alias `|`).
+- Action : strip complet, **ou** remplacement par un terme générique si le contexte est explicite (ex: `[[concepts/llm-wiki]]` → `the LLM wiki concept`).
+- Justification : les wikilinks sont des références internes au vault, sans valeur en dehors.
+
+### 2. Chemins de contenu privé
+
+- Pattern : `raw/notes/YYYY-MM-DD-<anything>.md`, `raw/transcripts/YYYY-MM-DD-<anything>.md`, `raw/clippings/<anything>.md`.
+- Action : remplacer par un placeholder générique (`raw/notes/<example>.md`, `raw/transcripts/<example>.md`).
+- Justification : les noms de fichiers révèlent souvent le sujet de la note privée.
+
+### 3. Slugs de domaines vault-specific
+
+- Lire la liste des domaines depuis `wiki/index.md` (section `## Domaines`) ou les noms de fichiers `wiki/domains/*.md`.
+- Pour chaque slug détecté dans le draft (mention textuelle ou path `wiki/domains/<slug>.md`), remplacer par `domain X`, `domain Y`, etc., **sauf si** le slug correspond à un terme générique attendu dans le template (`metier`, `tech`, `ia` peuvent rester si le contexte l'exige — mais c'est rare).
+- Justification : les domaines sont une projection personnelle du vault.
+
+### 4. Chemins `wiki/sources/<date>-<slug>.md`
+
+- Pattern : `wiki/sources/[0-9]{4}-[0-9]{2}-[0-9]{2}-<slug>.md`.
+- Action : remplacer par `wiki/sources/<example>.md` ou par une description fonctionnelle (`a source page about X`).
+- Justification : révèle ce que l'utilisateur a ingéré récemment.
+
+## Règles flag (review humaine obligatoire)
+
+Les patterns suivants ne sont **pas stripés silencieusement** mais signalés à l'utilisateur dans la prévisualisation, qui doit les valider ou les éditer :
+
+### 5. Noms propres de personnes
+
+- Heuristique : tout token capitalisé en **milieu de phrase** (hors début), sauf liste blanche connue (`Claude`, `Anthropic`, `GitHub`, `Linux`, noms de produits OSS standards).
+- Action : surligner dans la prévisualisation avec un avertissement « Nom propre détecté : `<token>` — confirmer ou éditer ».
+- Justification : un nom propre peut être une vraie personne du vault (collègue, formateur, sujet d'étude). La détection automatique aurait trop de faux positifs pour strip silencieusement.
+
+### 6. Noms d'entités externes spécifiques au vault
+
+- Pattern : noms d'entreprises, produits internes, projets non-publics référencés dans `wiki/entities/`.
+- Action : lire les noms d'entités depuis `wiki/entities/*.md` et flagger toute occurrence dans le draft.
+- Justification : un produit interne ou un client du vault ne doit jamais sortir publiquement.
+
+### 7. Identifiants utilisateur (emails, handles)
+
+- Pattern : `[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+`, `@[a-zA-Z0-9_]+` (handles potentiels).
+- Action : strip silencieux pour les emails. Flag pour les handles (peuvent être des références publiques légitimes comme `@anthropics`).
+
+## Règles de structure
+
+### 8. Anonymisation des cas concrets
+
+Si le draft cite un cas concret (« 18 pages BB ont eu... »), proposer une formulation neutre : « Some vault pages had... » ou « N pages affected (figure measured on the BoilingBrain reference vault) ». Le mainteneur du template peut choisir de préciser dans le contexte de l'issue, mais la formulation par défaut est anonyme.
+
+### 9. Templates par type d'issue
+
+- **bug** : sections `## Contexte`, `## Reproduction`, `## Fix proposé`, `## Test plan`, `## Impact`.
+- **enhancement** (alias `feature`) : sections `## Problème`, `## Proposition`, `## Alternatives considérées`, `## Out-of-scope`, `## Critères de done`.
+- **docs** : sections `## Section concernée`, `## Manque constaté`, `## Suggestion`.
+- **question** : sections `## Contexte`, `## Question`, `## Ce qui a déjà été essayé`.
+
+Le draft suit l'un de ces templates selon le type. Pas de section narrative libre.
+
+## Verdict final
+
+La création de l'issue est **toujours validée par l'utilisateur** via `AskUserQuestion` avec 3 options : créer, éditer manuellement, annuler. Aucune création silencieuse, même si toutes les règles strip/flag passent. Le filet de sécurité humain reste obligatoire.
+
+Si l'utilisateur choisit « éditer manuellement », l'issue n'est pas créée — un draft copy-pastable est affiché pour qu'il l'utilise dans l'UI GitHub.

--- a/.claude/template-version
+++ b/.claude/template-version
@@ -1,0 +1,1 @@
+template-version: 1.0.2

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+<!--
+Before opening this PR, please make sure:
+- The PR targets `develop` (releases happen via `develop` → `main`).
+- The branch is named `feature/<issue>-slug`, `fix/<issue>-slug`, or `docs/<topic>`.
+- An issue describes the problem or feature (link it below).
+-->
+
 ## What this changes
 
 <!-- Concise summary. Reference the issue if there is one (e.g. "fixes #12"). -->
@@ -12,11 +19,14 @@
 
 ## Checklist
 
+- [ ] PR targets `develop`
+- [ ] Branch named `feature/…`, `fix/…`, or `docs/…`
 - [ ] Change is **generic** (not domain-specific tooling — see CONTRIBUTING.md)
 - [ ] If a new placeholder was added, it's documented in `PLACEHOLDERS.md`
 - [ ] If a slash-command was added/modified, the README.md table is updated
 - [ ] If `BOOTSTRAP.md` flow changed, an entry is added to `CHANGELOG.md` under `[Unreleased]`
 - [ ] Commit messages follow the project convention (`<phase>: <what>` or `fix: <what>` / `feat: <what>`)
+- [ ] All review conversations resolved before merge
 
 ## Notes for reviewers
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: lint
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: |
+            **/*.md
+            !**/node_modules/**
+            !**/raw/**
+
+  link-check:
+    name: link-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --exclude-path raw
+            --exclude-path node_modules
+            --exclude 'mailto:'
+            --accept '100..=103,200..=299,403,429'
+            './**/*.md'
+          fail: true
+          # honors .lycheeignore for files/links generated at bootstrap time

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+# Files generated at bootstrap time inside a vault — not present in the template repo.
+# Keep this list minimal and document each entry.
+file:.*/CLAUDE\.md$
+file:.*/tracked-repos\.config\.json$

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,18 @@
+{
+  // Pragmatic config for a docs/wiki repo with many existing files.
+  // Catches structural issues (broken refs, hard tabs, duplicate titles)
+  // but ignores cosmetic line-level rules.
+  // See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+  "default": true,
+  "MD013": false,          // line length
+  "MD024": { "siblings_only": true }, // duplicate headings ok if not siblings
+  "MD031": false,          // blanks around fences
+  "MD032": false,          // blanks around lists
+  "MD033": false,          // inline HTML (used in templates)
+  "MD034": false,          // bare URLs
+  "MD036": false,          // emphasis-as-heading
+  "MD038": false,          // spaces inside code spans (false positives on indented code spans)
+  "MD040": false,          // fenced-code-language (many docs blocks have no language)
+  "MD041": false,          // first line top-level heading
+  "MD046": { "style": "fenced" }
+}

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -539,12 +539,22 @@ Crée aussi `.obsidian/app.json` minimal :
 }
 ```
 
-### 5.10 Reset git + commit initial
+### 5.10 Enregistrer la version du template + reset git + commit initial
 
 ```bash
 # Enregistrer le SHA du template avant de supprimer son historique.
 # Utilisé par /update-vault pour savoir à partir d'où lister les nouveaux commits.
-git rev-parse HEAD > .template-bootstrap-sha
+TEMPLATE_SHA=$(git rev-parse HEAD)
+echo "$TEMPLATE_SHA" > .template-bootstrap-sha
+
+# Enrichir .claude/template-version avec le SHA et la date du bootstrap.
+# Ce fichier est la source de vérité pour la machine de migration de /update-vault.
+TEMPLATE_VERSION=$(grep '^template-version:' .claude/template-version | awk '{print $2}')
+cat > .claude/template-version <<EOF
+template-version: ${TEMPLATE_VERSION}
+template-sha: ${TEMPLATE_SHA}
+last-updated: {{bootstrap_date}}
+EOF
 
 rm -rf .git/
 git init

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,28 +13,23 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`.claude/rules/`** : trois conventions transverses formalisées (frontmatter, pages-wiki, raw-vs-cache) avec frontmatter `paths:` qui permet l'auto-chargement par Claude Code quand un agent travaille sur un path matchant. Pattern documenté par Anthropic (Boris Cherny, 24 mars 2026). Propagé par `/update-vault` aux vaults existants.
 - **`.claude/template-version`** : fichier de versionning explicite du template (format `template-version: X.Y.Z` + `template-sha:` + `last-updated:`). Source de vérité unique pour la machine de migration de `/update-vault`. Créé au bootstrap (BOOTSTRAP 5.10), mis à jour à chaque `/update-vault` réussi.
 - **`scripts/migrations/`** : nouveau dossier pour les migrations breaking entre versions du template. Pattern `v<X.Y.Z>-<description>.md` (slash-commands Claude Code interactifs). Premier exemple : `v1.0.2-claude-md-slim.md`. Invoqués par `/update-vault` dans la chaîne entre version locale et cible.
+- **`/create-issue [bug|enhancement|docs|question]`** ([#4](https://github.com/tetra-plg/boiling-brain/issues/4)) : nouvelle slash-command pour remonter une issue vers le repo template upstream depuis le contexte de la session courante, avec **sanitization automatique** des données vault-specific (wikilinks, slugs de domaines, chemins privés `raw/notes/<date>-*`, emails, noms d'entités du wiki). Validation utilisateur obligatoire via `AskUserQuestion` avant `gh issue create`. Règles formalisées dans `.claude/rules/sanitization-issues.md` (auto-chargé par `paths:`). Workflow proactif : quand le radar contient une entrée concernant l'environnement template, le main context propose `/create-issue` à l'utilisateur (sans création silencieuse).
+- **`scripts/test-scan-raw.sh`** : fixture de test reproduisant les 3 cas du fix `scan-raw.sh` (apostrophe, parenthèses, espaces multiples) + un cas combiné. Asserte que tous reportent `SKIP` au scan. Exit code 1 si régression.
 
 ### Changed
 
-- **`CLAUDE.md.tpl` réduit à 111 lignes** (depuis 268, soit −59 %), conformément à la recommandation Anthropic « < 200 lignes » pour préserver l'adhérence aux instructions. Les sections Workflows détaillés (~143 lignes) sont remplacées par une table compacte qui pointe vers `.claude/commands/*.md`. La section Conventions (22 lignes) devient un pointeur vers `.claude/rules/`. Les sections instance-specific (Domaines, Agents experts, Architecture) restent inchangées.
+- **`CLAUDE.md.tpl` réduit à 112 lignes** (depuis 268, soit −58 %), conformément à la recommandation Anthropic « < 200 lignes » pour préserver l'adhérence aux instructions. Les sections Workflows détaillés (~143 lignes) sont remplacées par une table compacte qui pointe vers `.claude/commands/*.md`. La section Conventions (22 lignes) devient un pointeur vers `.claude/rules/`. Les sections instance-specific (Domaines, Agents experts, Architecture) restent inchangées.
 - **`/update-vault` refactoré en machine de migration versionnée** : lit `.claude/template-version` (avec fallback rétrocompat sur `.template-bootstrap-sha` pour v1.0.1 et sur le tag `v1.0.0` pour v1.0.0), compare avec la version cible upstream, propage les fichiers nouveaux (incluant `.claude/rules/**` et `scripts/migrations/**`), exécute la chaîne de migrations applicables, bumpe `.claude/template-version` à la fin si toutes les migrations sont acceptées.
 - **`BOOTSTRAP.md` section 5.10** : enrichit `.claude/template-version` avec le SHA et la date du bootstrap (en plus de `.template-bootstrap-sha` historique conservé pour rétrocompat).
 
 ### Fixed
 
-- **Trou de propagation des conventions vers les vaults existants** : avant v1.0.2, toute évolution de convention (frontmatter, immutabilité `raw/`, etc.) vivait dans `CLAUDE.md.tpl` consommé au bootstrap, sans mécanisme de propagation. Cas concret : 18 pages du vault de référence ont eu `source_sha256` rempli avec un placeholder par les agents experts (batch 2026-04-29) — non corrigeable sans patch manuel par vault. Avec v1.0.2, la règle « `source_sha256` toujours via `shasum -a 256` » vit dans `.claude/rules/frontmatter.md` et est propagée automatiquement par `/update-vault`.
-
-### Fixed
-
-- **`scripts/scan-raw.sh` : 3 bugs de parsing causant des faux `NEW`** ([#3](https://github.com/tetra-plg/boiling-brain/issues/3)).
+- **Trou de propagation des conventions vers les vaults existants** ([#5](https://github.com/tetra-plg/boiling-brain/issues/5)) : avant v1.0.2, toute évolution de convention (frontmatter, immutabilité `raw/`, etc.) vivait dans `CLAUDE.md.tpl` consommé au bootstrap, sans mécanisme de propagation. Cas concret : 18 pages du vault de référence ont eu `source_sha256` rempli avec un placeholder par les agents experts (batch 2026-04-29) — non corrigeable sans patch manuel par vault. Avec v1.0.2, la règle « `source_sha256` toujours via `shasum -a 256` » vit dans `.claude/rules/frontmatter.md` et est propagée automatiquement par `/update-vault`.
+- **`scripts/scan-raw.sh` : 3 bugs de parsing causant des faux `NEW`** ([#3](https://github.com/tetra-plg/boiling-brain/issues/3)) :
   - **Bug 1 (apostrophes mangées)** : `tr -d '"'"'` aux lignes 79, 106, 126 supprimait à la fois les guillemets YAML et les apostrophes des chemins. Tout `source_path` contenant une apostrophe (ex: `2026-01-30-claude-code-obsidian-cpr.md` qui mentionnait `BotFather to 'Hello'`) était mal indexé. Remplacé par `sed 's/^"//; s/"$//'` qui ne touche qu'aux guillemets en début/fin de chaîne.
   - **Bug 2 (parenthèses cassent les clés d'array assoc bash)** : un `source_path` ou `covered_paths` contenant `()` ou d'autres caractères spéciaux shell (`*`, `[`, `?`) cassait l'indexation. Neutralisé par une fonction `_safe_key` qui encode les clés via `printf '%q'` à l'écriture **et** au lookup, dans `path_to_slug`, `dir_to_slug` et `meta_to_slug`. Élimine toute la classe de bugs de quoting bash sans dépendance externe.
   - **Bug 3 (espaces multiples)** : couvert par le même `printf '%q'` — les espaces sont maintenant préservés exactement.
   - Tableau parallèle `indexed_paths` ajouté pour permettre l'itération sur les paths originaux (les clés encodées de `path_to_slug` ne sont pas réversibles).
-
-### Added
-
-- **`scripts/test-scan-raw.sh`** : fixture de test reproduisant les 3 cas (apostrophe, parenthèses, espaces multiples) + un cas combiné (apostrophe + parenthèses). Asserte que tous reportent `SKIP` au scan. Exit code 1 si régression.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
-## [Unreleased] — v1.0.2
+## [v1.0.2] — 2026-05-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ## [Unreleased]
 
+### Fixed
+
+- **`scripts/scan-raw.sh` : 3 bugs de parsing causant des faux `NEW`** ([#3](https://github.com/tetra-plg/boiling-brain/issues/3)).
+  - **Bug 1 (apostrophes mangées)** : `tr -d '"'"'` aux lignes 79, 106, 126 supprimait à la fois les guillemets YAML et les apostrophes des chemins. Tout `source_path` contenant une apostrophe (ex: `2026-01-30-claude-code-obsidian-cpr.md` qui mentionnait `BotFather to 'Hello'`) était mal indexé. Remplacé par `sed 's/^"//; s/"$//'` qui ne touche qu'aux guillemets en début/fin de chaîne.
+  - **Bug 2 (parenthèses cassent les clés d'array assoc bash)** : un `source_path` ou `covered_paths` contenant `()` ou d'autres caractères spéciaux shell (`*`, `[`, `?`) cassait l'indexation. Neutralisé par une fonction `_safe_key` qui encode les clés via `printf '%q'` à l'écriture **et** au lookup, dans `path_to_slug`, `dir_to_slug` et `meta_to_slug`. Élimine toute la classe de bugs de quoting bash sans dépendance externe.
+  - **Bug 3 (espaces multiples)** : couvert par le même `printf '%q'` — les espaces sont maintenant préservés exactement.
+  - Tableau parallèle `indexed_paths` ajouté pour permettre l'itération sur les paths originaux (les clés encodées de `path_to_slug` ne sont pas réversibles).
+
+### Added
+
+- **`scripts/test-scan-raw.sh`** : fixture de test reproduisant les 3 cas (apostrophe, parenthèses, espaces multiples) + un cas combiné (apostrophe + parenthèses). Asserte que tous reportent `SKIP` au scan. Exit code 1 si régression.
+
 ### Removed
 
 - **`RELEASE_NOTES.md`** : fichier supprimé. Il dupliquait le `CHANGELOG.md` et le body des releases GitHub, ce qui créait du drift à chaque release. La source unique pour les notes de release est désormais `CHANGELOG.md`. Le body GitHub est rédigé directement via `gh release create --notes-file <(extrait du CHANGELOG)` ou édité depuis l'interface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,48 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
-## [Unreleased]
+## [Unreleased] — v1.0.2
+
+### Added
+
+- **`.claude/rules/`** : trois conventions transverses formalisées (frontmatter, pages-wiki, raw-vs-cache) avec frontmatter `paths:` qui permet l'auto-chargement par Claude Code quand un agent travaille sur un path matchant. Pattern documenté par Anthropic (Boris Cherny, 24 mars 2026). Propagé par `/update-vault` aux vaults existants.
+- **`.claude/template-version`** : fichier de versionning explicite du template (format `template-version: X.Y.Z` + `template-sha:` + `last-updated:`). Source de vérité unique pour la machine de migration de `/update-vault`. Créé au bootstrap (BOOTSTRAP 5.10), mis à jour à chaque `/update-vault` réussi.
+- **`scripts/migrations/`** : nouveau dossier pour les migrations breaking entre versions du template. Pattern `v<X.Y.Z>-<description>.md` (slash-commands Claude Code interactifs). Premier exemple : `v1.0.2-claude-md-slim.md`. Invoqués par `/update-vault` dans la chaîne entre version locale et cible.
+
+### Changed
+
+- **`CLAUDE.md.tpl` réduit à 111 lignes** (depuis 268, soit −59 %), conformément à la recommandation Anthropic « < 200 lignes » pour préserver l'adhérence aux instructions. Les sections Workflows détaillés (~143 lignes) sont remplacées par une table compacte qui pointe vers `.claude/commands/*.md`. La section Conventions (22 lignes) devient un pointeur vers `.claude/rules/`. Les sections instance-specific (Domaines, Agents experts, Architecture) restent inchangées.
+- **`/update-vault` refactoré en machine de migration versionnée** : lit `.claude/template-version` (avec fallback rétrocompat sur `.template-bootstrap-sha` pour v1.0.1 et sur le tag `v1.0.0` pour v1.0.0), compare avec la version cible upstream, propage les fichiers nouveaux (incluant `.claude/rules/**` et `scripts/migrations/**`), exécute la chaîne de migrations applicables, bumpe `.claude/template-version` à la fin si toutes les migrations sont acceptées.
+- **`BOOTSTRAP.md` section 5.10** : enrichit `.claude/template-version` avec le SHA et la date du bootstrap (en plus de `.template-bootstrap-sha` historique conservé pour rétrocompat).
+
+### Fixed
+
+- **Trou de propagation des conventions vers les vaults existants** : avant v1.0.2, toute évolution de convention (frontmatter, immutabilité `raw/`, etc.) vivait dans `CLAUDE.md.tpl` consommé au bootstrap, sans mécanisme de propagation. Cas concret : 18 pages du vault de référence ont eu `source_sha256` rempli avec un placeholder par les agents experts (batch 2026-04-29) — non corrigeable sans patch manuel par vault. Avec v1.0.2, la règle « `source_sha256` toujours via `shasum -a 256` » vit dans `.claude/rules/frontmatter.md` et est propagée automatiquement par `/update-vault`.
 
 ### Removed
 
 - **`RELEASE_NOTES.md`** : fichier supprimé. Il dupliquait le `CHANGELOG.md` et le body des releases GitHub, ce qui créait du drift à chaque release. La source unique pour les notes de release est désormais `CHANGELOG.md`. Le body GitHub est rédigé directement via `gh release create --notes-file <(extrait du CHANGELOG)` ou édité depuis l'interface.
+
+### Migration depuis v1.0.x
+
+La migration vers v1.0.2 est **gérée par `/update-vault`** :
+
+```bash
+# Dans ton vault bootstrappé :
+/update-vault
+```
+
+`/update-vault` détecte automatiquement la version locale (via `.claude/template-version`, ou via fallback rétrocompat sur `.template-bootstrap-sha` pour v1.0.1, ou tag `v1.0.0` pour v1.0.0), propage les fichiers nouveaux (`.claude/rules/`, `scripts/migrations/`, `.claude/template-version`), puis invoque la migration `v1.0.2-claude-md-slim` qui :
+
+1. Lit le `CLAUDE.md` actuel.
+2. Identifie les sections à compacter (Workflows détaillés dupliqués, Conventions verbeuses).
+3. **Préserve les customizations utilisateur** (sections ajoutées hors template).
+4. Propose un diff via `AskUserQuestion` (3 options : appliquer / éditer manuellement / skip).
+5. Si appliqué : commit dédié `chore: migrate CLAUDE.md to v1.0.2 slim structure`.
+
+`CLAUDE.md` n'est jamais réécrit silencieusement — il est user-owned.
+
+Si tu préfères migrer manuellement, lis [scripts/migrations/v1.0.2-claude-md-slim.md](scripts/migrations/v1.0.2-claude-md-slim.md) qui décrit exactement quoi modifier.
 
 ## [v1.0.1] — hotfix
 

--- a/CLAUDE.md.tpl
+++ b/CLAUDE.md.tpl
@@ -13,13 +13,14 @@ Ce vault est un **LLM Wiki** : un écosystème de connaissances maintenu par LLM
 .claude/
   agents/        # subagents Claude Code — un expert par domaine (+ suggestions accumulées pour l'évolution)
   agent-memory/  # mémoires inter-sessions par agent (état du domaine, patterns en attente)
-  commands/      # slash commands (/ingest, /ingest-video, /query, /save, /lint, /evolve-agent{{slash_commands_extras}})
-
+  commands/      # slash commands (/ingest, /ingest-video, /query, /save, /lint, /evolve-agent, /update-vault{{slash_commands_extras}})
+  rules/         # conventions auto-chargées par Claude Code via le champ `paths` du frontmatter
+  template-version  # version du template avec laquelle ce vault est aligné
 
 raw/                 # sources brutes IMMUTABLES — ce qui est référencé par le wiki.
   notes/             # retours d'expérience perso (texte)
   transcripts/       # transcripts de vidéos/audios (YYYY-MM-DD-slug.md + timestamps)
-  videos-meta/       # pointeurs/metadata des vidéos (YYYY-MM-DD-slug.meta.md : URL, durée, hash, emplacement)
+  videos-meta/       # pointeurs/metadata des vidéos
   frames/            # frames extraites effectivement utilisées par le wiki (promues depuis cache)
 {{tracked_repos_arborescence}}  # + articles/, pdfs/, clippings/... selon besoin
 
@@ -31,7 +32,7 @@ cache/                 # artefacts TRANSITOIRES — jamais référencés par le 
 wiki/          # pages générées par le LLM. Tu possèdes cette couche.
   index.md     # portail humain minimal (overview, radar, log, domaines)
   log.md       # journal chronologique (ingest, query, lint, evolve)
-  radar.md     # questions ouvertes & points d'attention — alimenté à chaque ingest, consulté chaque matin
+  radar.md     # questions ouvertes & points d'attention — alimenté à chaque ingest
   overview.md  # portrait de l'utilisateur, mis à jour au fil de l'eau
   domains/     # pages racines des grands domaines (hubs)
   entities/    # personnes, entreprises, produits, lieux
@@ -42,14 +43,9 @@ wiki/          # pages générées par le LLM. Tu possèdes cette couche.
   cheatsheets/ # tableaux synthétiques, paliers, matrices
   diagrams/    # diagrammes Mermaid / ASCII
 
-scripts/       # utilitaires (extraction audio, transcription, sampling de frames, image-diff, backfill summaries, hub enrichment{{tracked_repos_scripts_extras}})
+scripts/       # utilitaires (extraction audio, transcription, sampling de frames, image-diff{{tracked_repos_scripts_extras}})
+  migrations/  # migrations breaking entre versions du template, invoquées par /update-vault
 ```
-
-### Principe raw vs cache
-
-- **`raw/` = strictement immutable et référencé par le wiki.** Inclut les transcripts (source de vérité pour les vidéos) et la metadata, pas les médias eux-mêmes. Chaque snapshot est un répertoire nouveau, **jamais réécrit**. Aucune exception.
-- **`cache/` = transitoire.** Les vidéos, audios et clones git y passent le temps du traitement, puis sont supprimés ou archivés hors vault. Ne jamais référencer `cache/` depuis une page du wiki.
-- **Conséquence** : si une frame d'une vidéo est utilisée par une page, elle doit être **promue** de `cache/frames/` vers `raw/frames/` — sinon elle disparaîtra.
 
 ## Domaines de l'utilisateur
 
@@ -59,26 +55,13 @@ Chaque domaine a une page dans `wiki/domains/` qui sert de hub.
 
 ## Conventions
 
-- Tous les liens internes sont en `[[wikilinks]]` style Obsidian.
-- Pages nommées en `kebab-case.md`, titres en français.
-- Frontmatter YAML sur chaque page du wiki :
-  ```yaml
-  ---
-  type: entity | concept | source | domain | synthesis | decision | overview | cheatsheet
-  domains: [<domain1>, <domain2>, ...]
-  created: YYYY-MM-DD
-  updated: YYYY-MM-DD
-  sources: [[source-slug]]
-  summary_l0: "≤140 chars, télégraphique, scannable"     # obligatoire pour domains/cheatsheets/concepts/syntheses, recommandé pour sources/entities
-  summary_l1: |                                            # 2-5 phrases, ~50-150 mots, description structurée
-    Description multi-lignes du contenu.
-  ---
-  ```
-  Les champs `summary_l0` et `summary_l1` alimentent le **tiered loading** des oracles par domaine. Un agent peut scanner un domaine entier via les `summary_l0` (TOC L0) sans charger les bodies, puis descendre en L1 (preview) ou L2 (full body) seulement quand pertinent.
-- Sources : `wiki/sources/YYYY-MM-DD-slug.md`. Inclure : résumé, key claims, entités mentionnées, concepts abordés, citations marquantes, lien vers `raw/...`.
-- Contradictions : `> [!warning] Contradiction` + explication.
-- Incertitudes : `> [!question]`.
-- Ne **jamais** modifier les fichiers dans `raw/`.
+Les conventions d'écriture (frontmatter, slugs, callouts, immutabilité de `raw/`) sont formalisées dans `.claude/rules/` et **auto-chargées** par Claude Code via le champ `paths` du frontmatter de chaque rule. Voir `.claude/rules/frontmatter.md`, `.claude/rules/pages-wiki.md`, `.claude/rules/raw-vs-cache.md`.
+
+Trois règles critiques résiduelles :
+
+- **`raw/` est strictement immutable.** Aucune exception. Aucun agent ni script ne réécrit un fichier de `raw/`.
+- **Frontmatter YAML obligatoire** sur chaque page wiki, avec `source_sha256` calculé via `shasum -a 256 <file>` — jamais un placeholder textuel.
+- **Slugs en `kebab-case.md`**, liens internes en `[[wikilinks]]` style Obsidian.
 
 ## Agents experts par domaine
 
@@ -86,182 +69,43 @@ L'ingestion est **déléguée à un agent expert** du domaine de la source. Les 
 
 {{agents_section}}
 
-Chaque agent a un prompt **volontairement ouvert** (pas une checklist fermée) et **écrit directement** dans le wiki. Il conclut par deux blocs parsables : `## Ingest summary` et `## Evolution suggestions`. Les suggestions s'accumulent dans `.claude/agents/<domain>-expert.suggestions.md`.
+Chaque agent a un prompt **volontairement ouvert** (pas une checklist fermée) et **écrit directement** dans le wiki. Il conclut par deux blocs parsables : `## Ingest summary` et `## Evolution suggestions`. Les suggestions s'accumulent dans `.claude/agents/<domain>-expert.suggestions.md` pour alimenter `/evolve-agent`.
 
-### Dispatch (`/ingest`)
-
-Le main context **propose** un agent avec niveau de confiance + justification, puis l'utilisateur **valide** (ou choisit autre chose) via `AskUserQuestion`. Trois cas : confiance haute → option recommandée ; confiance faible → liste sans recommandation ; cross-domaine → multiSelect pour plusieurs experts en parallèle. Si aucun agent adapté → fallback générique dans le main context.
-
-### Évolution des agents (`/evolve-agent <domain>`)
-
-Consomme les `.suggestions.md` accumulées, propose un diff du prompt de l'agent, applique sur validation, archive les suggestions intégrées dans `.suggestions.archive.md`, ajoute une entrée `evolve` dans `log.md`. Boucle d'amélioration **explicite** et **curée par l'humain** — pas d'auto-modification silencieuse.
+Le dispatch d'agent à `/ingest` propose un agent avec niveau de confiance + justification, puis l'utilisateur valide via `AskUserQuestion`. Voir `.claude/commands/ingest.md` pour le détail.
 
 ## Workflows
 
-### INGEST (`/ingest [--force] [chemin-ou-dossier]`)
+Les workflows détaillés vivent dans `.claude/commands/`. Tableau récapitulatif :
 
-**Mode batch idempotent.** Sans argument : scanne tout `raw/`. Avec un dossier : le sous-arbre. Avec un fichier précis : force re-ingest de ce fichier. Avec `--force` (combinable) : re-ingère même les fichiers au sha256 inchangé — utile après un `/evolve-agent` pour appliquer les nouveaux réflexes aux sources déjà ingérées (mise à jour des pages existantes, pas de doublons). Le contenu effectif de l'ingest est produit par l'**agent expert** du domaine (cf. ci-dessus).
+| Slash-command | Rôle |
+|---|---|
+| `/ingest [chemin]` | Ingestion idempotente des `raw/` via agent expert du domaine |
+| `/ingest-video <url-ou-path>` | Pipeline vidéo → transcript → ingest → frames (optionnel) |
+| `/sync-repos [noms]` | Snapshot immuable des repos GitHub trackés (si `tracked-repos.config.json` présent) |
+| `/query <question>` | Recherche dans le wiki avec citations, archive optionnelle |
+| `/save <slug>` | Archive la dernière synthèse dans `wiki/syntheses/` |
+| `/lint` | Détection de contradictions, orphelins, lacunes |
+| `/evolve-agent <domain>` | Évolution curée du prompt d'un agent depuis ses suggestions accumulées |
+| `/update-vault` | Récupère les améliorations upstream du template (machine de migration versionnée) |
 
-#### Détection de l'état de chaque source raw
+Pour le radar : « montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui » → lecture de `wiki/radar.md` + extraction des suggestions accumulées des agents (≥2 occurrences ou jugées structurantes).
 
-Lancer `bash scripts/scan-raw.sh [scope]` (sans argument = tout `raw/`) pour obtenir le statut de chaque fichier :
+## Décisions d'architecture
 
-- `NEW` — jamais couvert → ingest complet.
-- `SKIP` — déjà couvert (`source_path` exact, `covered_paths`, ou répertoire parent) → ignorer (sauf `--force`).
-- `MODIFIED` — couvert mais `source_sha256` changé → re-ingest.
-
-Le script bâtit un index en mémoire à partir des champs `source_path` et `covered_paths` de toutes les pages `wiki/sources/`, ce qui évite les faux positifs « NEW » quand un agent a synthétisé plusieurs fichiers raw en une page composite.
-
-Après scan : lister les **orphelins** (pages `wiki/sources/` dont le `source_path` n'existe plus dans `raw/`). Ne pas supprimer : flag dans le rapport pour décision manuelle.
-
-#### Par source ingérée (nouveau ou modifié)
-
-1. Lire (fetch si URL, ou enchaîner `scripts/transcribe.sh` si vidéo/podcast).
-2. **Proposer un agent expert** (cf. section « Agents experts par domaine ») avec niveau de confiance + justification ; obtenir la validation utilisateur via `AskUserQuestion`.
-3. **Spawner l'agent** avec : chemin du raw, liste des pages existantes du domaine, `wiki/domains/<d>.md`.
-4. L'agent exécute l'ingest de bout en bout (écriture directe dans le wiki, frontmatter `type: source` + `source_path` (obligatoire, non-vide) + `source_sha256` + `ingested` + `domains` + `covered_paths` (obligatoire si plusieurs raw couverts), + pages `entities/` / `concepts/` / `cheatsheets/` / `diagrams/` / `syntheses/` selon ses livrables) puis renvoie son rapport.
-5. Le main context :
-   - Appose l'`Ingest summary` dans `log.md` (entrée `## [YYYY-MM-DD] ingest | <titre> (agent: <nom>)`).
-   - Appendre les `Evolution suggestions` dans `.claude/agents/<domain>-expert.suggestions.md`.
-   - Met à jour `index.md` si l'agent ne l'a pas déjà fait.
-   - **Radar** : ajouter toutes les questions ouvertes remontées par l'agent dans `wiki/radar.md` (catégories : À vérifier / À rechercher / À décider / À améliorer / À surveiller). Format : `- [ ] **[Domaine · YYYY-MM-DD]** Description. → [[lien]]`. Ne pas dupliquer les entrées existantes.
-   - **Cross-domain** : si le rapport contient `Cross-domain: [<domaines>]`, spawner séquentiellement l'agent expert de chaque domaine listé en lui passant : l'entité/source créée + `wiki/domains/<d>.md` + instruction explicite « mets à jour ce hub de domaine pour référencer cette entité/source ».
-
-#### Rapport final
-
-Format :
-```
-N nouveaux · M mis à jour · K inchangés (skipped) · L orphelins
-```
-Suivi de :
-- Liste des pages créées/modifiées.
-- Contradictions détectées (entre sources ou avec le wiki existant).
-- Questions ouvertes ajoutées dans `wiki/radar.md`.
-- Orphelins (à supprimer manuellement si volontaire).
-
-### INGEST-VIDEO (`/ingest-video <chemin-ou-url-youtube> [--induction|--mode-a|--skip-frames|--resume]`)
-
-Pipeline vidéo → transcript → ingest → proposition de mode d'extraction de frames → extraction → re-spawn agent pour transcription markdown.
-
-**Mode `--resume <slug>`** : skip l'étape de transcription si `raw/transcripts/YYYY-MM-DD-<slug>.md` existe déjà (cas où la transcription a été faite en amont par un autre pipeline).
-
-#### Conventions de stockage vidéo
-
-- **`LLMWIKI_VIDEO_CACHE`** : variable d'environnement utilisée par `scripts/transcribe.sh`, `scripts/sample-frames.sh`, `scripts/extract-frames.sh` pour localiser les vidéos. Défaut : `cache/videos/` (disque interne, dans le vault). Override : exporte la variable vers un disque externe ou un cache dédié si tu manipules de gros volumes vidéo.
-- **`cache/videos/inbox/`** : drop zone pour les vidéos non-YouTube téléchargées manuellement (extension navigateur, drag-and-drop). Tu y déposes le fichier, puis invoques le pipeline avec ce chemin.
-
-#### Étapes 1-2 : transcript + ingest standard
-
-1. Acquisition audio : YouTube → `yt-dlp` audio direct (pas de vidéo stockée) ; fichier local → placé dans `${LLMWIKI_VIDEO_CACHE:-cache/videos}/`, audio extrait via `ffmpeg`. Le script [scripts/transcribe.sh](scripts/transcribe.sh) couvre les deux cas.
-2. Transcription locale via **whisper.cpp** ou **mlx-whisper** → `raw/transcripts/YYYY-MM-DD-<slug>.md` avec timestamps ~30s.
-3. Création de `raw/videos-meta/YYYY-MM-DD-<slug>.meta.md` : URL, durée, hash, emplacement (`archived` / `deleted` / `in-cache`).
-4. Purge `cache/audio/<slug>.*` après transcription.
-5. Workflow INGEST standard sur le transcript (dispatch agent expert + validation utilisateur). L'agent reçoit la convention frames en contexte. Une vidéo = une source.
-
-#### Étape 3 : choix du mode d'extraction (proposition à l'utilisateur)
-
-Tous les agents experts disposent d'une section `## Frames visuelles` dans leur prompt — chaque agent peut donc déclarer un bloc `## Frame requests` (mode A) quel que soit le domaine.
-
-Après l'ingest, `/ingest-video` calcule des **signaux** sur le transcript et le rapport agent :
-- `duration_min` (durée vidéo)
-- `visual_mentions` (count de patterns visuels dans le transcript : « regardez », « voilà », « vous voyez », « ce schéma », « ce tableau », « cette grille », « ce diagramme », « cette image », « à l'écran », etc.)
-- `frame_requests_count` (entrées du bloc `## Frame requests` du rapport agent)
-
-Puis **propose** un mode via `AskUserQuestion`, avec une recommandation justifiée :
-- **Mode A — frame requests directes** : pipeline historique. Recommandé si l'agent a déclaré un nombre cohérent de frames avec la densité visuelle.
-- **Mode B — induction croisée** (cf. [[decisions/extraction-frames-induction-runbook]]) : pipeline lourd en 9 étapes (sampling dense → image-diff → catalogage agent Explore → induction transcript ±30s → extraction 1080p → validation manuelle batch → promotion → re-spawn agent → transcription markdown). Recommandé pour vidéos ≥ 30 min avec densité visuelle ≥ 0.3 mention/min ET sous-extraction suspectée, ou agent qui n'a déclaré aucune frame malgré ≥ 10 mentions visuelles.
-- **Skip — pas d'extraction**. Recommandé si durée < 15 min ET aucune mention visuelle.
-
-**Override flags** sautent la proposition : `--induction` (force B), `--mode-a` (force A), `--skip-frames` (force skip).
-
-#### Étapes 4a / 4b : exécution du mode retenu
-
-**Mode A** : extraction one-shot via [scripts/extract-frames.sh](scripts/extract-frames.sh) → batch d'AskUserQuestion → promotion `raw/frames/YYYY-MM-DD-<source-slug>-<slug>.png` → re-spawn agent expert (re-ingest forcé) qui transcrit chaque frame en markdown dans la page wiki concernée.
-
-**Mode B** : pipeline complet du runbook. Scripts packagés : [scripts/sample-frames.sh](scripts/sample-frames.sh) (sampling dense, cadence paramétrable) et [scripts/diff-frames.py](scripts/diff-frames.py) (image-diff ROI optionnel — défaut plein cadre, voir Annexes domaine du runbook pour les ROI documentés). Le re-spawn de l'agent expert, en re-ingest forcé, lui demande aussi explicitement la transcription markdown de chaque frame promue.
-
-**Cas YouTube + frame demandée sans vidéo locale** : proposer re-téléchargement du segment (`yt-dlp --download-sections "*HH:MM:SS-HH:MM:SS"`) ou annoter `> [!question] Frame non extraite — vidéo non disponible en cache`.
-
-#### Étape 5 : sort de la vidéo locale
-
-Pour les vidéos locales : suppression / archivage hors-vault (`~/Archive/llm-wiki-videos/`) / conservation (déconseillé). **Après** l'extraction des frames.
-
-#### Convention frames (mode A — déclaration par l'agent)
-
-**Format** (produit par l'agent dans son rapport, après `## Ingest summary` et `## Evolution suggestions`) :
-```
-## Frame requests
-- FRAME: HH:MM:SS | slug-descriptif | Description précise du visuel attendu à l'écran
-```
-
-**Critères cumulatifs — les deux doivent être réunis :**
-1. **Confirmation verbale explicite** : le transcript contient une phrase confirmant qu'un visuel est affiché. Une inférence ne suffit pas. Les déclencheurs verbaux propres à chaque domaine sont listés dans la section `## Frames visuelles` du prompt de chaque agent.
-2. **Un visuel = une frame** : regrouper toutes les références verbales à un même visuel et ne déclarer qu'**un seul timestamp** (premier affichage complet).
-
-**Résultat attendu** : 2-4 frames max par heure pour la plupart des cas. Certains domaines / formats de vidéos peuvent justifier des exceptions documentées (codifiées par `/evolve-agent <domain>` après quelques ingests).
-
-#### Convention frames (mode B — pipeline runbook)
-
-L'agent expert ne déclare pas le bloc `## Frame requests` au moment de l'ingest initial — c'est `/ingest-video` qui pilote. Voir [[decisions/extraction-frames-induction-runbook]] pour les 9 étapes du pipeline.
-
-#### Convention nommage / référencement (modes A et B)
-
-- **Nommage** : `raw/frames/YYYY-MM-DD-<source-slug>-<slug-descriptif>.png`
-- **Référencement** : `![Label](../../../raw/frames/YYYY-MM-DD-source-slug-slug.png)`
-- **Frontmatter** des pages source : `frames: [raw/frames/...]` (optionnel)
-- **Transcription markdown** : chaque frame promue doit être transcrite en markdown structuré (table, Mermaid, code, liste KPIs, description sémantique, etc.) dans la page wiki qui la consomme. C'est non-optionnel — sans transcription, les `/query` doivent ré-analyser l'image à chaque appel. Le format adéquat selon le type de visuel est documenté dans la section `## Frames visuelles` du prompt de chaque agent et dans l'Étape 9 du runbook.
-{{sync_repos_section}}
-### RADAR (« montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui »)
-Quand l'utilisateur demande le radar ou la liste des choses à faire :
-1. Lire `wiki/radar.md` — présenter les entrées non cochées, groupées par catégorie.
-2. Lire `.claude/agents/*.suggestions.md` — extraire les suggestions récurrentes ou structurantes (≥2 apparitions, ou jugées haute valeur) et les résumer : quel agent, quel pattern, est-il mûr pour un `/evolve-agent` ?
-3. Proposer une ou deux actions prioritaires pour la session.
-4. Ne pas journaliser dans `log.md` (lecture seule).
-
-### QUERY (`/query <question>`)
-1. Lire `index.md` pour trouver les pages pertinentes.
-2. Lire ces pages, suivre les `[[wikilinks]]` nécessaires.
-3. Synthétiser avec citations `[[page]]`.
-4. Si substantiel, proposer de filer dans `wiki/syntheses/<slug>.md`.
-5. `log.md` : `## [YYYY-MM-DD] query | <question courte>`.
-
-### SAVE (`/save <slug>`)
-Archiver la dernière synthèse dans `wiki/syntheses/<slug>.md`, mettre à jour `index.md` et `log.md`.
-
-### LINT (`/lint`)
-- Contradictions, claims périmés, orphelines, concepts sans page, cross-refs manquantes, lacunes.
-- Suggérer prochaines sources à ingérer.
-
-### EVOLVE-AGENT (`/evolve-agent <domain>`)
-Faire évoluer le prompt système de l'agent expert `<domain>-expert` à partir des suggestions qu'il a lui-même remontées lors des ingestions précédentes.
-1. Lit `.claude/agents/<domain>-expert.suggestions.md` (append-only, alimenté par `/ingest`).
-2. Propose un **diff** du prompt à l'utilisateur (suggestions retenues récurrentes/structurantes ; écartées l'anecdotique).
-3. Sur validation : met à jour `.claude/agents/<domain>-expert.md`, archive les suggestions intégrées dans `.suggestions.archive.md`, ajoute une entrée `## [YYYY-MM-DD] evolve | <domain>-expert` dans `log.md`.
-4. L'agent mis à jour sera chargé au **prochain démarrage de session** (les subagents Claude Code sont chargés au boot).
-
-## Décisions d'architecture (`wiki/decisions/`)
-
-Les choix structurants sur le vault lui-même (workflows, conventions, outillage — pas les domaines de connaissance) vont dans `wiki/decisions/`, pas dans `wiki/syntheses/`. Format **ADR-lite** :
-
-- Slug descriptif, pas de numérotation.
-- Frontmatter `type: decision`.
-- Structure libre mais viser : **Problème** → **Options écartées** → **Décision retenue** → **Pourquoi** → **Questions ouvertes**.
-- Pas de champ `status` pour l'instant. Si une décision est révisée, créer une nouvelle décision qui cite et remplace l'ancienne ; l'ancienne garde son fichier comme trace historique.
-
-Exemples de sujets qui y vont : versioning des prompts d'agents, gestion des secrets dans le vault, conventions de snapshot pour sources évolutives, structuration des domaines.
+Les choix structurants sur le vault (workflows, conventions, outillage — pas les domaines de connaissance) vont dans `wiki/decisions/` au format ADR-lite : Problème → Options écartées → Décision retenue → Pourquoi → Questions ouvertes. Pas de numérotation, slug descriptif. Si une décision est révisée, créer une nouvelle qui cite et remplace l'ancienne.
 
 ## Principes d'écriture
 
-- Français. Termes techniques en VO si usage.
-- Une page = une idée/entité. >400 lignes → scinder. `overview.md` reste unique tant que <300 lignes, puis éclaté en sous-pages.
+- Français. Termes techniques en VO si l'usage VO est dominant.
+- Une page = une idée/entité. >400 lignes → scinder.
 - Toujours citer les sources (`sources:` frontmatter + `[[source-slug]]` inline si claim précis).
 - Listes et tableaux courts > paragraphes longs.
-- Ton neutre pour entities/concepts, plus personnel pour overview et domains.
+- Ton neutre pour `entities/`, `concepts/`. Plus personnel pour `overview` et `domains/`.
 
 ## Ce qu'il ne faut PAS faire
 
-- **Règle stricte** : une source = un fichier dans `raw/`. Pas d'ingestion depuis la mémoire ou depuis la conversation. Si tu veux faire entrer un souvenir / avis / retour d'expérience, dépose-le d'abord dans `raw/notes/YYYY-MM-DD-<sujet>.md`, puis ingère normalement.
+- **Une source = un fichier dans `raw/`.** Pas d'ingestion depuis la mémoire ou la conversation. Pour faire entrer un retour d'expérience : déposer d'abord dans `raw/notes/YYYY-MM-DD-<sujet>.md`, puis ingest normal.
 - **Ne jamais référencer `cache/` depuis le wiki.** Le contenu peut disparaître à tout moment.
-- Pas de liens inventés sans justification textuelle.
-- Pas de page pour chaque concept mentionné en passant — seuil : ≥2 sources OU jugé structurant par l'utilisateur.
-- Pas de longues introductions.
+- **Ne jamais modifier les fichiers dans `raw/`.** Une source qui évolue → nouveau fichier, jamais réécriture.
+- **Pas de page pour chaque concept mentionné en passant** : seuil ≥ 2 sources OU jugé structurant par l'utilisateur.
+- **Pas de longues introductions, pas de méta-commentaires.**

--- a/CLAUDE.md.tpl
+++ b/CLAUDE.md.tpl
@@ -13,7 +13,7 @@ Ce vault est un **LLM Wiki** : un écosystème de connaissances maintenu par LLM
 .claude/
   agents/        # subagents Claude Code — un expert par domaine (+ suggestions accumulées pour l'évolution)
   agent-memory/  # mémoires inter-sessions par agent (état du domaine, patterns en attente)
-  commands/      # slash commands (/ingest, /ingest-video, /query, /save, /lint, /evolve-agent, /update-vault{{slash_commands_extras}})
+  commands/      # slash commands (/ingest, /ingest-video, /query, /save, /lint, /evolve-agent, /update-vault, /create-issue{{slash_commands_extras}})
   rules/         # conventions auto-chargées par Claude Code via le champ `paths` du frontmatter
   template-version  # version du template avec laquelle ce vault est aligné
 
@@ -87,8 +87,9 @@ Les workflows détaillés vivent dans `.claude/commands/`. Tableau récapitulati
 | `/lint` | Détection de contradictions, orphelins, lacunes |
 | `/evolve-agent <domain>` | Évolution curée du prompt d'un agent depuis ses suggestions accumulées |
 | `/update-vault` | Récupère les améliorations upstream du template (machine de migration versionnée) |
+| `/create-issue [type]` | Crée une issue sanitizée sur le repo template upstream à partir du contexte courant |
 
-Pour le radar : « montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui » → lecture de `wiki/radar.md` + extraction des suggestions accumulées des agents (≥2 occurrences ou jugées structurantes).
+Pour le radar : « montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui » → lecture de `wiki/radar.md` + extraction des suggestions accumulées des agents (≥2 occurrences ou jugées structurantes). **Si une entrée du radar concerne l'environnement template** (bug ou manque touchant `scripts/`, `.claude/commands/`, `BOOTSTRAP.md`, ou tout fichier propagé par `/update-vault`), proposer à l'utilisateur de la remonter via `/create-issue <type>` — sans créer l'issue tout seul, juste suggérer la commande.
 
 ## Décisions d'architecture
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+This project adopts the **[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)** as its Code of Conduct.
+
+The full text is available at the link above and is incorporated here by reference.
+
+## Scope
+
+This Code applies within all project spaces — issues, pull requests, discussions, commit messages, and any other communication channel related to the project — and also applies when an individual is officially representing the project in public spaces.
+
+## Reporting
+
+If you observe behavior that violates this Code, please report it privately to the maintainer at `peije45@gmail.com` with `[boiling-brain conduct]` in the subject. Reports will be handled confidentially. Acknowledgement within 5 business days; first response within 14 days.
+
+For any conflict of interest involving the maintainer directly, you may also use a [private security advisory](https://github.com/tetra-plg/boiling-brain/security/advisories/new) as a private channel.
+
+## Enforcement
+
+The maintainer is responsible for clarifying and enforcing standards of acceptable behavior, and may take appropriate and fair corrective action in response to any behavior deemed inappropriate, threatening, offensive, or harmful — following the **Enforcement Guidelines** of the Contributor Covenant 2.1.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,34 @@ Thanks for your interest in BoilingBrain. This project is opinionated — the op
 - **Cosmetic refactors** without a behavioral motivation.
 - **Renaming sweeps** that don't change semantics.
 
+## Branching model (git flow)
+
+This repo uses a simple [git flow](https://nvie.com/posts/a-successful-git-branching-model/) layout:
+
+| Branch | Role |
+|---|---|
+| `main` | Tagged releases only (`vX.Y.Z`). Updated by merging `develop` at release time. Protected. |
+| `develop` | **Default branch.** Integration line — all contributions land here first. Protected. |
+| `feature/<issue>-slug` | New feature, branched from `develop`, merged back to `develop`. |
+| `fix/<issue>-slug` | Bug fix, branched from `develop`, merged back to `develop`. |
+| `docs/<topic>` | Doc-only change, branched from `develop`, merged back to `develop`. |
+
+Contributor flow:
+
+1. **Open an issue** describing the bug or feature (skip only for trivial doc fixes).
+2. **Fork** the repo (external contributors) or create a branch directly (maintainers).
+3. **Branch from `develop`** with the naming convention above. Example: `feature/42-add-spanish-bootstrap`.
+4. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, …). Describe the *why*, not the *what*.
+5. **Open a PR targeting `develop`** (not `main`). Fill the PR template, link the issue.
+6. CI must pass and at least one approval is required before merge.
+7. Merges into `develop` use **squash merge** (one clean commit per PR).
+8. The maintainer periodically merges `develop` → `main` and tags a new release (`vX.Y.Z`) following [semver](https://semver.org/).
+
 ## How to propose a change
 
 1. Open an issue first if the change is non-trivial. Describe what's broken or missing and why.
-2. For a fix : PR directly. Keep it scoped — one fix per PR.
-3. For a feature : align in the issue thread first, then PR.
+2. For a fix : PR directly against `develop`. Keep it scoped — one fix per PR.
+3. For a feature : align in the issue thread first, then PR against `develop`.
 
 ## Testing changes to `BOOTSTRAP.md`
 
@@ -36,6 +59,14 @@ The most consequential file is `BOOTSTRAP.md`. To test a change:
 - `*.tpl` files use `{{placeholder}}` syntax. New placeholders must be documented in `PLACEHOLDERS.md`.
 - No emojis in code or wiki files unless requested. Status indicators in BOOTSTRAP.md (✅, ⭐, etc.) are an exception.
 - Commit messages : describe the *why*, not the *what*. Reference the relevant phase if applicable (`phase 5c: <fix>`).
+
+## Code of Conduct
+
+By participating, you agree to abide by the project [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+If you discover a security issue, please follow the [security policy](SECURITY.md) — do not open a public issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ This lets agents (and you, via `/query`) navigate the wiki without paying the fu
 | `/lint [domain]` | Detect contradictions, orphans, missing cross-references, gaps. |
 | `/evolve-agent <domain>` | Curated update to a domain expert's prompt, fed by accumulated `.suggestions.md`. |
 | `/sync-repos [names]` *(optional)* | Snapshot GitHub repos by SHA into `raw/tracked-repos/` (or any `dest` declared per source). |
-| `/update-vault` | Cherry-pick improvements from the upstream template into your vault instance. |
+| `/update-vault` | Cherry-pick improvements from the upstream template into your vault instance (versioned migration machine). |
+| `/create-issue [type]` | Sanitize a draft and open an issue on the upstream template repo (auto-strips wikilinks, vault-specific slugs, private paths). Always validated by you before `gh issue create`. |
 
 ## Workflow loop
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If you really want to clone manually and skip the bootstrap, read every `*.tpl` 
   agents/        # one <domain>-expert.md per domain you declared
   agent-memory/  # one MEMORY.md per agent (state of the domain)
   commands/      # slash commands (generic, no per-instance customization)
+  rules/         # transverse conventions auto-loaded by Claude Code via `paths` frontmatter
+  template-version  # which template version this vault is aligned with (used by /update-vault)
 
 raw/             # IMMUTABLE source files. Never modified after first write.
 cache/           # transient artifacts (downloaded videos, audio, frames). gitignored.
@@ -112,9 +114,21 @@ wiki/            # the LLM-maintained layer.
 
 scripts/         # utilities (transcription, frame extraction, image-diff, summary backfill, hub enrichment, ...)
 
-CLAUDE.md        # project-wide LLM instructions (architecture, conventions, workflows)
+CLAUDE.md        # project-wide LLM instructions (slim ≤200 lines, points to .claude/rules/ and .claude/commands/)
 tracked-repos.config.json  # OPTIONAL: list of GitHub repos to snapshot via /sync-repos
 ```
+
+## `.claude/rules/` — transverse conventions
+
+Conventions that apply across the wiki (frontmatter format, slug rules, raw immutability) live in `.claude/rules/*.md`. Each rule has a `paths:` field in its frontmatter — Claude Code auto-loads the rule when the current working file matches one of those paths. This mirrors the [Anthropic-recommended pattern](https://www.anthropic.com/) (Boris Cherny, "CLAUDE.md best practices", 24 March 2026).
+
+Three rules ship by default:
+
+- `frontmatter.md` (paths: `wiki/sources/**`, `wiki/concepts/**`, `wiki/syntheses/**`, `wiki/decisions/**`, `wiki/entities/**`, `wiki/cheatsheets/**`, `wiki/diagrams/**`, `wiki/domains/**`) — frontmatter YAML rules, including the hard rule that `source_sha256` must always be computed via `shasum -a 256 <file>` (never a placeholder).
+- `pages-wiki.md` (paths: `wiki/**`) — kebab-case slugs, `[[wikilinks]]`, `[!warning]` / `[!question]` callouts, page sizing.
+- `raw-vs-cache.md` (paths: `raw/**`, `cache/**`) — strict immutability of `raw/`, transient nature of `cache/`.
+
+`.claude/rules/` is **upstream-tracked** — `/update-vault` propagates new and updated rules to existing vaults automatically.
 
 ## Tiered loading
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+BoilingBrain is a documentation/template project — it has no runtime, no network surface, and no data store. The realistic risk surface is limited to:
+
+- Malicious instructions injected into bootstrap prompts, slash-commands, or `*.tpl` files that could mislead Claude Code into running unsafe shell commands.
+- Supply-chain issues in CI workflows (`.github/workflows/`) that could leak secrets or push unauthorized changes.
+
+If you find something in either category, please report it privately:
+
+- Open a [private security advisory](https://github.com/tetra-plg/boiling-brain/security/advisories/new) on GitHub, **or**
+- Email the maintainer at `peije45@gmail.com` with `[boiling-brain security]` in the subject.
+
+Please do **not** open a public issue for security reports.
+
+## What to expect
+
+- Acknowledgement within **5 business days**.
+- A first assessment (accept / reject / need more info) within **14 days**.
+- If accepted, a fix or mitigation in the next minor release, with credit in the CHANGELOG unless you prefer to remain anonymous.
+
+## Out of scope
+
+- Issues in user vaults built from this template — those are private to each user.
+- Vulnerabilities in upstream dependencies (Claude Code, GitHub Actions) — report those to the upstream project.
+- Theoretical issues without a demonstrable impact path on this repository.

--- a/scripts/migrations/v1.0.2-claude-md-slim.md
+++ b/scripts/migrations/v1.0.2-claude-md-slim.md
@@ -1,0 +1,155 @@
+---
+description: Migration v1.0.2 — réduit le CLAUDE.md du vault à la nouvelle structure slim (≤200 lignes, pointeurs vers .claude/rules/ et .claude/commands/)
+---
+
+# Migration `v1.0.2-claude-md-slim`
+
+Ce slash-command est invoqué automatiquement par `/update-vault` quand le vault est en version < 1.0.2. Il réduit le `CLAUDE.md` du vault à la nouvelle structure slim introduite en v1.0.2 :
+
+- Suppression des sections "Workflows" détaillés (dupliquées avec `.claude/commands/*.md`).
+- Compaction de la section "Conventions" → pointeur vers `.claude/rules/`.
+- Préservation des sections instance-specific (Domaines, Agents experts, Architecture) et de toute customization utilisateur.
+
+## Contexte
+
+Le `CLAUDE.md.tpl` v1.0.x générait un `CLAUDE.md` ~313 lignes dupliquant ~60% du contenu des slash-commands. La v1.0.2 introduit :
+
+- `.claude/rules/` (auto-chargé par `paths`) pour les conventions transverses (frontmatter, pages-wiki, raw-vs-cache).
+- Un `CLAUDE.md.tpl` slim (~95 lignes) qui pointe vers `.claude/rules/` et `.claude/commands/` au lieu de tout dupliquer.
+
+Le `CLAUDE.md` du vault doit être migré pour profiter du nouveau pattern. Le fichier étant **user-owned** (customisé au bootstrap, potentiellement enrichi par l'utilisateur), la migration **ne le réécrit jamais sans validation**.
+
+## Workflow
+
+### 1. Détection des sections
+
+Lire le `CLAUDE.md` actuel. Identifier :
+
+- **Sections template-standard** (présentes dans le CLAUDE.md.tpl v1.0.x) : Rôles, Architecture, Domaines de l'utilisateur, Conventions, Agents experts par domaine, Workflows (INGEST, INGEST-VIDEO, SYNC-REPOS, RADAR, QUERY, SAVE, LINT, EVOLVE-AGENT), Décisions d'architecture, Principes d'écriture, Ce qu'il ne faut PAS faire.
+- **Sections instance-specific** à **conserver intactes** : tout ce qui découle du bootstrap (liste des domaines, liste des agents experts, customizations utilisateur visibles).
+- **Sections customisées par l'utilisateur** (ajoutées hors template) : tout titre `##` ou `###` qui n'apparaît pas dans la liste template-standard ci-dessus → **préserver tel quel**.
+
+### 2. Construction du CLAUDE.md slim cible
+
+Composer un nouveau `CLAUDE.md` qui :
+
+1. **Conserve l'intro et le rôle** (`# {{vault_name}} — Schéma...`, `## Rôles`).
+2. **Conserve `## Architecture`** intacte (instance-specific via les placeholders consommés au bootstrap, peut contenir des refs aux tracked-repos de l'utilisateur).
+3. **Conserve `## Domaines de l'utilisateur`** intact (liste des domaines générée au bootstrap).
+4. **Remplace `## Conventions`** par un bloc compact :
+   ```markdown
+   ## Conventions
+
+   Les conventions d'écriture (frontmatter, slugs, callouts, immutabilité de `raw/`) sont
+   formalisées dans `.claude/rules/` et auto-chargées par Claude Code via le champ `paths`
+   du frontmatter de chaque rule. Voir `.claude/rules/frontmatter.md`,
+   `.claude/rules/pages-wiki.md`, `.claude/rules/raw-vs-cache.md`.
+
+   Trois règles critiques résiduelles :
+
+   - **`raw/` est strictement immutable.** Aucune exception.
+   - **Frontmatter YAML obligatoire** sur chaque page wiki, avec `source_sha256` calculé via `shasum -a 256` (jamais un placeholder).
+   - **Slugs en `kebab-case.md`**, liens internes en `[[wikilinks]]`.
+   ```
+5. **Conserve `## Agents experts par domaine`** intact (liste générée au bootstrap, plus la sous-section `### Dispatch (/ingest)` et `### Évolution des agents (/evolve-agent <domain>)` qui sont template-standard mais courtes — peuvent être compactées en pointeurs vers `.claude/commands/ingest.md` et `.claude/commands/evolve-agent.md`).
+6. **Remplace `## Workflows`** par une table compacte :
+   ```markdown
+   ## Workflows
+
+   Les workflows détaillés vivent dans `.claude/commands/`. Tableau récapitulatif :
+
+   | Slash-command | Rôle |
+   |---|---|
+   | `/ingest [chemin]` | Ingestion idempotente des `raw/` via agent expert du domaine |
+   | `/ingest-video <url-ou-path>` | Pipeline vidéo → transcript → ingest → frames (optionnel) |
+   | `/sync-repos [noms]` | Snapshot immuable des repos GitHub trackés (si `tracked-repos.config.json` présent) |
+   | `/query <question>` | Recherche dans le wiki avec citations, archive optionnelle |
+   | `/save <slug>` | Archive la dernière synthèse dans `wiki/syntheses/` |
+   | `/lint` | Détection de contradictions, orphelins, lacunes |
+   | `/evolve-agent <domain>` | Évolution curée du prompt d'un agent depuis ses suggestions accumulées |
+   | `/update-vault` | Récupère les améliorations upstream du template (machine de migration versionnée) |
+
+   Pour le radar : « montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui » → lecture
+   de `wiki/radar.md` + suggestions accumulées des agents.
+   ```
+7. **Conserve `## Décisions d'architecture`** raccourci à 2-3 lignes pointer vers `wiki/decisions/` :
+   ```markdown
+   ## Décisions d'architecture
+
+   Les choix structurants sur le vault (workflows, conventions, outillage) vont dans
+   `wiki/decisions/` au format ADR-lite (Problème → Options écartées → Décision → Pourquoi).
+   ```
+8. **Conserve `## Principes d'écriture`** intact (court, instance-relevant).
+9. **Conserve `## Ce qu'il ne faut PAS faire`** intact (court et critique).
+10. **Insère toutes les sections customisées détectées en étape 1** à la fin (ou à leur position d'origine si possible) avec un commentaire `<!-- préservé depuis CLAUDE.md pré-v1.0.2 -->`.
+
+### 3. Diff interactif
+
+Calculer la diff entre le `CLAUDE.md` actuel et la cible composée. Présenter via `AskUserQuestion` :
+
+```json
+{
+  "questions": [{
+    "question": "CLAUDE.md va être réduit de N lignes à M lignes (suppressions surtout dans Workflows/Conventions). Que faire ?",
+    "header": "Migration CLAUDE.md",
+    "multiSelect": false,
+    "options": [
+      {"label": "✅ Appliquer la migration", "description": "Écrit le nouveau CLAUDE.md. Customizations utilisateur préservées. Commit dédié."},
+      {"label": "✏️ Éditer manuellement", "description": "Affiche le diff complet, l'utilisateur applique à la main. La migration ne touche pas le fichier."},
+      {"label": "⏭️ Skip pour cette session", "description": "Ne touche pas CLAUDE.md. La migration sera reproposée à la prochaine /update-vault."}
+    ]
+  }]
+}
+```
+
+Avant de poser la question, afficher un résumé du diff :
+
+- Nombre de lignes avant / après.
+- Nombre de sections supprimées / compactées / conservées.
+- Liste des **customizations utilisateur détectées** qui seront préservées (nommer les sections).
+- Optionnel : afficher le diff complet (`diff -u`) si l'utilisateur le demande explicitement.
+
+### 4. Application
+
+**Si « Appliquer »** :
+
+1. Écrire le nouveau `CLAUDE.md`.
+2. `git add CLAUDE.md`.
+3. `git commit -m "chore: migrate CLAUDE.md to v1.0.2 slim structure"`.
+4. Afficher : `Migration v1.0.2-claude-md-slim appliquée. CLAUDE.md réduit de N à M lignes.`.
+
+**Si « Éditer manuellement »** :
+
+1. Afficher le diff complet.
+2. Indiquer à l'utilisateur : « Édite `CLAUDE.md` à la main, puis relance `/update-vault` pour bumper `.claude/template-version` ».
+3. Ne pas bumper la version automatiquement — laisser `/update-vault` re-vérifier au prochain run.
+
+**Si « Skip »** :
+
+1. Ne rien écrire.
+2. Indiquer : « Migration `v1.0.2-claude-md-slim` skippée. `.claude/template-version` reste sur la version précédente. La migration sera reproposée au prochain `/update-vault` ».
+
+## Idempotence
+
+Cette migration est appelée par `/update-vault` **seulement si** `.claude/template-version` indique une version < 1.0.2 (ou si le fichier n'existe pas et que la rétrocompat détecte v1.0.0 / v1.0.1).
+
+Une fois la migration appliquée et `.claude/template-version` bumpé à `1.0.2`, elle ne sera plus appelée.
+
+Si l'utilisateur a skippé ou édité manuellement, `.claude/template-version` n'est pas bumpé — la migration sera reproposée.
+
+## Préservation des customizations
+
+Pour identifier ce qui est "customization utilisateur" vs "section template" :
+
+- Les sections **dont le titre exact** correspond à une section du `CLAUDE.md.tpl` v1.0.x sont template-standard (et donc remplaçables). Liste exhaustive : `## Rôles`, `## Architecture`, `## Domaines de l'utilisateur`, `## Conventions`, `## Agents experts par domaine`, `## Workflows`, `## Décisions d'architecture`, `## Principes d'écriture`, `## Ce qu'il ne faut PAS faire`. Et leurs sous-sections `###` standards (INGEST, INGEST-VIDEO, etc.).
+- **Toute autre section** (ajoutée par l'utilisateur — ex: `## Mon contexte projet`, `## Notes pour Claude`, `## Setup matériel`, etc.) est customization → **préservée intacte**.
+- En cas de doute (titre proche mais pas exactement template-standard), préserver et signaler à l'utilisateur dans le résumé du diff.
+
+## Note pour les futures migrations
+
+Ce fichier est le premier exemple du pattern `scripts/migrations/v<X>-*.md`. Pour les migrations futures :
+
+- Un slash-command par version contenant des migrations breaking.
+- Invoqué par `/update-vault` dans la chaîne entre version locale et cible.
+- Toujours interactif (jamais d'écriture silencieuse sur fichiers user-owned).
+- Idempotent (vérifier la version avant d'agir).

--- a/scripts/scan-raw.sh
+++ b/scripts/scan-raw.sh
@@ -57,11 +57,20 @@ if [ ${#files[@]} -eq 0 ]; then
   exit 0
 fi
 
+# --- Encodage des clés d'array associatif ---
+# Les arrays associatifs bash mishandlent les caractères spéciaux dans les clés
+# (parenthèses, globs, espaces multiples, etc.). printf %q neutralise toute
+# la classe de bugs de quoting en encodant la clé une fois pour toutes.
+_safe_key() {
+  printf '%q' "$1"
+}
+
 # --- Construction de l'index : raw_path → (slug, sha256) ---
 # Charge une fois tous les wiki/sources pour éviter O(N×M) grep
 
-declare -A path_to_slug   # raw_path (ou raw_dir/) → slug
-declare -A path_to_sha    # raw_path → source_sha256 stocké dans la page
+declare -A path_to_slug   # safe_key(raw_path) → slug
+declare -A path_to_sha    # safe_key(raw_path) → source_sha256 stocké dans la page
+declare -a indexed_paths  # paths originaux (pour itération — les clés encodées de path_to_slug ne le permettent pas)
 
 while IFS= read -r source_file; do
   slug=$(basename "$source_file" .md)
@@ -76,10 +85,11 @@ while IFS= read -r source_file; do
   while IFS= read -r line; do
     # Début source_path
     if echo "$line" | grep -q "^source_path:"; then
-      val=$(echo "$line" | sed 's/^source_path:[[:space:]]*//' | tr -d '"'"'")
+      val=$(echo "$line" | sed 's/^source_path:[[:space:]]*//' | sed 's/^"//; s/"$//')
       if [ -n "$val" ]; then
         # Scalaire
-        path_to_slug["$val"]="$slug"
+        path_to_slug["$(_safe_key "$val")"]="$slug"
+        indexed_paths+=("$val")
         [ -z "$first_sp" ] && first_sp="$val"
         in_sp=0
       else
@@ -103,9 +113,10 @@ while IFS= read -r source_file; do
         in_covered=0
         continue
       fi
-      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | tr -d '"'"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | sed 's/^"//; s/"$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
       if [ -n "$item" ]; then
-        path_to_slug["$item"]="$slug"
+        path_to_slug["$(_safe_key "$item")"]="$slug"
+        indexed_paths+=("$item")
         [ $in_sp -eq 1 ] && [ -z "$first_sp" ] && first_sp="$item"
       fi
     fi
@@ -123,8 +134,11 @@ while IFS= read -r source_file; do
         in_sources=0
         continue
       fi
-      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | tr -d '"'"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-      [ -n "$item" ] && path_to_slug["$item"]="$slug"
+      item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | sed 's/^"//; s/"$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      if [ -n "$item" ]; then
+        path_to_slug["$(_safe_key "$item")"]="$slug"
+        indexed_paths+=("$item")
+      fi
     fi
   done < "$source_file"
 
@@ -133,7 +147,7 @@ while IFS= read -r source_file; do
     sha_line=$(grep "^source_sha256:" "$source_file" 2>/dev/null | head -1 | sed 's/^source_sha256:[[:space:]]*//')
     # Ignore si c'est aussi une liste YAML (commence par vide → valeur vide)
     if [ -n "$sha_line" ] && [[ "$sha_line" != -* ]]; then
-      path_to_sha["$first_sp"]="$sha_line"
+      path_to_sha["$(_safe_key "$first_sp")"]="$sha_line"
     fi
   fi
 
@@ -143,17 +157,19 @@ done < <(find "$WIKI_SOURCES" -name "*.md" -type f)
 # Pour chaque source_path indexé, on note son répertoire parent → slug
 # Cela permet de SKIP un fichier si un autre fichier du même dossier est déjà couvert.
 
-declare -A dir_to_slug   # raw/foo/bar/ → slug (premier slug rencontré pour ce dossier)
-declare -A meta_to_slug  # raw/videos-meta/SLUG.meta.md → slug via transcript
+declare -A dir_to_slug   # safe_key(raw/foo/bar/) → slug (premier slug rencontré pour ce dossier)
+declare -A meta_to_slug  # safe_key(raw/videos-meta/SLUG.meta.md) → slug via transcript
 
-for indexed_path in "${!path_to_slug[@]}"; do
+for indexed_path in "${indexed_paths[@]}"; do
   [ -z "$indexed_path" ] && continue
+  ip_key=$(_safe_key "$indexed_path")
 
   # Index des répertoires implicites (≥4 niveaux de profondeur requis)
   idir="${indexed_path%/*}/"
+  idir_key=$(_safe_key "$idir")
   depth=$(printf '%s' "$idir" | tr -cd '/' | wc -c | tr -d ' ')
-  if [ "$depth" -ge 4 ] && [ -z "${dir_to_slug[$idir]+_}" ]; then
-    dir_to_slug["$idir"]="${path_to_slug[$indexed_path]}"
+  if [ "$depth" -ge 4 ] && [ -z "${dir_to_slug[$idir_key]+_}" ]; then
+    dir_to_slug["$idir_key"]="${path_to_slug[$ip_key]}"
   fi
 
   # Index videos-meta → transcript
@@ -161,7 +177,8 @@ for indexed_path in "${!path_to_slug[@]}"; do
     filename="${indexed_path##*/}"
     filename="${filename%.md}"
     meta_path="raw/videos-meta/${filename}.meta.md"
-    [ -z "${meta_to_slug[$meta_path]+_}" ] && meta_to_slug["$meta_path"]="${path_to_slug[$indexed_path]}"
+    meta_key=$(_safe_key "$meta_path")
+    [ -z "${meta_to_slug[$meta_key]+_}" ] && meta_to_slug["$meta_key"]="${path_to_slug[$ip_key]}"
   fi
 done
 
@@ -170,11 +187,12 @@ done
 for abs_path in "${files[@]}"; do
   # Chemin relatif depuis la racine du vault
   rel="${abs_path#$VAULT_ROOT/}"
+  rel_key=$(_safe_key "$rel")
 
   # 1. Match exact sur source_path ou covered_paths
-  if [ -n "${path_to_slug[$rel]+_}" ]; then
-    slug="${path_to_slug[$rel]}"
-    stored_sha="${path_to_sha[$rel]:-}"
+  if [ -n "${path_to_slug[$rel_key]+_}" ]; then
+    slug="${path_to_slug[$rel_key]}"
+    stored_sha="${path_to_sha[$rel_key]:-}"
     if [ -n "$stored_sha" ]; then
       current_sha=$(sha256sum "$abs_path" 2>/dev/null | cut -d' ' -f1)
       if [ "$current_sha" != "$stored_sha" ]; then
@@ -193,8 +211,9 @@ for abs_path in "${files[@]}"; do
     parent=$(dirname "$parent")
     [ "$parent" = "." ] || [ "$parent" = "raw" ] || [ "$parent" = "" ] && break
     parent_slash="${parent}/"
-    if [ -n "${path_to_slug[$parent_slash]+_}" ]; then
-      covered="${path_to_slug[$parent_slash]}"
+    parent_key=$(_safe_key "$parent_slash")
+    if [ -n "${path_to_slug[$parent_key]+_}" ]; then
+      covered="${path_to_slug[$parent_key]}"
       break
     fi
   done
@@ -206,14 +225,15 @@ for abs_path in "${files[@]}"; do
 
   # 3. Match implicite : même répertoire qu'un fichier déjà indexé (≥4 niveaux de profondeur)
   rel_dir="$(dirname "$rel")/"
-  if [ -n "${dir_to_slug[$rel_dir]+_}" ]; then
-    echo "SKIP     $rel  (covered-by-dir-implicit: ${dir_to_slug[$rel_dir]})"
+  rel_dir_key=$(_safe_key "$rel_dir")
+  if [ -n "${dir_to_slug[$rel_dir_key]+_}" ]; then
+    echo "SKIP     $rel  (covered-by-dir-implicit: ${dir_to_slug[$rel_dir_key]})"
     continue
   fi
 
   # 4. Correspondance videos-meta → transcript déjà ingéré
-  if [ -n "${meta_to_slug[$rel]+_}" ]; then
-    echo "SKIP     $rel  (covered-by-transcript: ${meta_to_slug[$rel]})"
+  if [ -n "${meta_to_slug[$rel_key]+_}" ]; then
+    echo "SKIP     $rel  (covered-by-transcript: ${meta_to_slug[$rel_key]})"
     continue
   fi
 

--- a/scripts/test-scan-raw.sh
+++ b/scripts/test-scan-raw.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# test-scan-raw.sh — Vérifie que scan-raw.sh gère correctement les caractères
+# spéciaux dans les chemins (apostrophes, parenthèses, espaces multiples).
+#
+# Usage:
+#   bash scripts/test-scan-raw.sh
+#
+# Codes de sortie : 0 = tous les cas SKIP, 1 = au moins un cas en NEW (régression).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCAN_RAW="$SCRIPT_DIR/scan-raw.sh"
+
+# --- Préparation d'un vault temporaire avec fichiers raw piégés ---
+
+TESTDIR=$(mktemp -d /tmp/test-scan-raw.XXXXXX)
+trap 'rm -rf "$TESTDIR"' EXIT
+
+mkdir -p "$TESTDIR/raw/notes" "$TESTDIR/wiki/sources"
+
+# Fichier 1 : apostrophe dans le nom (cas réel BB : `2026-01-30-claude-code-obsidian-cpr.md`
+# qui mentionnait `BotFather to 'Hello'` dans son source_path original)
+APOSTROPHE_FILE="$TESTDIR/raw/notes/2026-01-30-claude's-note.md"
+echo "Note avec apostrophe dans le nom" > "$APOSTROPHE_FILE"
+
+# Fichier 2 : parenthèses dans le nom
+PARENS_FILE="$TESTDIR/raw/notes/foo (bar).md"
+echo "Note avec parenthèses dans le nom" > "$PARENS_FILE"
+
+# Fichier 3 : espaces multiples dans le nom
+SPACES_FILE="$TESTDIR/raw/notes/multi  space.md"
+echo "Note avec doubles espaces dans le nom" > "$SPACES_FILE"
+
+# Fichier 4 : caractères composés (parenthèses + apostrophe)
+COMBO_FILE="$TESTDIR/raw/notes/it's (composite).md"
+echo "Note combinant apostrophe et parenthèses" > "$COMBO_FILE"
+
+# Calcul du sha256 de chaque fichier
+APOSTROPHE_SHA=$(sha256sum "$APOSTROPHE_FILE" | cut -d' ' -f1)
+PARENS_SHA=$(sha256sum "$PARENS_FILE" | cut -d' ' -f1)
+SPACES_SHA=$(sha256sum "$SPACES_FILE" | cut -d' ' -f1)
+COMBO_SHA=$(sha256sum "$COMBO_FILE" | cut -d' ' -f1)
+
+# Page wiki qui couvre les 4 raw via source_path (scalaire) + covered_paths (liste)
+cat > "$TESTDIR/wiki/sources/2026-05-01-trapped-paths.md" <<EOF
+---
+type: source
+source_path: "raw/notes/2026-01-30-claude's-note.md"
+source_sha256: $APOSTROPHE_SHA
+covered_paths:
+  - "raw/notes/foo (bar).md"
+  - "raw/notes/multi  space.md"
+  - "raw/notes/it's (composite).md"
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Trapped paths — fixture pour test-scan-raw.sh
+EOF
+
+# --- Exécution du scan ---
+
+# scan-raw.sh attend un layout vault avec wiki/sources et raw/ relatif au script.
+# On copie le script dans le testdir et on l'exécute depuis là.
+mkdir -p "$TESTDIR/scripts"
+cp "$SCAN_RAW" "$TESTDIR/scripts/scan-raw.sh"
+
+# Le script utilise SCRIPT_DIR/.. comme VAULT_ROOT.
+output=$(bash "$TESTDIR/scripts/scan-raw.sh" 2>&1)
+
+echo "=== Sortie du scan ==="
+echo "$output"
+echo ""
+
+# --- Vérifications ---
+
+errors=0
+
+check_skip() {
+  local pattern="$1"
+  local label="$2"
+  if echo "$output" | grep -qE "^SKIP\s+.*${pattern}"; then
+    echo "✅ $label : SKIP"
+  else
+    echo "❌ $label : devrait être SKIP, vérifie la sortie"
+    errors=$((errors + 1))
+  fi
+}
+
+# Bug 1 — apostrophe (source_path scalaire)
+check_skip "claude.s-note" "Bug 1 (apostrophe, source_path)"
+
+# Bug 2 — parenthèses (covered_paths liste)
+check_skip "foo \(bar\)" "Bug 2 (parenthèses, covered_paths)"
+
+# Bug 3 — espaces multiples (covered_paths liste)
+check_skip "multi  space" "Bug 3 (espaces multiples, covered_paths)"
+
+# Cas combiné (apostrophe + parenthèses)
+check_skip "it.s \(composite\)" "Cas combiné (apostrophe + parenthèses)"
+
+# Vérification : aucun NEW dans la sortie
+if echo "$output" | grep -qE "^NEW\s+raw/notes"; then
+  echo "❌ Au moins un fichier reporté NEW alors qu'il devrait être SKIP :"
+  echo "$output" | grep "^NEW"
+  errors=$((errors + 1))
+fi
+
+if [ "$errors" -eq 0 ]; then
+  echo ""
+  echo "🎉 Tous les cas reportent correctement SKIP."
+  exit 0
+else
+  echo ""
+  echo "❌ $errors erreur(s) détectée(s)."
+  exit 1
+fi


### PR DESCRIPTION
## Release v1.0.2

Cycle v1.0.2 complet : 3 PRs mergées dans `develop` (#7, #8, #9) + finalisation CHANGELOG (#10).

### Highlights

- **`CLAUDE.md.tpl` slim (268 → 112 lignes, −58 %)** : workflows détaillés extraits dans `.claude/commands/*.md`, conventions extraites dans `.claude/rules/` ([#5](https://github.com/tetra-plg/boiling-brain/issues/5)).
- **`.claude/rules/`** auto-chargées par Claude Code via `paths:` frontmatter (pattern Boris Cherny) : `frontmatter.md`, `pages-wiki.md`, `raw-vs-cache.md`. Propagées par `/update-vault` aux vaults existants.
- **`.claude/template-version` + `scripts/migrations/v<X>-*.md`** : machine de migration versionnée pour `/update-vault`. Rétrocompat v1.0.0 et v1.0.1.
- **`/update-vault` refactoré** comme machine de migration versionnée (lecture version locale, comparaison cible, propagation, chaîne de migrations, version bump).
- **`scripts/scan-raw.sh` : 3 bugs de parsing fixés** ([#3](https://github.com/tetra-plg/boiling-brain/issues/3)) — apostrophes (`tr -d`), parenthèses (`printf %q` neutralise toute la classe de bugs de quoting bash), espaces multiples. Fixture de test `scripts/test-scan-raw.sh`.
- **`/create-issue [bug|enhancement|docs|question]`** ([#4](https://github.com/tetra-plg/boiling-brain/issues/4)) : nouvelle slash-command pour remonter une issue sanitizée vers le template upstream depuis le contexte de la session courante. Sanitization 9 règles (strip wikilinks, paths privés, slugs domaines vault ; flag noms propres, entités, handles ; anonymisation chiffrée). Validation utilisateur obligatoire avant `gh issue create`. Comportement proactif depuis le radar.

### Migration depuis v1.0.x

Détails dans le CHANGELOG. TL;DR : `/update-vault` détecte automatiquement la version locale (rétrocompat v1.0.0 / v1.0.1), propage les nouveaux fichiers, déclenche la migration interactive `v1.0.2-claude-md-slim` qui préserve les customizations user du `CLAUDE.md`.

Validé en condition réelle sur le BoilingBrain (vault v1.0.1) — migration en 3 commits propres ([details dans PR #7](https://github.com/tetra-plg/boiling-brain/pull/7)).

### Test plan release

- [x] PR #7, #8, #9 individuellement validées (smoke tests + condition réelle pour #5 et #4).
- [x] `wc -l CLAUDE.md.tpl` ≤ 200 (cible 112).
- [x] `bash scripts/test-scan-raw.sh` passe.
- [x] CHANGELOG header : `[v1.0.2] — 2026-05-01`.
- [ ] Tag v1.0.2 + GitHub release post-merge (auto via les commandes du mainteneur).

### Cleanup post-release

- PR #2 (v1.1.0 — MCP server, compress-bb, hooks) sera rebasée sur `develop` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)