### PR TITLE
fix(v1.1.0): review findings — heredoc + preview + pipx + scan_domain truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,14 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`/compress-bb`**: document "When NOT to use" to avoid redundancy with substantive `raw/notes/` (#22).
 - **`scripts/scan-raw.sh`**: avoid silent kill under `set -euo pipefail` when `source_sha256` absent on composite pages (#23).
 - **`/update-vault`**: track applied migrations individually via `applied-migrations:` field in `.claude/template-version` — fixes silent skip of migrations added retroactively (after a version bump). Vaults pre-v1.1.0 auto-populate the field at first run post-upgrade. (#31)
+- **`scripts/setup-mcp.sh`**: quote heredoc delimiter and pass shell vars via `os.environ` — vault paths containing `"` or `\` no longer corrupt the Python hook registration silently (review finding A).
+- **`scripts/setup-mcp.sh`**: surface pipx install errors instead of swallowing stderr — real cause visible when fastmcp installation fails (review finding C).
+- **`scripts/mcp-wiki.py`**: `scan_domain` now accepts an optional `limit` parameter (default `0` = no limit) and surfaces capping in the output (`X / Y pages`) — large domains no longer lose pages silently (#36, review finding D).
 
 ### Changed
 
 - **`.claude/commands/compress-bb.md`**: translated to EN (v1.0.3 alignment, no functional change).
+- **`scripts/mcp-wiki.py`**: `preview_page` outputs a whitelisted set of frontmatter fields (`type`, `domains`, `created`, `updated`, `summary_l0`, `sources`, `status`, `verdict`) instead of every field — controls verbosity with the new ADR L3 fields (review finding B).
 
 ### Migration from v1.0.x
 

--- a/scripts/mcp-wiki.py
+++ b/scripts/mcp-wiki.py
@@ -27,7 +27,6 @@ WIKI_DIR = WIKI_PATH / "wiki"
 RAW_DIR = WIKI_PATH / "raw"
 CACHE_DIR = WIKI_PATH / "cache"
 
-MAX_PAGES = 80
 MAX_OUTPUT_TOKENS_APPROX = 10_000
 
 FRONT_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
@@ -76,11 +75,12 @@ def _domain_pages(domain: str) -> list[Path]:
         "Use FIRST before answering any question about the user's knowledge domains. "
         "Lists wiki pages for a given domain with their summary_l0 (one-line synopsis). "
         "domain: one of poker, ia, factory, metier, tech, astro. "
-        "Returns a compact index (up to 80 pages, sorted by last updated) — "
-        "use preview_page or read_page for details."
+        "Returns ALL pages by default (sorted by last updated). "
+        "Pass limit=N to cap output (e.g. on very large domains > 5000 pages). "
+        "Use preview_page or read_page for details."
     )
 )
-def scan_domain(domain: str) -> str:
+def scan_domain(domain: str, limit: int = 0) -> str:
     pages = _domain_pages(domain)
     if not pages:
         return f"Aucune page trouvée pour le domaine « {domain} »."
@@ -94,9 +94,14 @@ def scan_domain(domain: str) -> str:
             return ("", "")
 
     pages.sort(key=sort_key, reverse=True)
-    pages = pages[:MAX_PAGES]
+    total = len(pages)
+    if limit > 0:
+        pages = pages[:limit]
 
-    lines = [f"# Domaine : {domain} ({len(pages)} pages)\n"]
+    if limit > 0 and total > limit:
+        lines = [f"# Domaine : {domain} ({len(pages)} / {total} pages, capped at limit={limit})\n"]
+    else:
+        lines = [f"# Domaine : {domain} ({len(pages)} pages)\n"]
     for p in pages:
         try:
             fm, _ = _parse_front(p.read_text(encoding="utf-8"))

--- a/scripts/mcp-wiki.py
+++ b/scripts/mcp-wiki.py
@@ -135,9 +135,13 @@ def preview_page(page_path: str) -> str:
         return f"Erreur de lecture : {e}"
     fm, body = _parse_front(content)
     lines = [f"# Preview : {page_path}\n"]
-    for k, v in fm.items():
-        if k != "summary_l1":
-            lines.append(f"**{k}**: {v}")
+    # Whitelisted frontmatter fields — caps output verbosity with ADR L3 fields
+    # (verdict_evidence, verdict_date, revisit_after are skipped on purpose).
+    preview_fields = ("type", "domains", "created", "updated", "summary_l0",
+                      "sources", "status", "verdict")
+    for k in preview_fields:
+        if k in fm:
+            lines.append(f"**{k}**: {fm[k]}")
     l1 = fm.get("summary_l1", "")
     if l1:
         lines.append(f"\n## summary_l1\n{l1}")

--- a/scripts/mcp-wiki.py
+++ b/scripts/mcp-wiki.py
@@ -135,8 +135,7 @@ def preview_page(page_path: str) -> str:
         return f"Erreur de lecture : {e}"
     fm, body = _parse_front(content)
     lines = [f"# Preview : {page_path}\n"]
-    # Whitelisted frontmatter fields — caps output verbosity with ADR L3 fields
-    # (verdict_evidence, verdict_date, revisit_after are skipped on purpose).
+    # Whitelist: caps verbosity — verdict_evidence, verdict_date, revisit_after intentionally skipped.
     preview_fields = ("type", "domains", "created", "updated", "summary_l0",
                       "sources", "status", "verdict")
     for k in preview_fields:

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -59,7 +59,7 @@ if python3 -c "import fastmcp" 2>/dev/null; then
   echo "✅ fastmcp déjà disponible pour python3 système."
 elif command -v pipx &>/dev/null; then
   echo "📦 Installation de fastmcp via pipx…"
-  pipx install fastmcp 2>/dev/null || pipx upgrade fastmcp || true
+  pipx install fastmcp || pipx upgrade fastmcp || true
   PIPX_VENVS="$(pipx environment --value PIPX_LOCAL_VENVS 2>/dev/null || echo "$HOME/.local/pipx/venvs")"
   CANDIDATE="$PIPX_VENVS/fastmcp/bin/python"
   if [[ -x "$CANDIDATE" ]] && "$CANDIDATE" -c "import fastmcp" 2>/dev/null; then
@@ -94,12 +94,13 @@ else
 fi
 
 # --- Hook Stop dans ~/.claude/settings.json ---
-python3 - <<PYEOF
+CLAUDE_SETTINGS="$CLAUDE_SETTINGS" VAULT_PATH="$VAULT_PATH" python3 - <<'PYEOF'
 import json
+import os
 from pathlib import Path
 
-settings_path = Path("$CLAUDE_SETTINGS")
-vault_path = "$VAULT_PATH"
+settings_path = Path(os.environ["CLAUDE_SETTINGS"])
+vault_path = os.environ["VAULT_PATH"]
 
 if settings_path.exists():
     try:


### PR DESCRIPTION
## Summary

PR-E (post-review findings) — corrige 4 findings issus du `/review-pr` autopilot sur PR #2 + 1 bug L0 retrieval découvert lors du sanity check.

## Closes

- Closes #36 — MCP scan_domain silently truncates to 80 pages

## Findings traités

| # | File | Severity | Fix |
|---|------|----------|-----|
| A | `scripts/setup-mcp.sh:97-137` | 🔴 BLOCKING | Heredoc `<<'PYEOF'` quoted + vars via `os.environ` |
| B | `scripts/mcp-wiki.py:138-146` | 🟡 Design | `preview_page` whitelist 8 frontmatter fields |
| C | `scripts/setup-mcp.sh:62` | 🟡 UX | Drop `2>/dev/null` sur `pipx install` |
| D | `scripts/mcp-wiki.py:30,83-104` | 🔴 Bug L0 | `scan_domain(domain, limit=0)` no-limit default + cap banner (#36) |

## Commits

| # | Commit | Fichiers |
|---|--------|----------|
| 1 | `fix(setup-mcp): quote heredoc + surface pipx errors (review findings A, C)` | `scripts/setup-mcp.sh` |
| 2 | `fix(mcp-wiki): scan_domain limit param + truncation banner (#36)` | `scripts/mcp-wiki.py` |
| 3 | `refactor(mcp-wiki): whitelist preview_page frontmatter fields (review finding B)` | `scripts/mcp-wiki.py` |
| 4 | `docs(changelog): v1.1.0 review findings entries` | `CHANGELOG.md` |

## Décisions design

- **Finding D — limit=0 par défaut** : le BB retourne TOUTES les pages d'un domaine d'un seul appel (~14k tokens max pour le plus gros domaine actuel `ia` 369 pages). Pas de troncature silencieuse, pas d'heuristique à coder côté LLM. Le user peut passer `limit=N` pour cap si nécessaire futur (BB > 5000 pages).
- **Finding B — whitelist** : `type`, `domains`, `created`, `updated`, `summary_l0`, `sources`, `status`, `verdict`. Skip : `verdict_evidence` (long narrative), `verdict_date`, `revisit_after`, `summary_l1` (déjà géré séparément), `source_path`, `source_sha256`, etc.
- **Finding A — heredoc** : `<<'PYEOF'` quoted delimiter + `CLAUDE_SETTINGS="$CLAUDE_SETTINGS" VAULT_PATH="$VAULT_PATH" python3 - ...` + `os.environ[...]` côté Python. Robuste à `"`, `\`, `$` dans les paths.
- **Finding C — pipx stderr** : `2>/dev/null` supprimé. La logique amont (`python3 -c "import fastmcp"` ligne 56) garantit qu'on n'atteint `pipx install` que si fastmcp est absent — donc « already installed » ne se déclenche pas.

## Test plan

- [x] Finding A : review visuelle `<<'PYEOF'` quoted + `os.environ` ; vault paths avec `"` / `\` ne cassent plus les literals
- [x] Finding B : review visuelle whitelist 8 champs ; verdict_evidence et autres champs verbeux skippés
- [x] Finding C : `2>/dev/null` supprimé sur ligne 62
- [x] Finding D : `scan_domain(domain, limit=0)` par défaut retourne tout ; `limit=N` cap avec banner
- [x] `python3 -c "import ast; ast.parse(open('scripts/mcp-wiki.py').read())"` → exit 0 (syntaxe Python OK après 2 modifs)
- [ ] **Smoke test bout-en-bout** : MCP server disconnected dans cette session ; validation fonctionnelle après merge + redémarrage Claude Code

## Garde-fous anti-surcharge

- 0 nouvel agent / command / hook
- Delta cumulé : +27 / -13 lignes (3 fichiers)
- Budget global v1.1.0 : PR-A+B+C+D (~200) + PR-E (~15) ≈ **~215 lignes**

## Status

✅ Ready for review (post-`/review-pr` findings + scan_domain truncation fix)