### PR TITLE
fix(scan-raw): normaliser quotes YAML et apostrophes Unicode + corriger VAULT_ROOT post-refactor (#39)

### DIFF
--- a/.claude/rules/frontmatter.md
+++ b/.claude/rules/frontmatter.md
@@ -41,6 +41,10 @@ covered_paths:                               # optional: if the page synthesizes
   - "raw/<folder>/<file2>.md"
 ```
 
+### Hard rule `source_path` round-trip
+
+`source_path` **must round-trip byte-for-byte** to the on-disk filename. Do NOT normalise typographic characters (apostrophes `'` ↔ `’`, quotes, em/en dashes, etc.) when emitting `source_path`. `scripts/wiki-maint/scan-raw.sh` applies Unicode normalization symmetrically at match time (NFC + fold U+2019 → U+0027), but emitting a normalized `source_path` against a non-normalized filename creates ghost duplicate pages on every subsequent sweep.
+
 ### Hard rule `source_sha256`
 
 `source_sha256` must **always** be computed via `shasum -a 256 <file>` on the actual file at ingestion time. Never a textual placeholder (`see-raw-file`, the slug, a fake hex, `TODO`...). This rule applies without exception to every expert agent.

--- a/scripts/wiki-maint/scan-raw.sh
+++ b/scripts/wiki-maint/scan-raw.sh
@@ -65,6 +65,19 @@ _safe_key() {
   printf '%q' "$1"
 }
 
+# Normalise un chemin pour la comparaison : NFC unicode + repli des apostrophes
+# typographiques (U+2019 RIGHT SINGLE QUOTATION MARK → U+0027 APOSTROPHE).
+# Les autres caractères typographiques sont volontairement hors scope en v1.1.0.
+_normalize_path() {
+  python3 - <<'PY' "$1"
+import sys, unicodedata
+p = sys.argv[1]
+p = unicodedata.normalize("NFC", p)
+p = p.replace("’", "'")
+sys.stdout.write(p)
+PY
+}
+
 # --- Construction de l'index : raw_path → (slug, sha256) ---
 # Charge une fois tous les wiki/sources pour éviter O(N×M) grep
 
@@ -88,7 +101,7 @@ while IFS= read -r source_file; do
       val=$(echo "$line" | sed 's/^source_path:[[:space:]]*//' | sed 's/^"//; s/"$//')
       if [ -n "$val" ]; then
         # Scalaire
-        path_to_slug["$(_safe_key "$val")"]="$slug"
+        path_to_slug["$(_safe_key "$(_normalize_path "$val")")"]="$slug"
         indexed_paths+=("$val")
         [ -z "$first_sp" ] && first_sp="$val"
         in_sp=0
@@ -115,7 +128,7 @@ while IFS= read -r source_file; do
       fi
       item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | sed 's/^"//; s/"$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
       if [ -n "$item" ]; then
-        path_to_slug["$(_safe_key "$item")"]="$slug"
+        path_to_slug["$(_safe_key "$(_normalize_path "$item")")"]="$slug"
         indexed_paths+=("$item")
         [ $in_sp -eq 1 ] && [ -z "$first_sp" ] && first_sp="$item"
       fi
@@ -136,7 +149,7 @@ while IFS= read -r source_file; do
       fi
       item=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*//' | sed 's/^"//; s/"$//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
       if [ -n "$item" ]; then
-        path_to_slug["$(_safe_key "$item")"]="$slug"
+        path_to_slug["$(_safe_key "$(_normalize_path "$item")")"]="$slug"
         indexed_paths+=("$item")
       fi
     fi
@@ -146,7 +159,7 @@ while IFS= read -r source_file; do
   if [ -n "$first_sp" ]; then
     sha_line=$(grep "^source_sha256:" "$source_file" 2>/dev/null | head -1 | sed 's/^source_sha256:[[:space:]]*//; s/^"//; s/"$//' || true)
     if [ -n "$sha_line" ] && [[ "$sha_line" != -* ]]; then
-      path_to_sha["$(_safe_key "$first_sp")"]="$sha_line"
+      path_to_sha["$(_safe_key "$(_normalize_path "$first_sp")")"]="$sha_line"
     fi
   fi
 
@@ -161,11 +174,11 @@ declare -A meta_to_slug  # safe_key(raw/videos-meta/SLUG.meta.md) → slug via t
 
 for indexed_path in "${indexed_paths[@]}"; do
   [ -z "$indexed_path" ] && continue
-  ip_key=$(_safe_key "$indexed_path")
+  ip_key=$(_safe_key "$(_normalize_path "$indexed_path")")
 
   # Index des répertoires implicites (≥4 niveaux de profondeur requis)
   idir="${indexed_path%/*}/"
-  idir_key=$(_safe_key "$idir")
+  idir_key=$(_safe_key "$(_normalize_path "$idir")")
   depth=$(printf '%s' "$idir" | tr -cd '/' | wc -c | tr -d ' ')
   if [ "$depth" -ge 4 ] && [ -z "${dir_to_slug[$idir_key]+_}" ]; then
     dir_to_slug["$idir_key"]="${path_to_slug[$ip_key]}"
@@ -176,7 +189,7 @@ for indexed_path in "${indexed_paths[@]}"; do
     filename="${indexed_path##*/}"
     filename="${filename%.md}"
     meta_path="raw/videos-meta/${filename}.meta.md"
-    meta_key=$(_safe_key "$meta_path")
+    meta_key=$(_safe_key "$(_normalize_path "$meta_path")")
     [ -z "${meta_to_slug[$meta_key]+_}" ] && meta_to_slug["$meta_key"]="${path_to_slug[$ip_key]}"
   fi
 done
@@ -186,7 +199,7 @@ done
 for abs_path in "${files[@]}"; do
   # Chemin relatif depuis la racine du vault
   rel="${abs_path#$VAULT_ROOT/}"
-  rel_key=$(_safe_key "$rel")
+  rel_key=$(_safe_key "$(_normalize_path "$rel")")
 
   # 1. Match exact sur source_path ou covered_paths
   if [ -n "${path_to_slug[$rel_key]+_}" ]; then
@@ -210,7 +223,7 @@ for abs_path in "${files[@]}"; do
     parent=$(dirname "$parent")
     [ "$parent" = "." ] || [ "$parent" = "raw" ] || [ "$parent" = "" ] && break
     parent_slash="${parent}/"
-    parent_key=$(_safe_key "$parent_slash")
+    parent_key=$(_safe_key "$(_normalize_path "$parent_slash")")
     if [ -n "${path_to_slug[$parent_key]+_}" ]; then
       covered="${path_to_slug[$parent_key]}"
       break
@@ -224,7 +237,7 @@ for abs_path in "${files[@]}"; do
 
   # 3. Match implicite : même répertoire qu'un fichier déjà indexé (≥4 niveaux de profondeur)
   rel_dir="$(dirname "$rel")/"
-  rel_dir_key=$(_safe_key "$rel_dir")
+  rel_dir_key=$(_safe_key "$(_normalize_path "$rel_dir")")
   if [ -n "${dir_to_slug[$rel_dir_key]+_}" ]; then
     echo "SKIP     $rel  (covered-by-dir-implicit: ${dir_to_slug[$rel_dir_key]})"
     continue

--- a/scripts/wiki-maint/scan-raw.sh
+++ b/scripts/wiki-maint/scan-raw.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-VAULT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VAULT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WIKI_SOURCES="$VAULT_ROOT/wiki/sources"
 
 # --- Collecte des fichiers à analyser ---
@@ -144,7 +144,7 @@ while IFS= read -r source_file; do
 
   # `source_sha256_composite:` ignoré : non comparable au sha d'un fichier individuel.
   if [ -n "$first_sp" ]; then
-    sha_line=$(grep "^source_sha256:" "$source_file" 2>/dev/null | head -1 | sed 's/^source_sha256:[[:space:]]*//' || true)
+    sha_line=$(grep "^source_sha256:" "$source_file" 2>/dev/null | head -1 | sed 's/^source_sha256:[[:space:]]*//; s/^"//; s/"$//' || true)
     if [ -n "$sha_line" ] && [[ "$sha_line" != -* ]]; then
       path_to_sha["$(_safe_key "$first_sp")"]="$sha_line"
     fi


### PR DESCRIPTION
## Summary

Trois fixes dans `scripts/wiki-maint/scan-raw.sh` (chemin nouveau post-refactor #42), couvrant l'issue #39 et un bug introduit par le déplacement de PR #44.

### Commit 1 — `0eda1a7` : YAML quotes sur source_sha256 + VAULT_ROOT

- **Bug #39 partie 1** : `source_sha256: "X"` (quoted, convention) était comparé à `X` (depuis `sha256sum`, no quotes) → toute page suivant la convention reportée à tort `MODIFIED`. Fix : sed strip les guillemets surrounding, comme déjà fait pour `source_path`.
- **Bug bonus du refactor #42/PR #44** : après le déplacement `scripts/scan-raw.sh` → `scripts/wiki-maint/scan-raw.sh`, `VAULT_ROOT="$(dirname ..)"` résolvait à `scripts/` au lieu de la racine du vault → `WIKI_SOURCES` et `raw/` cherchaient au mauvais endroit. Fix : `..` → `../..` (un niveau de plus). **Sans ce fix, impossible de reproduire le bug #39 sur fixture** (le script ne trouvait aucune page wiki/sources).

### Commit 2 — `20cc936` : Unicode apostrophe normalization

- **Bug #39 partie 2** (commentaire de l'issue) : filename `it's` (U+2019) vs `source_path: "it's"` (U+0027, normalisé silencieusement par l'agent) → match byte-exact failed → faux `NEW`, risque de duplicate page.
- Fix : nouvelle fonction `_normalize_path()` (NFC + fold U+2019 → U+0027) appliquée **symétriquement** aux 10 callsites de `_safe_key` impliquant un chemin (build de l'index + lookup).

### Commit 3 — `4885fd7` : Règle frontmatter source_path round-trip

- Ajoute une règle dans `.claude/rules/frontmatter.md` : `source_path` doit round-tripper byte-for-byte au filename on-disk. Évite que les futurs agents ingest reproduisent la cause amont du bug Unicode.

## Test plan

Fixtures de vérification créées dans `/tmp/scan-raw-fixture-{quoted,unicode}/`.

- [x] Quoted-sha fixture : `MODIFIED` → `SKIP` après fix
- [x] Régression quoted : unquoted sha → toujours `SKIP`
- [x] Régression quoted : raw modifié → toujours `MODIFIED`
- [x] Unicode fixture (U+2019 file + U+0027 source_path) : `NEW` → `SKIP` après fix
- [x] Régression Unicode : U+2019 des deux côtés → `SKIP`
- [x] Régression Unicode : ASCII pur → `SKIP` (no-op)
- [x] Régression Unicode : vraiment nouveau file → `NEW`
- [ ] Sweep complet contre BoilingBrain post-merge : la liste de false MODIFIED/NEW doit se réduire significativement

## Files touched

- `scripts/wiki-maint/scan-raw.sh` (commits 1 + 2)
- `.claude/rules/frontmatter.md` (commit 3)

Closes #39