### PR TITLE
feat(v1.1.0): ingest workflow + agent contract + agent-memory

### DIFF
--- a/.claude/agent-output-contract.md
+++ b/.claude/agent-output-contract.md
@@ -1,0 +1,41 @@
+# Agent output contract
+
+Every expert agent invoked by `/ingest` returns **three parsable markdown blocks** at the end of its turn. The main context reads these blocks and writes the downstream files. **The agent never writes to `wiki/log.md`, `wiki/radar.md`, or `.claude/agents/*.suggestions.md` directly.**
+
+## Three blocks
+
+```markdown
+## Ingest summary
+- Pages created: [[wiki/sources/...]], [[wiki/concepts/...]], …
+- Pages updated: …
+- Deliverables produced: …
+- Contradictions detected: …
+- Cross-domain: […]
+
+## Radar items
+- Specific observations attached to a named source / timestamp / project.
+- Missing facts ("what is the exact value of X?").
+- "If 2nd occurrence of X, create concept Y" (threshold not met).
+- Content gaps to fill via a future ingest.
+
+## Evolution suggestions
+- Concept broadened to the domain (derived from a specific observation).
+- Behavioral rule applicable to any future ingest **independent of the content**.
+- Structural blind spot of the prompt.
+- "N/A" if nothing notable — default encouraged.
+```
+
+## Conceptual derivation rule (core)
+
+For every specific observation, apply the **double jump**:
+
+1. **Broadened concept?** → `## Evolution suggestions` (transverse rule)
+2. **Specific detail not covered by this ingest?** → `## Radar items` (to investigate)
+
+**Decisive test** for `Evolution suggestions`: *"Would this rule still hold if the source was about another actor in the domain?"* If no → not transverse → `Radar items`.
+
+## Examples
+
+**Valid Evolution suggestion** (transverse): "Future ingests of LLM provider docs should systematically capture context window, pricing tier, and reasoning configurability."
+
+**Invalid** (specific): "Anthropic Opus 4.7 has a 1M context window." → goes to `## Radar items` (mention of a specific actor).

--- a/.claude/agents/domain-expert.md.tpl
+++ b/.claude/agents/domain-expert.md.tpl
@@ -65,9 +65,10 @@ When the source brings up a new kind of angle this list doesn't cover, **integra
 - Archive entries > 90 days into `## Expired patterns`.
 - Update domain state sections (recent concepts, sub-series in progress, etc.) where relevant.
 
-**Memory vs Evolution suggestions distinction**:
-- Memory = **project state** (patterns awaiting, progress, existing structural pages).
-- Evolution suggestions = **behavioral rules** for the prompt, via `/evolve-agent`.
+**Memory vs Suggestions vs Radar distinction**:
+- `agent-memory/{{domain_slug}}/MEMORY.md` = **project state** (patterns awaiting their 2nd occurrence, recent concepts, sub-series in progress). You read at startup, update at ingest end.
+- `## Evolution suggestions` (returned to main context) = **behavioral rules** for the prompt, consumed by `/evolve-agent`.
+- `## Radar items` (returned to main context) = **specific observations** to investigate, propagated to `wiki/radar.md`.
 
 ## Visual frames
 
@@ -78,7 +79,7 @@ When you ingest a **video transcript**, you can request a frame capture if two c
 
 {{domain_slug}}-specific triggers: {{trigger_examples}}.
 
-Declare your requests at the end of the report, **after** `## Ingest summary` and `## Evolution suggestions`:
+Declare your requests at the end of the report, **after** the three blocks (`## Ingest summary`, `## Radar items`, `## Evolution suggestions`):
 
 ```
 ## Frame requests
@@ -101,30 +102,22 @@ When `source_sha256` is identical but the ingest is forced: behavior is **additi
 
 ## How you report back to the main context
 
-At the end of your turn, return **two parsable markdown blocks**:
+At the end of your turn, return **three parsable markdown blocks** per the contract in `.claude/agent-output-contract.md`:
 
 ```markdown
 ## Ingest summary
-- Pages created: [[wiki/sources/...]], [[wiki/concepts/...]], …
-- Pages updated: …
-- Deliverables produced: …
-- Contradictions detected: …
-- Open questions: …
-- Cross-domain: […]  ← domains outside {{domain_label}} touched by this source — empty if none
+- Pages created/updated, deliverables, contradictions, cross-domain.
+
+## Radar items
+- Specific observations, missing facts, thresholds not met (cf. contract).
 
 ## Evolution suggestions
-- Recurring pattern detected: <description + pointer(s)>
-- Suspected blind spot: <description>
-- Proposed addition / modification to my prompt: <concrete text>
-- Proposed new deliverable category: <description>
+- Transverse rules only. "N/A" if nothing notable.
 ```
 
-Be concrete in `Evolution suggestions`: these are your raw materials for `/evolve-agent {{domain_slug}}` which will improve your prompt later. Flag:
-- what comes back often and would deserve to be codified,
-- what you almost missed for lack of a prepared angle,
-- a new kind of deliverable that would be useful.
+The **main context** appends these blocks to `wiki/log.md`, `wiki/radar.md`, and `.claude/agents/{{domain_slug}}-expert.suggestions.md`. **You never write to those files directly** — this avoids drift across agents.
 
-If nothing notable, write "N/A" — don't force invention.
+For `Evolution suggestions`, apply the **decisive test** from the contract: *"Would this rule still hold if the source was about another actor in the domain?"* If no → it's a `Radar item`, not an Evolution suggestion.
 
 ## Posture
 

--- a/.claude/commands/evolve-agent.md
+++ b/.claude/commands/evolve-agent.md
@@ -14,6 +14,7 @@ Evolve the prompt of the expert agent `$ARGUMENTS-expert` from the suggestions i
 - **Current prompt**: `.claude/agents/$ARGUMENTS-expert.md`.
 - **Accumulated suggestions**: `.claude/agents/$ARGUMENTS-expert.suggestions.md` (append-only, timestamped by `/ingest`).
 - **Previous archive** (if it exists): `.claude/agents/$ARGUMENTS-expert.suggestions.archive.md` — to see what's already been integrated in the past.
+- **Operational memory** (read-only, for context): `.claude/agent-memory/$ARGUMENTS/MEMORY.md` and `.claude/agent-memory/$ARGUMENTS/patterns_pending.md` if they exist. These document the project state — use them to disambiguate suggestions but **do not modify** them.
 
 If the suggestions file doesn't exist or is empty → tell the user, suggest they trigger one or more domain ingests first.
 

--- a/.claude/commands/ingest.md
+++ b/.claude/commands/ingest.md
@@ -93,7 +93,7 @@ If the agent's report contains a `## Frame requests` block, handle **before** th
 
 ### 4c. Pending-ingest purge
 
-Remove from `cache/.pending-ingest` the paths processed in this run (NEW + MODIFIED) and the stale SKIP entries detected at step 1. The main context accumulates `PROCESSED_PATHS` and `STALE_SKIP_PATHS` during the run.
+Remove from `cache/.pending-ingest` the paths processed in this run (NEW + MODIFIED) and the stale SKIP entries detected at step 1. The main context accumulates these throughout the run: `PROCESSED_PATHS` = all NEW + MODIFIED paths from step 1; `STALE_SKIP_PATHS` = SKIP entries that were already present in `.pending-ingest` at step 1.
 
 ```bash
 PENDING="cache/.pending-ingest"

--- a/.claude/commands/ingest.md
+++ b/.claude/commands/ingest.md
@@ -54,27 +54,29 @@ If video/audio/URL not transcribed → chain `scripts/transcribe.sh` first.
 
 ### 3. Spawning the expert agent
 
+Read `.claude/agent-output-contract.md` once at the start of the run; inject it integrally into every spawn prompt below.
+
 For each validated agent, launch an `Agent` call with:
 - `subagent_type`: the chosen agent.
 - **Prompt** containing:
   - Path of the raw file to ingest.
   - List of titles of existing pages in the domain (`wiki/entities/`, `wiki/concepts/`, `wiki/cheatsheets/`, etc. depending on the agent's deliverables).
   - Path of `wiki/domains/<d>.md`.
-  - Instruction: execute the ingest end-to-end, then return the report in `## Ingest summary` + `## Evolution suggestions` format (cf. agent prompt).
+  - The full content of `.claude/agent-output-contract.md`.
+  - Instruction: execute the ingest end-to-end, then return the three blocks (`## Ingest summary`, `## Radar items`, `## Evolution suggestions`) per the contract. The agent **does not write** to `wiki/log.md`, `wiki/radar.md`, or `.claude/agents/*.suggestions.md` — the main context handles propagation.
 
 Cross-domain → multiple agents in parallel (same multi-tool call).
 
 ### 4. Collection and journaling
 
-When the agent(s) have returned their report:
+When the agent(s) have returned their report, the **main context** writes (never the agent):
 
-1. Append to `wiki/log.md`:
-   ```
-   ## [YYYY-MM-DD] ingest | <source title> (agent: <name>)
-   <summary of the Ingest summary block — pages created/updated, deliverables>
-   ```
-2. Append the `## Evolution suggestions` block to `.claude/agents/<domain>-expert.suggestions.md` (create if needed) with a `### [YYYY-MM-DD HH:MM] source: <path>` timestamp.
-3. Update `wiki/index.md` if the agent didn't already.
+1. **`wiki/log.md`** ← append summary line from `## Ingest summary` (`## [YYYY-MM-DD] ingest | <source title> (agent: <name>)` + 2-3 lines on pages created/updated/deliverables).
+2. **`wiki/radar.md`** ← append entries from `## Radar items` under the relevant thematic section. If no section matches, append to a `## Triage` block at the top of the file and flag this in the final report.
+3. **`.claude/agents/<domain>-expert.suggestions.md`** ← append the `## Evolution suggestions` block (timestamped `### [YYYY-MM-DD HH:MM] source: <path>`). Skip if the block is "N/A".
+4. **`wiki/index.md`** ← update if the agent's pages aren't already linked.
+
+Centralizing writes in the main context prevents drift and inconsistent formatting across agents.
 
 ### 4b. Frame extraction (if present)
 
@@ -88,6 +90,20 @@ If the agent's report contains a `## Frame requests` block, handle **before** th
    d. On rejection → propose 3 quick alternatives without re-asking the user to specify an offset: extract at T-10s (`offset=-5`), T+0s (`offset=0`) and T+20s (`offset=15`) via `./scripts/extract-frames.sh <video> <timestamp> cache/frames/<slug>-altN.png <offset>`, show all 3 as a batch, validate or annotate `> [!question] Frame not extracted` if none works.
 3. If no video in cache: tell the user the declared timestamps with the expected description — they can re-run manually or annotate the frames as `> [!question]`.
 4. Include in the final report: `Frames: N promoted · M rejected` (or `Frame requests: N declared — video not available in cache`).
+
+### 4c. Pending-ingest purge
+
+Remove from `cache/.pending-ingest` the paths processed in this run (NEW + MODIFIED) and the stale SKIP entries detected at step 1. The main context accumulates `PROCESSED_PATHS` and `STALE_SKIP_PATHS` during the run.
+
+```bash
+PENDING="cache/.pending-ingest"
+[ -f "$PENDING" ] || exit 0
+printf '%s\n' "${PROCESSED_PATHS[@]}" "${STALE_SKIP_PATHS[@]}" \
+  | sort -u \
+  | grep -vFxf - "$PENDING" > "$PENDING.tmp" || true
+mv "$PENDING.tmp" "$PENDING"
+[ -s "$PENDING" ] || rm -f "$PENDING"
+```
 
 ### 5. Final overall report
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`scripts/migrations/v1.1.0-mcp-setup.md`**: interactive migration invoked by `/update-vault` for vaults < 1.1.0. Runs `setup-mcp.sh` (MCP + global Stop hook) and patches the vault's `CLAUDE.md` to add the "Session start" section that drives the reading of `cache/.pending-ingest` and `cache/.session-pending` signals.
 - **`/update-vault`**: optional `target-branch` argument to test pre-release feat branches before merge (e.g. `/update-vault feat/v1.2.0`). Default behavior unchanged (target `main`). (#30)
 
+### Added (ingest + agent surface)
+
+- **`.claude/agent-output-contract.md`**: factorized contract specifying the three output blocks every expert agent returns (`## Ingest summary`, `## Radar items`, `## Evolution suggestions`) with the conceptual derivation rule. Injected into agent prompts at spawn by `/ingest`. (#19)
+- **`/ingest`**: parses `## Radar items` from agent reports and propagates them to `wiki/radar.md`; purges processed and stale entries from `cache/.pending-ingest` at end of run. (#19, #24)
+- **`.claude/agents/domain-expert.md.tpl`**: section "How you report back" refactored — references the contract, clarifies that the main context (not the agent) writes downstream files. (#19, #25)
+- **`/evolve-agent`**: reads `.claude/agent-memory/<domain>/patterns_pending.md` in read-only mode to disambiguate suggestions. (#26)
+- **`CLAUDE.md.tpl`**: section "Per-domain expert agents" documents the agent-output-contract and the agent-memory convention (no separate rule — subagents do not see `.claude/rules/`). (#26)
+
 ### Added (L3 readiness)
 
 - **ADR template** (`wiki/decisions/decision.md.tpl`): frontmatter fields `verdict`, `verdict_date`, `verdict_evidence` (all opt-in, null by default) + `## Real feedback` section with T+30/60/90d placeholders. (#18)

--- a/CLAUDE.md.tpl
+++ b/CLAUDE.md.tpl
@@ -69,7 +69,9 @@ Ingestion is **delegated to a domain-expert agent** matching the source. Agents 
 
 {{agents_section}}
 
-Each agent has a **deliberately open** prompt (not a closed checklist) and **writes directly** into the wiki. It concludes with two parsable blocks: `## Ingest summary` and `## Evolution suggestions`. Suggestions accumulate in `.claude/agents/<domain>-expert.suggestions.md` to feed `/evolve-agent`.
+Each agent has a **deliberately open** prompt (not a closed checklist) and **writes directly** into `wiki/` pages it owns (sources, concepts, entities, etc.). It concludes with three parsable blocks per `.claude/agent-output-contract.md`: `## Ingest summary`, `## Radar items`, `## Evolution suggestions`. The **main context** (not the agent) appends those blocks to `wiki/log.md`, `wiki/radar.md`, and `.claude/agents/<domain>-expert.suggestions.md` to feed `/evolve-agent`.
+
+Operational memory lives in `.claude/agent-memory/<domain>/` (`MEMORY.md` + `patterns_pending.md` + free-form notes): the agent reads it at startup and updates it at ingest end. Distinct from `.suggestions.md` (behavioral rules for `/evolve-agent`). No `.claude/rules/agent-memory.md` — subagents don't load `.claude/rules/` from the main context.
 
 The agent dispatch in `/ingest` proposes an agent with a confidence level + justification, then the user validates via `AskUserQuestion`. See `.claude/commands/ingest.md` for details.
 
@@ -100,7 +102,7 @@ Structural choices about the vault (workflows, conventions, tooling — not know
 
 At the start of each session, check the signals left in `cache/`:
 
-- **`cache/.pending-ingest`**: one or more paths awaiting ingestion (dropped via the `drop_to_raw` MCP or by another vault). Suggest `/ingest <path>` for each entry. Don't delete the file — wait for user confirmation.
+- **`cache/.pending-ingest`**: paths awaiting ingestion. Run `bash scripts/scan-raw.sh` first — purge silently the `SKIP` (stale, already ingested), suggest `/ingest <path>` for `NEW` / `MODIFIED` entries. Remove the file if empty.
 - **`cache/.session-pending`**: the previous session had unjournaled changes (commits + modified files detected by the `Stop` hook). Suggest `/compress-bb <slug>` to archive the journal into `raw/notes/sessions/`. Delete the file after the proposal.
 
 These checks are silent if the files are absent.


### PR DESCRIPTION
## Summary

Refonte de la surface ingest/agent (PR-B du découpage v1.1.0 par fichier-cible) : contrat factorisé pour les subagents, propagation Radar items vers `wiki/radar.md`, purge `.pending-ingest`, formalisation `.claude/agent-memory/`.

## Closes

- Closes #19 — Séparer « radar items » (spécifique) et « evolution suggestions » (concept élargi)
- Closes #24 — `cache/.pending-ingest` ne se purge jamais après `/ingest`
- Closes #25 — `/ingest` : ambiguïté sur qui écrit `wiki/log.md` et `.suggestions.md`
- Closes #26 — Convention `.claude/agent-memory/<agent>/` à formaliser (cadrer)

## Commits

| # | Commit | Fichiers |
|---|--------|----------|
| 1 | `feat(contract): create agent-output-contract.md with 3-block output spec (#19)` | nouveau `.claude/agent-output-contract.md` (41 l) |
| 2 | `feat(ingest+agent): 3-block output, Radar propagation, .pending-ingest purge (#19, #24, #25)` | `ingest.md` + `domain-expert.md.tpl` |
| 3 | `feat(evolve+claude-md): patterns_pending.md context + agent-memory framing (#26)` | `evolve-agent.md` + `CLAUDE.md.tpl` |
| 4 | `docs(changelog): v1.1.0 ingest+agent surface entries` | `CHANGELOG.md` |

## Décisions design (recos Anthropic via `claude-code-guide` Q1-Q5)

- **Contrat fichier dédié** (`.claude/agent-output-contract.md`, ≤40 l) injecté au spawn par `/ingest` (Q2/Q3 ✓)
- **Référence courte** dans `domain-expert.md.tpl` (Q4 ✓) — 3 blocs au lieu de 2, redirection vers le contrat
- **Pas de rule `.claude/rules/agent-memory.md`** (Q5 ✗) — subagents ne voient pas les rules → convention documentée dans `domain-expert.md.tpl` (déjà fait l. 60-70) + `CLAUDE.md.tpl`
- **Main context écrit**, jamais l'agent → évite drift inter-agents (lève #25)
- **#24 migré PR-A → PR-B** : touche `ingest.md` partagé avec #19, regroupement évite conflits

## Architecture (3 blocs)

```markdown
## Ingest summary       → wiki/log.md
## Radar items          → wiki/radar.md (NEW: propagation codifiée)
## Evolution suggestions → .claude/agents/<domain>-expert.suggestions.md
```

**Règle de dérivation conceptuelle** (cœur du contrat) :
- Observation spécifique → Concept élargi au domaine ? → `Evolution suggestions`
- Sinon → `Radar items`
- Test décisif : « la règle tient-elle sur un autre acteur du domaine ? »

## Test plan

- [x] `.claude/agent-output-contract.md` créé (41 l, ≤40 cible respectée)
- [x] `/ingest` step 3 : injection du contrat au spawn (lecture une fois par run)
- [x] `/ingest` step 4 : main context écrit les 3 fichiers (log.md, radar.md, .suggestions.md)
- [x] `/ingest` step 4c : purge `.pending-ingest` (NEW + STALE_SKIP, idempotent)
- [x] `domain-expert.md.tpl` : section "How you report back" refactorée vers 3 blocs + référence courte
- [x] `domain-expert.md.tpl` : distinction Memory vs Suggestions vs Radar clarifiée
- [x] `evolve-agent.md` step 1 : lecture read-only de `patterns_pending.md` pour contexte
- [x] `CLAUDE.md.tpl` : section "Per-domain expert agents" pointe vers contract + agent-memory
- [x] `CLAUDE.md.tpl` ligne 105 : `.pending-ingest` signale les SKIP stales (cf. #24)
- [x] CHANGELOG.md v1.1.0 : nouvelle section `### Added (ingest + agent surface)` avec 5 entrées
- [ ] **Smoke test impossible** : déclencherait un vrai `/ingest` sur source réelle (effets de bord BB peuplé) — validation visuelle uniquement

## Garde-fous anti-surcharge

- 0 nouvel agent / command / hook
- Delta cumulé : +92 / −31 lignes (6 fichiers, 1 nouveau)
- Budget global v1.1.0 : PR-A (~25) + PR-C (~50) + PR-D (~45) + PR-B (~80) = **~200 lignes**
- ⚠️ Dépasse la cible originale +150 (PR-B légitimement le plus gros scope). Valeur ajoutée justifie le coût.

## Status

✅ Ready for review (le plus gros morceau v1.1.0)