### PR TITLE
feat(mcp): refonte couche tiered-loading (scan_domain hiérarchique + 7 scan_<type> + search_wiki enrichi) (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
   - `/domain rename <old-slug> <new-slug>` — full vault scan via `scripts/wiki-maint/scan-domain-refs.sh`, bucketed presentation (canonical / frontmatter / wikilink / alias / composed / prose / log-tag / historical / numeric-drift), case-by-case validation for ambiguous buckets (composed slugs, prose words, wikilink aliases). Physical renames of `<slug>-expert.md`, `<slug>-expert.suggestions[.archive].md`, memory dir, and `wiki/domains/<slug>.md`.
   - `/domain remove <slug>` — `--archive` (default) strips the domain from active declarations while preserving historical traces in `wiki/log.md`, `wiki/decisions/`, `wiki/syntheses/`, `wiki/sources/`. `--purge` proposes the historical sweep case-by-case. `--include-historical` opt-in for archive mode. (#38)
 - **`scripts/wiki-maint/scan-domain-refs.sh`**: helper script (called by `/domain rename` and `/domain remove`) that scans the entire vault for a slug and emits a line-oriented report categorized in 9 buckets. Convention aligned with `scan-raw.sh` (machine-parseable, exit codes 0/1, env var `VAULT_PATH` for inter-vault testing). (#38)
+- **MCP tiered-loading refactor — 7 new tools**: `scan_concepts(domain, query, top)`, `scan_entities(...)`, `scan_decisions(...)`, `scan_syntheses(...)`, `scan_cheatsheets(...)`, `scan_diagrams(...)`, `scan_sources(...)`. Per-type drill-down inside a domain. Without `query`, return the top N pages by centrality (incoming wikilinks). With `query`, filter via case + separator-insensitive tokenisation and rank by centrality.
+- **`scripts/mcp/smoke_test.py`**: standalone harness that invokes every MCP tool against a real vault (`WIKI_PATH=…`), prints OK/FAIL against the v1.1.0 token gates, and exits non-zero on failure. Used as the gate before tagging v1.1.0.
 
 ### Added (ingest + agent surface)
 
@@ -53,6 +55,8 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`/update-vault` — slash-command slimmed to ~170 lines (from ~350)** by extracting two helper scripts: `scripts/wiki-maint/detect-vault-version.sh` (version detection + applied-migrations back-fill) and `scripts/wiki-maint/propagate-templates.sh` (file propagation with 3-way merge). The markdown command focuses on LLM-driven orchestration (AskUserQuestion, branching decisions, migration sub-workflows); the shell scripts carry their own documentation and `--help`.
 - **`.claude/commands/compress-bb.md`**: translated to EN (v1.0.3 alignment, no functional change).
 - **`scripts/mcp/mcp-wiki.py`**: `preview_page` outputs a whitelisted set of frontmatter fields (`type`, `domains`, `created`, `updated`, `summary_l0`, `sources`, `status`, `verdict`) instead of every field — controls verbosity with the new ADR L3 fields (review finding B).
+- **Breaking — `scan_domain` return format**: no longer dumps all pages of the domain. Returns a compact hierarchical view: the `wiki/domains/<domain>.md` hub `summary_l1`, page counts per type with explicit pointers to the new `scan_<type>` tools, and the top 10 pages by centrality. Estimated reduction: ~94% on a 388-page domain (measured against BoilingBrain `ia`, dropping from ~23k to ~900 tokens).
+- **Breaking — `search_wiki` return format**: replaced `<path>:<line>: <extract>` with an enriched line per result: `<path> (<type>) — <summary_l0> — wikilinks: [<slugs>]`. Matching is now tokenised (case + separator insensitive); ranking is by centrality (backlinks).
 
 ### Migration from v1.0.x
 

--- a/scripts/mcp/mcp-wiki.py
+++ b/scripts/mcp/mcp-wiki.py
@@ -259,6 +259,138 @@ def scan_domain(domain: str) -> str:
     return "\n".join(lines)
 
 
+def _scan_type_impl(domain: str, type_singular: str, type_plural: str, query: str, top: int) -> str:
+    """Shared implementation for scan_concepts, scan_entities, scan_decisions,
+    scan_syntheses, scan_cheatsheets, scan_diagrams. scan_sources wraps this
+    too but adds a refusal path for empty queries.
+    """
+    pages = []
+    for p in _domain_pages(domain):
+        try:
+            fm, body = _parse_front(p.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if str(fm.get("type", "")).strip().lower() != type_singular:
+            continue
+        pages.append((p, fm, body))
+
+    if not pages:
+        return f"Aucune page de type « {type_singular} » dans le domaine « {domain} »."
+
+    if query.strip():
+        tokens = _normalize_query(query)
+        scored = []
+        for p, fm, body in pages:
+            haystack_parts = [
+                str(fm.get("summary_l0", "")),
+                str(fm.get("summary_l1", "")),
+                p.stem,
+                body,
+            ]
+            haystack = _normalize_haystack(" ".join(haystack_parts))
+            if _all_tokens_present(tokens, haystack):
+                centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
+                scored.append((centrality, p, fm))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        kept = scored[:top]
+        if not kept:
+            return f"Aucune page de type « {type_singular} » dans « {domain} » ne matche « {query} »."
+    else:
+        ranked = []
+        for p, fm, _body in pages:
+            centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
+            ranked.append((centrality, p, fm))
+        ranked.sort(key=lambda x: x[0], reverse=True)
+        kept = ranked[:top]
+
+    header = (
+        f"# {type_plural} dans {domain} — top {len(kept)}"
+        + (f" pour « {query} »" if query.strip() else " par centralité")
+    )
+    lines = [header, ""]
+    for _c, p, fm in kept:
+        lines.append(_compact_l0(fm, p))
+    return "\n".join(lines)
+
+
+@mcp.tool(
+    description=(
+        "List concepts in a domain. Without query: top N by centrality (backlinks). "
+        "With query: only concepts whose title/body/summary contain all tokens "
+        "(case + separator insensitive), ranked by centrality. Use after scan_domain "
+        "to drill into the concept layer."
+    )
+)
+def scan_concepts(domain: str, query: str = "", top: int = 20) -> str:
+    return _scan_type_impl(domain, "concept", "Concepts", query, top)
+
+
+@mcp.tool(
+    description="List entities (people, tools, places, organisations) in a domain. Same semantics as scan_concepts."
+)
+def scan_entities(domain: str, query: str = "", top: int = 20) -> str:
+    return _scan_type_impl(domain, "entity", "Entities", query, top)
+
+
+@mcp.tool(
+    description="List decisions (ADRs, retained tradeoffs) in a domain. Same semantics as scan_concepts."
+)
+def scan_decisions(domain: str, query: str = "", top: int = 20) -> str:
+    return _scan_type_impl(domain, "decision", "Decisions", query, top)
+
+
+@mcp.tool(
+    description="List syntheses (cross-cutting summaries) in a domain. Same semantics as scan_concepts."
+)
+def scan_syntheses(domain: str, query: str = "", top: int = 20) -> str:
+    return _scan_type_impl(domain, "synthesis", "Syntheses", query, top)
+
+
+@mcp.tool(
+    description="List cheatsheets (quick-reference how-tos) in a domain. Same semantics as scan_concepts."
+)
+def scan_cheatsheets(domain: str, query: str = "", top: int = 20) -> str:
+    return _scan_type_impl(domain, "cheatsheet", "Cheatsheets", query, top)
+
+
+@mcp.tool(
+    description="List diagrams (visual artefacts) in a domain. Same semantics as scan_concepts."
+)
+def scan_diagrams(domain: str, query: str = "", top: int = 20) -> str:
+    return _scan_type_impl(domain, "diagram", "Diagrams", query, top)
+
+
+@mcp.tool(
+    description=(
+        "List source pages in a domain. UNLIKE scan_concepts/entities/etc., "
+        "scan_sources REQUIRES a non-empty query — sources are typically too "
+        "numerous to enumerate usefully without a target. With query: only "
+        "sources whose title/body/summary contain all tokens, ranked by centrality."
+    )
+)
+def scan_sources(domain: str, query: str = "", top: int = 20) -> str:
+    if not query.strip():
+        n_sources = sum(
+            1 for p in _domain_pages(domain)
+            if _safe_get_type(p) == "source"
+        )
+        return (
+            f"scan_sources(\"{domain}\") sans query retournerait {n_sources} sources, peu utile.\n"
+            f"Préciser une query : scan_sources(\"{domain}\", query=\"<topic>\").\n"
+            f"Pour explorer le domaine sans cible, préférer scan_domain(\"{domain}\") "
+            f"ou scan_concepts(\"{domain}\")."
+        )
+    return _scan_type_impl(domain, "source", "Sources", query, top)
+
+
+def _safe_get_type(p) -> str:
+    try:
+        fm, _ = _parse_front(p.read_text(encoding="utf-8"))
+        return str(fm.get("type", "")).strip().lower()
+    except Exception:
+        return ""
+
+
 @mcp.tool(
     description=(
         "Preview a wiki page: frontmatter fields + summary_l1 (2-5 sentence description). "

--- a/scripts/mcp/mcp-wiki.py
+++ b/scripts/mcp/mcp-wiki.py
@@ -70,48 +70,191 @@ def _domain_pages(domain: str) -> list[Path]:
     return matches
 
 
+_BACKLINK_CACHE: dict[str, int] | None = None
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]")
+
+
+def _build_backlink_index() -> dict[str, int]:
+    """Scan every wiki page once and count [[slug]] occurrences. Result is
+    cached in-process. Slug = page path relative to WIKI_DIR, without the .md
+    extension (e.g. 'concepts/model-context-protocol' for
+    wiki/concepts/model-context-protocol.md). Wikilinks may also use bare
+    slugs ('model-context-protocol') — those are counted under the bare-slug
+    bucket and added to the full-slug count by _compute_centrality.
+    """
+    counts: dict[str, int] = {}
+    for p in _all_wiki_pages():
+        try:
+            content = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        for m in _WIKILINK_RE.finditer(content):
+            target = m.group(1).strip()
+            counts[target] = counts.get(target, 0) + 1
+    return counts
+
+
+def _compute_centrality(page_path: str) -> int:
+    """Return the number of backlinks pointing to `page_path` (relative to
+    WIKI_PATH, e.g. 'wiki/concepts/foo.md'). Builds the backlink index lazily;
+    subsequent calls reuse the cache. To refresh, set the module-level
+    `_BACKLINK_CACHE = None` and call again.
+    """
+    global _BACKLINK_CACHE
+    if _BACKLINK_CACHE is None:
+        _BACKLINK_CACHE = _build_backlink_index()
+    if not page_path.startswith("wiki/"):
+        page_path = "wiki/" + page_path
+    rel = page_path[len("wiki/"):]
+    if rel.endswith(".md"):
+        rel = rel[:-3]
+    full = _BACKLINK_CACHE.get(rel, 0)
+    bare = _BACKLINK_CACHE.get(rel.rsplit("/", 1)[-1], 0) if "/" in rel else 0
+    return full + bare
+
+
+def _normalize_query(q: str) -> list[str]:
+    """Lowercase, NFC-normalise, split on whitespace and hyphens, drop empties.
+    Used by the matching layer to make 'two-words', 'two words', and 'twowords'
+    queries behave consistently against the page content.
+    """
+    import unicodedata
+    q = unicodedata.normalize("NFC", q).lower()
+    tokens: list[str] = []
+    for chunk in q.replace("-", " ").split():
+        if chunk:
+            tokens.append(chunk)
+    return tokens
+
+
+def _normalize_haystack(text: str) -> str:
+    """Counterpart of _normalize_query for the searched text. Lowercase, NFC,
+    collapse hyphens and whitespace to single spaces.
+    """
+    import unicodedata
+    text = unicodedata.normalize("NFC", text).lower()
+    text = text.replace("-", " ")
+    text = " ".join(text.split())
+    return text
+
+
+def _all_tokens_present(tokens: list[str], haystack: str) -> bool:
+    """True iff every token from _normalize_query is a substring of the
+    pre-normalised haystack.
+    """
+    return all(t in haystack for t in tokens)
+
+
+def _compact_l0(fm: dict, p) -> str:
+    """Compact one-line representation used by scan_<type> outputs.
+    Format: '- <slug> — <summary_l0>'. The slug is the page filename
+    without the .md extension; the type is left implicit (the caller
+    knows it from its own tool name).
+    """
+    l0 = fm.get("summary_l0", "—") or "—"
+    slug = p.stem
+    return f"- {slug} — {l0}"
+
+
+_TYPES_FOR_SCAN_TOOLS = (
+    "concepts",
+    "sources",
+    "syntheses",
+    "entities",
+    "cheatsheets",
+    "decisions",
+    "diagrams",
+)
+
+# Map from the directory-style plural name used in the scan_<type> tool to the
+# singular value stored in the `type:` frontmatter field.
+_TYPE_TOOL_TO_FRONTMATTER = {
+    "concepts": "concept",
+    "sources": "source",
+    "syntheses": "synthesis",
+    "entities": "entity",
+    "cheatsheets": "cheatsheet",
+    "decisions": "decision",
+    "diagrams": "diagram",
+}
+
+
 @mcp.tool(
     description=(
         "Use FIRST before answering any question about the user's knowledge domains. "
-        "Lists wiki pages for a given domain with their summary_l0 (one-line synopsis). "
-        "domain: one of poker, ia, factory, metier, tech, astro. "
-        "Returns ALL pages by default (sorted by last updated). "
-        "Pass limit=N to cap output (e.g. on very large domains > 5000 pages). "
-        "Use preview_page or read_page for details."
+        "Returns a compact hierarchical overview of a domain: the hub page (summary_l1), "
+        "page counts by type, and the top 10 pages by centrality (incoming wikilinks). "
+        "Use scan_concepts / scan_entities / scan_<type>(domain, query=...) to drill down. "
+        "domain: one of poker, ia, factory, vie-professionnelle, mental, tech, meta "
+        "(or your vault's domains)."
     )
 )
-def scan_domain(domain: str, limit: int = 0) -> str:
+def scan_domain(domain: str) -> str:
     pages = _domain_pages(domain)
     if not pages:
         return f"Aucune page trouvée pour le domaine « {domain} »."
 
-    # Sort by updated desc, then created desc
-    def sort_key(p: Path):
+    # Hub page lookup: wiki/domains/<domain>.md with type: domain
+    hub_path = WIKI_DIR / "domains" / f"{domain}.md"
+    hub_l1 = ""
+    if hub_path.exists():
+        try:
+            hub_fm, _ = _parse_front(hub_path.read_text(encoding="utf-8"))
+            hub_l1 = hub_fm.get("summary_l1", "") or ""
+        except Exception:
+            hub_l1 = ""
+
+    # Counts by type (frontmatter `type:` value, lowercased and trimmed)
+    counts: dict[str, int] = {}
+    for p in pages:
         try:
             fm, _ = _parse_front(p.read_text(encoding="utf-8"))
-            return (str(fm.get("updated", "")), str(fm.get("created", "")))
+            t = str(fm.get("type", "")).strip().lower()
+            counts[t] = counts.get(t, 0) + 1
         except Exception:
-            return ("", "")
+            continue
 
-    pages.sort(key=sort_key, reverse=True)
-    total = len(pages)
-    if limit > 0:
-        pages = pages[:limit]
-
-    if limit > 0 and total > limit:
-        lines = [f"# Domaine : {domain} ({len(pages)} / {total} pages, capped at limit={limit})\n"]
-    else:
-        lines = [f"# Domaine : {domain} ({len(pages)} pages)\n"]
+    # Top 10 pages by centrality (backlinks)
+    ranked: list[tuple[int, Path, dict]] = []
     for p in pages:
         try:
             fm, _ = _parse_front(p.read_text(encoding="utf-8"))
         except Exception:
             fm = {}
         rel = str(p.relative_to(WIKI_PATH))
-        l0 = fm.get("summary_l0", "—")
-        page_type = fm.get("type", "")
-        updated = fm.get("updated", fm.get("created", ""))
-        lines.append(f"- [{rel}] ({page_type}, {updated}) — {l0}")
+        c = _compute_centrality(rel)
+        ranked.append((c, p, fm))
+    ranked.sort(key=lambda x: x[0], reverse=True)
+    top = ranked[:10]
+
+    # Assemble the response
+    lines = [f"# Domaine {domain} ({len(pages)} pages)\n"]
+    if hub_l1:
+        lines.append("## Hub\n")
+        lines.append(hub_l1.strip())
+        lines.append("")
+
+    lines.append("## Structure")
+    type_to_tool = {v: k for k, v in _TYPE_TOOL_TO_FRONTMATTER.items()}
+    sorted_counts = sorted(counts.items(), key=lambda kv: -kv[1])
+    for t, n in sorted_counts:
+        tool = type_to_tool.get(t)
+        if tool == "sources":
+            hint = f'scan_sources("{domain}", query=...)  [query required]'
+        elif tool:
+            hint = f'scan_{tool}("{domain}")'
+        else:
+            hint = "(no dedicated scan tool for this type)"
+        lines.append(f"- {t}: {n} → {hint}")
+    lines.append("")
+
+    lines.append("## Top 10 pages centrales (par backlinks)")
+    for c, p, fm in top:
+        slug = p.stem
+        rel_dir = str(p.parent.relative_to(WIKI_DIR))
+        t = fm.get("type", "")
+        l0 = fm.get("summary_l0", "—") or "—"
+        lines.append(f"- {rel_dir}/{slug} ({t}, {c} backlinks) — {l0}")
 
     return "\n".join(lines)
 

--- a/scripts/mcp/mcp-wiki.py
+++ b/scripts/mcp/mcp-wiki.py
@@ -473,7 +473,7 @@ def _outgoing_wikilinks(body: str, limit: int = 10) -> list[str]:
         "matches 'two-words' and 'twowords'). Results are ranked by centrality."
     )
 )
-def search_wiki(query: str, limit: int = 20) -> str:
+def search_wiki(query: str, limit: int = 10) -> str:
     tokens = _normalize_query(query)
     if not tokens:
         return "Requête vide."
@@ -503,7 +503,7 @@ def search_wiki(query: str, limit: int = 20) -> str:
         rel = str(p.relative_to(WIKI_PATH))
         t = fm.get("type", "")
         l0 = fm.get("summary_l0", "—") or "—"
-        wikilinks = _outgoing_wikilinks(body, limit=10)
+        wikilinks = _outgoing_wikilinks(body, limit=3)
         wikilinks_str = ", ".join(wikilinks) if wikilinks else "—"
         lines.append(f"- {rel} ({t}) — {l0} — wikilinks: [{wikilinks_str}]")
     return "\n".join(lines)

--- a/scripts/mcp/mcp-wiki.py
+++ b/scripts/mcp/mcp-wiki.py
@@ -445,34 +445,68 @@ def read_page(page_path: str) -> str:
         return f"Erreur de lecture : {e}"
 
 
+_OUTGOING_WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]")
+
+
+def _outgoing_wikilinks(body: str, limit: int = 10) -> list[str]:
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for m in _OUTGOING_WIKILINK_RE.finditer(body):
+        slug = m.group(1).strip()
+        if slug in seen_set:
+            continue
+        seen_set.add(slug)
+        seen.append(slug)
+        if len(seen) >= limit:
+            break
+    return seen
+
+
 @mcp.tool(
     description=(
-        "Full-text search across all wiki pages. "
-        "Returns matching pages with filename, type, and the matching line. "
-        "query: search term (case-insensitive). "
-        "limit: max results (default 20)."
+        "Full-text tokenised search across all wiki pages. Cross-type, "
+        "cross-domain. Returns matching pages with path, type, summary_l0, "
+        "and up to 10 outgoing wikilinks for quick navigation. Use this for "
+        "natural-language queries that are not domain-scoped; use "
+        "scan_<type>(domain, query=...) for domain-scoped drill-downs. "
+        "Query is tokenised (case + separator insensitive: 'two words' "
+        "matches 'two-words' and 'twowords'). Results are ranked by centrality."
     )
 )
 def search_wiki(query: str, limit: int = 20) -> str:
-    if not query.strip():
+    tokens = _normalize_query(query)
+    if not tokens:
         return "Requête vide."
-    pattern = re.compile(re.escape(query), re.IGNORECASE)
-    results = []
+    scored: list[tuple[int, Path, dict, str]] = []
     for p in _all_wiki_pages():
         try:
             content = p.read_text(encoding="utf-8")
         except Exception:
             continue
-        for i, line in enumerate(content.splitlines(), 1):
-            if pattern.search(line):
-                rel = str(p.relative_to(WIKI_PATH))
-                results.append(f"{rel}:{i}: {line.strip()}")
-                break  # one match per file
-        if len(results) >= limit:
-            break
-    if not results:
+        fm, body = _parse_front(content)
+        haystack_parts = [
+            str(fm.get("summary_l0", "")),
+            str(fm.get("summary_l1", "")),
+            p.stem,
+            body,
+        ]
+        haystack = _normalize_haystack(" ".join(haystack_parts))
+        if _all_tokens_present(tokens, haystack):
+            centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
+            scored.append((centrality, p, fm, body))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    kept = scored[:limit]
+    if not kept:
         return f"Aucun résultat pour « {query} »."
-    return f"# Résultats pour « {query} » ({len(results)})\n\n" + "\n".join(results)
+    lines = [f"# Résultats pour « {query} » ({len(kept)})", ""]
+    for _c, p, fm, body in kept:
+        rel = str(p.relative_to(WIKI_PATH))
+        t = fm.get("type", "")
+        l0 = fm.get("summary_l0", "—") or "—"
+        wikilinks = _outgoing_wikilinks(body, limit=10)
+        wikilinks_str = ", ".join(wikilinks) if wikilinks else "—"
+        lines.append(f"- {rel} ({t}) — {l0} — wikilinks: [{wikilinks_str}]")
+    return "\n".join(lines)
 
 
 @mcp.tool(

--- a/scripts/mcp/mcp-wiki.py
+++ b/scripts/mcp/mcp-wiki.py
@@ -17,6 +17,7 @@ Usage:
 import os
 import re
 import json
+import unicodedata
 from pathlib import Path
 from typing import Optional
 
@@ -118,7 +119,6 @@ def _normalize_query(q: str) -> list[str]:
     Used by the matching layer to make 'two-words', 'two words', and 'twowords'
     queries behave consistently against the page content.
     """
-    import unicodedata
     q = unicodedata.normalize("NFC", q).lower()
     tokens: list[str] = []
     for chunk in q.replace("-", " ").split():
@@ -131,7 +131,6 @@ def _normalize_haystack(text: str) -> str:
     """Counterpart of _normalize_query for the searched text. Lowercase, NFC,
     collapse hyphens and whitespace to single spaces.
     """
-    import unicodedata
     text = unicodedata.normalize("NFC", text).lower()
     text = text.replace("-", " ")
     text = " ".join(text.split())
@@ -445,13 +444,10 @@ def read_page(page_path: str) -> str:
         return f"Erreur de lecture : {e}"
 
 
-_OUTGOING_WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]")
-
-
 def _outgoing_wikilinks(body: str, limit: int = 10) -> list[str]:
     seen: list[str] = []
     seen_set: set[str] = set()
-    for m in _OUTGOING_WIKILINK_RE.finditer(body):
+    for m in _WIKILINK_RE.finditer(body):
         slug = m.group(1).strip()
         if slug in seen_set:
             continue

--- a/scripts/mcp/smoke_test.py
+++ b/scripts/mcp/smoke_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Smoke test for the MCP server tools against a real vault.
+
+Usage:
+  WIKI_PATH=/path/to/vault python3 scripts/mcp/smoke_test.py [domain]
+
+Loads the MCP module (without starting the server), invokes each tool with a
+canonical input, prints the result length in characters and an approximate
+token count, and exits non-zero if any output exceeds the Phase 5 gate limits.
+
+Default domain: 'ia' (matches the BoilingBrain reference). Override via argv.
+"""
+import sys
+import importlib.util
+import pathlib
+
+DEFAULT_DOMAIN = sys.argv[1] if len(sys.argv) > 1 else "ia"
+
+spec = importlib.util.spec_from_file_location(
+    "mcp_wiki",
+    str(pathlib.Path(__file__).parent / "mcp-wiki.py"),
+)
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+
+GATES = [
+    ("scan_domain", lambda: m.scan_domain(DEFAULT_DOMAIN), 1500),
+    ("scan_concepts (query)", lambda: m.scan_concepts(DEFAULT_DOMAIN, query="alignement"), 800),
+    ("scan_concepts (no query)", lambda: m.scan_concepts(DEFAULT_DOMAIN), 800),
+    ("scan_entities (no query)", lambda: m.scan_entities(DEFAULT_DOMAIN), 800),
+    ("scan_decisions (no query)", lambda: m.scan_decisions(DEFAULT_DOMAIN), 800),
+    ("scan_sources (no query, must refuse)", lambda: m.scan_sources(DEFAULT_DOMAIN), 200),
+    ("scan_sources (query)", lambda: m.scan_sources(DEFAULT_DOMAIN, query="alignement"), 800),
+    ("search_wiki (mcp)", lambda: m.search_wiki("model context protocol"), 800),
+]
+
+failures = []
+for name, fn, max_tokens in GATES:
+    out = fn()
+    chars = len(out)
+    tokens = chars // 4
+    status = "OK" if tokens <= max_tokens else "FAIL"
+    print(f"[{status}] {name}: {chars} chars (~{tokens} tokens, cap {max_tokens})")
+    if status == "FAIL":
+        failures.append((name, tokens, max_tokens))
+
+print()
+if failures:
+    print(f"{len(failures)} gate(s) failed:")
+    for name, t, cap in failures:
+        print(f"  - {name}: {t} > {cap}")
+    sys.exit(1)
+print("All gates passed.")

--- a/scripts/mcp/smoke_test.py
+++ b/scripts/mcp/smoke_test.py
@@ -10,11 +10,16 @@ token count, and exits non-zero if any output exceeds the Phase 5 gate limits.
 
 Default domain: 'ia' (matches the BoilingBrain reference). Override via argv.
 """
+import os
 import sys
 import importlib.util
 import pathlib
 
 DEFAULT_DOMAIN = sys.argv[1] if len(sys.argv) > 1 else "ia"
+
+if not os.environ.get("WIKI_PATH"):
+    print("Error: WIKI_PATH env var required. Usage: WIKI_PATH=/path/to/vault python3 smoke_test.py [domain]", file=sys.stderr)
+    sys.exit(1)
 
 spec = importlib.util.spec_from_file_location(
     "mcp_wiki",


### PR DESCRIPTION
## Summary

Refonte de la couche tiered-loading du serveur MCP `boiling-brain-wiki` pour traiter le bottleneck token mesuré sur BoilingBrain (`scan_domain('ia')` actuel ~23k tokens sur 385 pages).

### Nouveau pattern d'usage

```
scan_domain(domain)                    ← orientation (~860 tokens : hub + counts + top centralité)
  ↓
scan_<type>(domain, query="", top=20)  ← drill-down par type (~700 tokens)
  ↓
preview_page(path) → read_page(path)   ← tiered loading classique L1 → L2
```

Et en cross-type / cross-domain :
```
search_wiki(query)                     ← natural-language query, ~670 tokens, format enrichi
```

### Détail des commits

1. `f585cc3` — **scan_domain redesigné** : hub `summary_l1` + counts par type + top 10 centralité. Breaking sur le format de retour. Helpers introduits : `_compute_centrality` (lazy backlink index), `_normalize_query/_haystack/_all_tokens_present`, `_compact_l0`.
2. `fea97b0` — **7 nouveaux scan_<type>** : `concepts, entities, decisions, syntheses, cheatsheets, diagrams, sources`. Signature uniforme `(domain, query='', top=20)`. Logique partagée via `_scan_type_impl`. `scan_sources` REFUSE si query vide (sources rarement utiles sans cible).
3. `ee0d4ba` — **search_wiki refactor** : matching tokenisé case + séparateur insensible. Format de retour enrichi (path, type, L0, wikilinks sortants). Tri par centralité. Breaking sur le format. `scripts/mcp/smoke_test.py` ajouté (harness standalone pour valider tous les gates contre un vault réel).
4. `303bb8d` — **CHANGELOG** : breaking changes documentés.
5. `5e3a6ee` — **Fix gates** : search_wiki defaults rabaissés (limit 20→10, wikilinks 10→3) après smoke test post-impl. Tous les gates passent.

### Pas d'aliases

Retiré du scope (décision brainstorm + patch). Le matching repose uniquement sur centralité (backlinks) + grep tokenisé/normalisé.

## Validation post-impl (smoke_test.py contre BoilingBrain)

```
[OK] scan_domain: 3453 chars (~863 tokens, cap 1500)
[OK] scan_concepts (query): 296 chars (~74 tokens, cap 800)
[OK] scan_concepts (no query): 3145 chars (~786 tokens, cap 800)
[OK] scan_entities (no query): 2948 chars (~737 tokens, cap 800)
[OK] scan_decisions (no query): 2883 chars (~720 tokens, cap 800)
[OK] scan_sources (no query, must refuse): 212 chars (~53 tokens, cap 200)
[OK] scan_sources (query): 541 chars (~135 tokens, cap 800)
[OK] search_wiki (mcp): 2684 chars (~671 tokens, cap 800)
All gates passed.
```

`scan_domain('ia')` passe de ~23k tokens à 863 tokens — **réduction ~96%**.

## Test plan

- [x] Smoke test (`scripts/mcp/smoke_test.py ia`) → all gates passed contre BoilingBrain
- [x] `python3 -m py_compile scripts/mcp/mcp-wiki.py` → OK
- [ ] Restart Claude Code après merge → vérifier que les 7 nouveaux outils sont visibles via `claude mcp list` + `/mcp`
- [ ] Validation Phase 5 du plan v1.1.0 (gates pré-tag finaux)

Closes #41