### PR TITLE
fix(lint): préciser l'heuristique d'orphans (exclure source parente)

### DIFF
--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -12,9 +12,24 @@ Si vide : analyse complète du wiki (coûteux — réserver aux revues mensuelle
 Report on:
 - Contradictions across pages
 - Stale claims
-- Orphan pages (no inbound links)
+- Orphan pages — voir critère ci-dessous
 - Concepts mentioned without their own page
 - Missing cross-references
 - Data gaps worth researching
 
 Suggest next sources to ingest.
+
+## Orphan pages — critère
+
+**Orphan = page avec 0 inbound link depuis une page autre que sa source parente d'ingestion.**
+
+Une page créée à partir d'une seule source aura toujours ≥1 inbound depuis cette source ; ce lien trivial ne suffit pas à la connecter au réseau de cross-refs (hubs de domaine, cheatsheets, autres concepts, syntheses). Le critère naïf "0 inbound" rate ces cas.
+
+Heuristique pratique :
+
+1. Pour chaque page non-source, lire son frontmatter `sources:`.
+2. Lister les wikilinks entrants vers la page (grep).
+3. Soustraire les inbounds qui viennent des sources listées dans son `sources:` (et leurs `covered_paths`).
+4. Si reste 0 → orphan effective.
+
+Exemple : un concept framework créé lors de l'ingestion d'une doc unique, jamais cross-référencé depuis le hub de son domaine ni depuis un concept voisin, est orphan — même s'il a 1 inbound depuis sa source parente.


### PR DESCRIPTION
## Summary

- Précise la définition d'orphan dans `.claude/commands/lint.md` : **0 inbound depuis une page autre que la source parente d'ingestion**.
- Ajoute l'heuristique pratique en 4 étapes (lecture du frontmatter `sources:`, grep des inbounds, soustraction des inbounds-source, vérification du reste).
- Aucun changement à `CLAUDE.md.tpl` : il ne mentionne `/lint` que dans une table de commandes, sans détail à aligner.

## Test plan

- [x] Lancer `/lint <domaine>` sur un vault peuplé contenant une page avec inbounds uniquement depuis sa source parente
- [x] Vérifier que cette page apparaît bien dans la liste des orphelines (alors qu'elle ne l'aurait pas été avec l'ancien critère)

### Cas test concret (vault `boiling-brain`)

**Page** : `wiki/entities/avichawla.md`

**Frontmatter** :
```yaml
sources: [[sources/2026-04-24-rag-vs-cag-avichawla]]
```

**Inbounds détectés (3)** :
- `wiki/sources/2026-04-24-rag-vs-cag-avichawla.md` → source parente
- `wiki/index.md` → trivial (out-of-scope, déjà couvert par autres heuristiques)
- `wiki/log-archive.md` → trivial (out-of-scope)

**Résultat** :
- Ancien critère (`0 inbound`) : 3 inbounds → **pas orpheline** (faux négatif — l'entité est isolée de facto, aucun concept ni hub de domaine ne la référence)
- Nouveau critère : on retire la source parente, il reste 2 inbounds triviaux → **orpheline ✓**

C'est exactement le scénario décrit dans l'issue #12.

Closes #12