### PR TITLE
feat(v1.1.0): L3 readiness — verdict ADR + revisit_after + Real feedback

### DIFF
--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -16,6 +16,9 @@ Report on:
 - Concepts mentioned without their own page
 - Missing cross-references
 - Data gaps worth researching
+- **L3 readiness**:
+  - ADRs (`wiki/decisions/*.md`) older than 90 days without `verdict` (status confirmation overdue).
+  - Pages whose `revisit_after` date has passed (decisions and concepts).
 
 Suggest next sources to ingest.
 

--- a/.claude/rules/frontmatter.md
+++ b/.claude/rules/frontmatter.md
@@ -62,7 +62,7 @@ verdict_date: null | YYYY-MM-DD                       # optional, must accompany
 verdict_evidence: null | "short narrative"            # optional, must accompany verdict
 ```
 
-ADRs without `verdict` after **90 days** are flagged by `/lint` (forces L3 confrontation — see [[decisions/template-l3-optims-v1.1x]]).
+ADRs without `verdict` after **90 days** are flagged by `/lint` (forces L3 confrontation with reality).
 
 ## Optional `revisit_after` field
 

--- a/.claude/rules/frontmatter.md
+++ b/.claude/rules/frontmatter.md
@@ -53,6 +53,25 @@ shasum -a 256 raw/<folder>/<file>.md | awk '{print $1}'
 
 If the file cannot be hashed (invalid path, access error), the ingestion fails — no silent fallback.
 
+## Fields specific to `type: decision` pages
+
+```yaml
+status: pending | accepted                            # mandatory
+verdict: null | validated | invalidated | partial     # optional, null until reality validates
+verdict_date: null | YYYY-MM-DD                       # optional, must accompany verdict
+verdict_evidence: null | "short narrative"            # optional, must accompany verdict
+```
+
+ADRs without `verdict` after **90 days** are flagged by `/lint` (forces L3 confrontation — see [[decisions/template-l3-optims-v1.1x]]).
+
+## Optional `revisit_after` field
+
+```yaml
+revisit_after: YYYY-MM-DD     # on type: decision and type: concept pages
+```
+
+`/lint` flags pages whose `revisit_after` date has passed. Use this to schedule a re-read of a concept or decision (e.g. after a related project ships, after a major external change).
+
 ## `summary_l0` and `summary_l1` fields (tiered loading)
 
 Mandatory for `domains/`, `cheatsheets/`, `concepts/`, `syntheses/`. Recommended for `sources/`, `entities/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`scripts/migrations/v1.1.0-mcp-setup.md`**: interactive migration invoked by `/update-vault` for vaults < 1.1.0. Runs `setup-mcp.sh` (MCP + global Stop hook) and patches the vault's `CLAUDE.md` to add the "Session start" section that drives the reading of `cache/.pending-ingest` and `cache/.session-pending` signals.
 - **`/update-vault`**: optional `target-branch` argument to test pre-release feat branches before merge (e.g. `/update-vault feat/v1.2.0`). Default behavior unchanged (target `main`). (#30)
 
+### Added (L3 readiness)
+
+- **ADR template** (`wiki/decisions/decision.md.tpl`): frontmatter fields `verdict`, `verdict_date`, `verdict_evidence` (all opt-in, null by default) + `## Real feedback` section with T+30/60/90d placeholders. (#18)
+- **`revisit_after` frontmatter field** on `type: decision` and `type: concept` pages (opt-in). (#18)
+- **`/lint`**: flag ADRs ≥ 90 days without `verdict`, and pages whose `revisit_after` is past. (#18)
+
 ### Fixed (alpha feedback)
 
 - **`/compress-bb`**: document "When NOT to use" to avoid redundancy with substantive `raw/notes/` (#22).

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ Five tools are exposed:
 4. After a few ingestions in a domain, run `/evolve-agent <domain>` to fold accumulated suggestions back into the expert's prompt.
 5. Use `/query` whenever you need to answer something from the corpus. Substantial answers can be archived via `/save`.
 
+## L3 readiness
+
+The template ships with **opt-in scaffolding** for the L3 layer of personal knowledge management (model revision via real-world feedback): `verdict` frontmatter on ADRs, `revisit_after` on decisions and concepts, `## Real feedback` section in the ADR template. The template does not enforce L3 — only you can judge if a decision held up — but `/lint` surfaces stale ADRs (≥ 90 days without verdict) and overdue revisits to prompt confrontation with reality.
+
 ## Who is this for?
 
 **For you if:**

--- a/wiki/decisions/decision.md.tpl
+++ b/wiki/decisions/decision.md.tpl
@@ -4,7 +4,7 @@ domains: [<domain1>]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 sources: []
-status: pending | accepted
+status: pending              # pending | accepted
 verdict: null            # null | validated | invalidated | partial — fill after T+30/60/90d
 verdict_date: null       # YYYY-MM-DD when verdict was assigned
 verdict_evidence: null   # short text: what actually happened

--- a/wiki/decisions/decision.md.tpl
+++ b/wiki/decisions/decision.md.tpl
@@ -1,0 +1,48 @@
+---
+type: decision
+domains: [<domain1>]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+sources: []
+status: pending | accepted
+verdict: null            # null | validated | invalidated | partial — fill after T+30/60/90d
+verdict_date: null       # YYYY-MM-DD when verdict was assigned
+verdict_evidence: null   # short text: what actually happened
+revisit_after: null      # optional YYYY-MM-DD — /lint flags this page when the date is past
+summary_l0: "≤140 chars"
+summary_l1: |
+  2-5 sentences.
+---
+
+# ADR — <title>
+
+## Problem
+
+<What forced this decision? Constraints, observations, evidence.>
+
+## Discarded options
+
+<Other paths considered and why they were dropped.>
+
+## Decision
+
+<The chosen path, in one paragraph.>
+
+## Why
+
+<Rationale, trade-offs, dependencies.>
+
+## Open questions
+
+- [ ] <Question to revisit later.>
+
+## Real feedback
+
+<!-- Fill 30/60/90 days after the decision. Empty = ADR not yet validated by reality.
+     Mechanism: `/lint` flags ADRs ≥90d old without `verdict`. -->
+
+### YYYY-MM-DD (T+Xd)
+
+- What happened:
+- Hypothesis confirmed / invalidated:
+- Revision action:


### PR DESCRIPTION
## Summary

Optims L3 readiness (PR-D du découpage v1.1.0 par fichier-cible) sur les ADRs et concepts du wiki. Implémente les 3 pièces **cheap** de l'ADR du BB (`wiki/decisions/template-l3-optims-v1.1x.md`) : frontmatter `verdict`, `revisit_after`, section `## Real feedback`. Les optims 2/4/5/6/8 (audit-l3, decision-checkup, hooks, `/publish`) restent hors scope → v1.1.1+.

## Closes

- Closes #18 — Add L3 readiness optims to v1.1.x

## Commits

| # | Commit | Fichiers |
|---|--------|----------|
| 1 | `feat(adr): template with verdict frontmatter + Real feedback section (#18)` | nouveau `wiki/decisions/decision.md.tpl` (48 lignes) |
| 2 | `feat(rules+lint): document verdict + revisit_after, flag stale ADRs ≥90d (#18)` | `frontmatter.md` + `lint.md` |
| 3 | `docs(changelog+readme): L3 readiness framing v1.1.0 (#18)` | `README.md` + `CHANGELOG.md` |

## Décisions design

- **Emplacement template ADR** : `wiki/decisions/decision.md.tpl` (cohérent avec `wiki/domains/domain.md.tpl`)
- **Seuil `/lint`** : **90 jours** (cf. issue #18, médian 60-120 ADR BB)
- **Section** : `## Real feedback` en EN (alignement v1.0.3)
- **100 % opt-in** : tous les champs `null` par défaut → aucune migration forcée des 3 ADRs existants

## Test plan

- [x] `decision.md.tpl` créé avec frontmatter complet + section `## Real feedback` avec placeholders T+30/60/90d
- [x] `frontmatter.md` : nouvelles sections « Fields specific to `type: decision` » + « Optional `revisit_after` field »
- [x] `lint.md` : bullet « L3 readiness » sous "Report on"
- [x] README.md : paragraphe « L3 readiness — opt-in scaffolding » entre Workflow loop et Who is this for?
- [x] CHANGELOG.md v1.1.0 : nouvelle section `### Added (L3 readiness)` avec 3 entrées
- [ ] **Smoke test impossible** : le `.tpl` est consommé au bootstrap, intestable sans bootstrapper un nouveau vault — validation visuelle uniquement

## Garde-fous anti-surcharge

- 0 nouvel agent / command / hook (juste un nouveau template ADR `.tpl`)
- Delta cumulé : +80 / −0 lignes (5 fichiers, 1 nouveau)
- Budget global v1.1.0 : PR-A (~25) + PR-C (~50) + PR-D (~45) = **~120 lignes** → sous le seuil +150

## Status

✅ Ready for review