### PR TITLE
feat(ci): revamp CI pour vaults vivants — Prettier + markdownlint sémantique + wiki-integrity (v1.1.0)

### DIFF
--- a/.claude/agent-output-contract.md
+++ b/.claude/agent-output-contract.md
@@ -6,6 +6,7 @@ Every expert agent invoked by `/ingest` returns **three parsable markdown blocks
 
 ```markdown
 ## Ingest summary
+
 - Pages created: [[wiki/sources/...]], [[wiki/concepts/...]], …
 - Pages updated: …
 - Deliverables produced: …
@@ -13,12 +14,14 @@ Every expert agent invoked by `/ingest` returns **three parsable markdown blocks
 - Cross-domain: […]
 
 ## Radar items
+
 - Specific observations attached to a named source / timestamp / project.
 - Missing facts ("what is the exact value of X?").
 - "If 2nd occurrence of X, create concept Y" (threshold not met).
 - Content gaps to fill via a future ingest.
 
 ## Evolution suggestions
+
 - Concept broadened to the domain (derived from a specific observation).
 - Behavioral rule applicable to any future ingest **independent of the content**.
 - Structural blind spot of the prompt.
@@ -32,7 +35,7 @@ For every specific observation, apply the **double jump**:
 1. **Broadened concept?** → `## Evolution suggestions` (transverse rule)
 2. **Specific detail not covered by this ingest?** → `## Radar items` (to investigate)
 
-**Decisive test** for `Evolution suggestions`: *"Would this rule still hold if the source was about another actor in the domain?"* If no → not transverse → `Radar items`.
+**Decisive test** for `Evolution suggestions`: _"Would this rule still hold if the source was about another actor in the domain?"_ If no → not transverse → `Radar items`.
 
 ## Examples
 

--- a/.claude/commands/compress-bb.md
+++ b/.claude/commands/compress-bb.md
@@ -103,15 +103,7 @@ After successful persistence (either path), display:
 - A reminder: the file will be proposed for ingestion at the next session start (via the SessionStart hook).
 - The manual-ingest shortcut: `/ingest raw/notes/sessions/YYYY-MM-DD-<slug>.md`.
 
-## Final step — normalise markdown
-
-After all pages are written/updated, format the produced markdown so it stays
-consistent and the CI `format-check` job passes:
-
-```bash
-npx -y prettier --write "raw/notes/sessions/**/*.md"
-```
-
-> Note: `compress-bb` writes into `raw/`, which Prettier ignores by default via
-> `.prettierignore`. Pass the path explicitly (Prettier honours explicit args
-> over ignore patterns) so the session note is normalised before ingest.
+> Note: `/compress-bb` writes only into `raw/notes/sessions/`, which is gitignored
+> and never linted by CI. No formatting step is needed here — the session note is
+> normalised later, when `/ingest` turns it into `wiki/` pages (which `/ingest`
+> formats via `scripts/wiki-maint/format-md.py`).

--- a/.claude/commands/compress-bb.md
+++ b/.claude/commands/compress-bb.md
@@ -13,11 +13,11 @@ Use this workflow at the end of a substantive work session: analysis, decisions,
 
 If the session already produced a substantive `raw/notes/<topic>.md`, don't duplicate the content into a session journal.
 
-| Situation | Session journal | `.pending-ingest` |
-|-----------|-----------------|-------------------|
-| Existing note covers everything | skip | `grep -qFx <note> \|\| echo <note> >> .pending-ingest` |
-| Note + valuable uncaptured meta | 3-5 line pointer to the note | append the pointer (normal flow) |
-| No substantive note | normal flow (steps below) | normal flow |
+| Situation                       | Session journal              | `.pending-ingest`                                      |
+| ------------------------------- | ---------------------------- | ------------------------------------------------------ |
+| Existing note covers everything | skip                         | `grep -qFx <note> \|\| echo <note> >> .pending-ingest` |
+| Note + valuable uncaptured meta | 3-5 line pointer to the note | append the pointer (normal flow)                       |
+| No substantive note             | normal flow (steps below)    | normal flow                                            |
 
 The session journal is reserved for meta that would be lost otherwise: scope pivots, tooling friction, verbal decision reasoning. `cache/.session-pending` is orthogonal (SESSION START signal, deleted right after the proposal).
 
@@ -43,18 +43,23 @@ themes: [list of themes covered]
 # Session — <slug> (YYYY-MM-DD)
 
 ## Context
+
 <What was ongoing before the session: project state, starting goal.>
 
 ## What was done
+
 <List of concrete actions: files created/modified, decisions made, problems solved.>
 
 ## Learnings & insights
+
 <What emerged from the session: new understandings, observed patterns, surprises.>
 
 ## Open questions
+
 <What remains unclear or to resolve in the next session.>
 
 ## Next steps
+
 <Concrete actions identified for follow-up.>
 ```
 
@@ -93,6 +98,20 @@ Followed by a fenced code block containing the journal content (the YAML-frontma
 ### 4. Confirm to the user
 
 After successful persistence (either path), display:
+
 - The path created: `raw/notes/sessions/YYYY-MM-DD-<slug>.md`.
 - A reminder: the file will be proposed for ingestion at the next session start (via the SessionStart hook).
 - The manual-ingest shortcut: `/ingest raw/notes/sessions/YYYY-MM-DD-<slug>.md`.
+
+## Final step — normalise markdown
+
+After all pages are written/updated, format the produced markdown so it stays
+consistent and the CI `format-check` job passes:
+
+```bash
+npx -y prettier --write "raw/notes/sessions/**/*.md"
+```
+
+> Note: `compress-bb` writes into `raw/`, which Prettier ignores by default via
+> `.prettierignore`. Pass the path explicitly (Prettier honours explicit args
+> over ignore patterns) so the session note is normalised before ingest.

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -32,6 +32,7 @@ Extract `<owner/repo>` from the remote URL (parse `https://github.com/<owner>/<r
 ## 2. Issue type determination
 
 Parse `$ARGUMENTS`:
+
 - First token = type, among `bug`, `enhancement` (alias `feature`), `docs`, `question`.
 - Rest = optional short description to pre-fill the title.
 
@@ -39,17 +40,31 @@ If type missing or invalid → `AskUserQuestion`:
 
 ```json
 {
-  "questions": [{
-    "question": "Which issue type do you want to create?",
-    "header": "Type",
-    "multiSelect": false,
-    "options": [
-      {"label": "bug", "description": "Something doesn't work as expected (sections: Context, Reproduction, Proposed fix, Test plan, Impact)"},
-      {"label": "enhancement", "description": "Improvement or new feature (sections: Problem, Proposal, Alternatives, Out-of-scope, Done criteria)"},
-      {"label": "docs", "description": "Gap or imprecision in template docs (sections: Section concerned, Gap observed, Suggestion)"},
-      {"label": "question", "description": "Usage or design question (sections: Context, Question, What was already tried)"}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Which issue type do you want to create?",
+      "header": "Type",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "bug",
+          "description": "Something doesn't work as expected (sections: Context, Reproduction, Proposed fix, Test plan, Impact)"
+        },
+        {
+          "label": "enhancement",
+          "description": "Improvement or new feature (sections: Problem, Proposal, Alternatives, Out-of-scope, Done criteria)"
+        },
+        {
+          "label": "docs",
+          "description": "Gap or imprecision in template docs (sections: Section concerned, Gap observed, Suggestion)"
+        },
+        {
+          "label": "question",
+          "description": "Usage or design question (sections: Context, Question, What was already tried)"
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -64,6 +79,7 @@ If the label doesn't exist, create the issue without label (signal in the previe
 ## 3. Context collection
 
 Read the current conversation to identify the issue subject:
+
 - Which file / behavior / scenario is at stake?
 - Which observed-vs-expected error (for bug) / which gap (for enhancement / docs) / which point of confusion (for question)?
 - Are there relevant code excerpts, error traces, or commands?
@@ -75,6 +91,7 @@ If the description from `$ARGUMENTS` is provided, use it as a **candidate title*
 ### Structure by type
 
 **bug**:
+
 ```markdown
 ## Context
 
@@ -99,6 +116,7 @@ If the description from `$ARGUMENTS` is provided, use it as a **candidate title*
 ```
 
 **enhancement**:
+
 ```markdown
 ## Problem
 
@@ -123,6 +141,7 @@ If the description from `$ARGUMENTS` is provided, use it as a **candidate title*
 ```
 
 **docs**:
+
 ```markdown
 ## Section concerned
 
@@ -138,6 +157,7 @@ If the description from `$ARGUMENTS` is provided, use it as a **candidate title*
 ```
 
 **question**:
+
 ```markdown
 ## Context
 
@@ -161,6 +181,7 @@ Apply the rules of `.claude/rules/sanitization-issues.md` to the title **and** b
 - **Anonymization of concrete cases**: rephrase "18 BB pages had X" as "N pages affected (figure measured on the BoilingBrain reference vault)" or "Some vault pages had X".
 
 Build a **sanitization report** with:
+
 - List of silent transformations applied (can be copied for audit).
 - List of flagged elements awaiting user confirmation.
 
@@ -195,16 +216,24 @@ Then `AskUserQuestion`:
 
 ```json
 {
-  "questions": [{
-    "question": "What do you want to do with this draft?",
-    "header": "Issue",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Create the issue", "description": "Creates the issue via gh issue create. Will return the URL."},
-      {"label": "✏️ Edit manually", "description": "Doesn't create anything. Shows the draft ready to copy-paste into the GitHub UI."},
-      {"label": "❌ Cancel", "description": "Aborts without creating anything."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "What do you want to do with this draft?",
+      "header": "Issue",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Create the issue",
+          "description": "Creates the issue via gh issue create. Will return the URL."
+        },
+        {
+          "label": "✏️ Edit manually",
+          "description": "Doesn't create anything. Shows the draft ready to copy-paste into the GitHub UI."
+        },
+        { "label": "❌ Cancel", "description": "Aborts without creating anything." }
+      ]
+    }
+  ]
 }
 ```
 
@@ -226,15 +255,23 @@ After successful creation, propose via `AskUserQuestion`:
 
 ```json
 {
-  "questions": [{
-    "question": "Add a tracker in wiki/radar.md?",
-    "header": "Radar",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Yes, track in the radar", "description": "Adds an entry `- [ ] **[Template · YYYY-MM-DD]** <short description>. → <URL>` in wiki/radar.md \"To watch\" category"},
-      {"label": "❌ No, no local follow-up", "description": "The issue lives its life on GitHub only"}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Add a tracker in wiki/radar.md?",
+      "header": "Radar",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Yes, track in the radar",
+          "description": "Adds an entry `- [ ] **[Template · YYYY-MM-DD]** <short description>. → <URL>` in wiki/radar.md \"To watch\" category"
+        },
+        {
+          "label": "❌ No, no local follow-up",
+          "description": "The issue lives its life on GitHub only"
+        }
+      ]
+    }
+  ]
 }
 ```
 

--- a/.claude/commands/domain.md
+++ b/.claude/commands/domain.md
@@ -73,41 +73,56 @@ Dispatch on the first word of `$ARGUMENTS`:
 
 3. **Per-bucket protocol**:
 
-   | Bucket | What | Pattern | Action |
-   |---|---|---|---|
-   | CANONICAL | Slug in the 5 active declarations | P-all | Substitute |
-   | FRONTMATTER | `domains:` field across `wiki/**/*.md` | P-all | Substitute |
-   | WIKILINK | `[[domains/<old>]]` no alias | P-all | Substitute |
-   | ALIAS | `[[domains/<old>\|Label]]` | P-1by1 | Dialog A |
-   | COMPOSED | Other kebab slugs containing `<old>` | P-1by1 | Dialog B |
-   | PROSE | Slug word in body. If >30 hits, propose initial P-none group "keep all, uncheck to rename" | P-1by1 | Dialog C |
-   | LOGTAG | Tagging patterns in `wiki/log.md` | P-none | Warn: rewriting a log tag = falsifying history |
-   | HIST | Refs in log / decisions / syntheses / sources | Skip default | `--include-historical` → P-none by sub-bucket |
-   | DRIFT | Numeric counts in prose (`N domains`, `N expert agents`) | — | Final warning, no auto-fix |
+   | Bucket      | What                                                                                       | Pattern      | Action                                         |
+   | ----------- | ------------------------------------------------------------------------------------------ | ------------ | ---------------------------------------------- |
+   | CANONICAL   | Slug in the 5 active declarations                                                          | P-all        | Substitute                                     |
+   | FRONTMATTER | `domains:` field across `wiki/**/*.md`                                                     | P-all        | Substitute                                     |
+   | WIKILINK    | `[[domains/<old>]]` no alias                                                               | P-all        | Substitute                                     |
+   | ALIAS       | `[[domains/<old>\|Label]]`                                                                 | P-1by1       | Dialog A                                       |
+   | COMPOSED    | Other kebab slugs containing `<old>`                                                       | P-1by1       | Dialog B                                       |
+   | PROSE       | Slug word in body. If >30 hits, propose initial P-none group "keep all, uncheck to rename" | P-1by1       | Dialog C                                       |
+   | LOGTAG      | Tagging patterns in `wiki/log.md`                                                          | P-none       | Warn: rewriting a log tag = falsifying history |
+   | HIST        | Refs in log / decisions / syntheses / sources                                              | Skip default | `--include-historical` → P-none by sub-bucket  |
+   | DRIFT       | Numeric counts in prose (`N domains`, `N expert agents`)                                   | —            | Final warning, no auto-fix                     |
 
    **Dialog A — ALIAS**:
+
    ```json
-   {"question": "Alias at <path>:<line> — '[[domains/<old>|<Label>]]'. Action?",
-    "options": [
-      {"label": "Rename slug + keep label", "description": "[[domains/<new>|<Label>]]"},
-      {"label": "Rename slug + sync label", "description": "[[domains/<new>|<NewLabel>]] (NewLabel derived: capitalize, hyphens → spaces; user-overridable via Other)"},
-      {"label": "Leave as-is", "description": "Skip this occurrence"}]}
+   {
+     "question": "Alias at <path>:<line> — '[[domains/<old>|<Label>]]'. Action?",
+     "options": [
+       { "label": "Rename slug + keep label", "description": "[[domains/<new>|<Label>]]" },
+       {
+         "label": "Rename slug + sync label",
+         "description": "[[domains/<new>|<NewLabel>]] (NewLabel derived: capitalize, hyphens → spaces; user-overridable via Other)"
+       },
+       { "label": "Leave as-is", "description": "Skip this occurrence" }
+     ]
+   }
    ```
 
    **Dialog B — COMPOSED**:
+
    ```json
-   {"question": "Composed slug '<composed>' at <path>:<line>. Rename?",
-    "options": [
-      {"label": "Leave as-is", "description": "Separate concept (Recommended)"},
-      {"label": "Rename", "description": "<composed> → <new-composed> everywhere"}]}
+   {
+     "question": "Composed slug '<composed>' at <path>:<line>. Rename?",
+     "options": [
+       { "label": "Leave as-is", "description": "Separate concept (Recommended)" },
+       { "label": "Rename", "description": "<composed> → <new-composed> everywhere" }
+     ]
+   }
    ```
 
    **Dialog C — PROSE**:
+
    ```json
-   {"question": "Prose at <path>:<line>. Context: '<line>'. Rename?",
-    "options": [
-      {"label": "Leave as-is", "description": "Natural-language word"},
-      {"label": "Rename", "description": "Substitute on this line"}]}
+   {
+     "question": "Prose at <path>:<line>. Context: '<line>'. Rename?",
+     "options": [
+       { "label": "Leave as-is", "description": "Natural-language word" },
+       { "label": "Rename", "description": "Substitute on this line" }
+     ]
+   }
    ```
 
 4. **Physical renames** — `mv` for `.claude/agents/<old>-expert.md` (+ `.suggestions[.archive].md` if present), `.claude/agent-memory/<old>${SUFFIX}/`, `wiki/domains/<old>.md`. Inside each renamed file, substitute slug + label references (frontmatter `name:`, `description:`, body).
@@ -132,26 +147,35 @@ If you catch yourself proposing batch deletion of content pages → abort, rebui
 
 ### Per-bucket by mode
 
-| Mode | B1-B4 | B5/B6/B7 | B8 HIST | B9 |
-|---|---|---|---|---|
-| `--archive` (default) | Edit (line / frontmatter / wikilink) | Skip silent → final warnings | Fully preserved, no prompt | Final warning |
-| `--include-historical` | Same as archive | Same | P-none by sub-bucket, action = edit (not delete) | Same |
-| `--purge` | Same as archive | P-1by1 (delete the occurrence) | Implies `--include-historical`; page deletion stays opt-in case-by-case | Same |
+| Mode                   | B1-B4                                | B5/B6/B7                       | B8 HIST                                                                 | B9            |
+| ---------------------- | ------------------------------------ | ------------------------------ | ----------------------------------------------------------------------- | ------------- |
+| `--archive` (default)  | Edit (line / frontmatter / wikilink) | Skip silent → final warnings   | Fully preserved, no prompt                                              | Final warning |
+| `--include-historical` | Same as archive                      | Same                           | P-none by sub-bucket, action = edit (not delete)                        | Same          |
+| `--purge`              | Same as archive                      | P-1by1 (delete the occurrence) | Implies `--include-historical`; page deletion stays opt-in case-by-case | Same          |
 
 **B2 FRONTMATTER — two steps**:
 
-- *Step 1*: P-all, remove `<slug>` from each `domains:` list (keep others). B8 HIST pages **excluded in `--archive`** (their frontmatter untouched).
-- *Step 2 — orphan dialog* (one-by-one, never batch, never pre-checked):
+- _Step 1_: P-all, remove `<slug>` from each `domains:` list (keep others). B8 HIST pages **excluded in `--archive`** (their frontmatter untouched).
+- _Step 2 — orphan dialog_ (one-by-one, never batch, never pre-checked):
 
-   ```json
-   {"question": "Page <path> orphan (domains: []) after removing <slug>. Action?",
+  ```json
+  {
+    "question": "Page <path> orphan (domains: []) after removing <slug>. Action?",
     "options": [
-      {"label": "Re-tag", "description": "Pick another domain from EXISTING_DOMAINS"},
-      {"label": "Leave orphan", "description": "domains: [] — page stays, flagged by /lint (Recommended)"},
-      {"label": "Delete the page", "description": "Explicit opt-in — only for mono-domain pure-description pages"}]}
-   ```
+      { "label": "Re-tag", "description": "Pick another domain from EXISTING_DOMAINS" },
+      {
+        "label": "Leave orphan",
+        "description": "domains: [] — page stays, flagged by /lint (Recommended)"
+      },
+      {
+        "label": "Delete the page",
+        "description": "Explicit opt-in — only for mono-domain pure-description pages"
+      }
+    ]
+  }
+  ```
 
-   If >3 orphans, present in alphabetical path order — user can answer "Leave orphan" rapidly.
+  If >3 orphans, present in alphabetical path order — user can answer "Leave orphan" rapidly.
 
 ### Phase 4 — Physical deletions (exhaustive)
 

--- a/.claude/commands/evolve-agent.md
+++ b/.claude/commands/evolve-agent.md
@@ -21,6 +21,7 @@ If the suggestions file doesn't exist or is empty → tell the user, suggest the
 ### 2. Analyze
 
 For each accumulated suggestion:
+
 - Classify: **recurring pattern** (≥2 occurrences) / **blind spot** / **prompt proposal** / **deliverable proposal**.
 - Deduplicate equivalent suggestions.
 - Filter: keep what's **recurring** or **clearly structural**. Discard isolated anecdotal items (but don't archive them — they may become recurring later).
@@ -28,12 +29,14 @@ For each accumulated suggestion:
 ### 3. Propose a revision diff
 
 Present a **concise revision plan** to the user:
+
 - List of suggestions kept (and why).
 - List of suggestions discarded for this iteration (with reason).
 - **Proposed diff** on `.claude/agents/$ARGUMENTS-expert.md`: sections added, modified, removed.
 - Expected impact on next ingests (in 2-3 lines).
 
 Ask for validation via `AskUserQuestion` with options:
+
 - **Apply the diff** (default option if relevant).
 - **Modify** (user specifies what should change).
 - **Defer** (do nothing, suggestions stay pending).
@@ -60,3 +63,12 @@ Ask for validation via `AskUserQuestion` with options:
 - **Human curation, not silent self-modification** — the agent proposes, the user validates.
 - **No regression**: the diff respects the existing structure (frontmatter, sections, tone). We add or refine, we don't refactor without reason.
 - **Traceability**: every evolution is logged, every integrated suggestion is archived with its date and origin.
+
+## Final step — normalise markdown
+
+After all pages are written/updated, format the produced markdown so it stays
+consistent and the CI `format-check` job passes:
+
+```bash
+npx -y prettier --write ".claude/agents/**/*.md" "wiki/**/*.md"
+```

--- a/.claude/commands/evolve-agent.md
+++ b/.claude/commands/evolve-agent.md
@@ -70,5 +70,5 @@ After all pages are written/updated, format the produced markdown so it stays
 consistent and the CI `format-check` job passes:
 
 ```bash
-npx -y prettier --write ".claude/agents/**/*.md" "wiki/**/*.md"
+python3 scripts/wiki-maint/format-md.py --write ".claude/agents/**/*.md" "wiki/**/*.md"
 ```

--- a/.claude/commands/format.md
+++ b/.claude/commands/format.md
@@ -1,22 +1,27 @@
 ---
-description: Format all markdown in the vault with Prettier (on-demand / one-shot normalisation)
+description: Format all markdown in the vault, Obsidian-safe (on-demand / one-shot normalisation)
 argument-hint: [path-or-folder — empty = whole repo]
 ---
 
 Normalise markdown formatting so it stays consistent across the whole wiki and
 passes the CI `format-check` job.
 
-Run Prettier in write mode on the target (default: the whole repo; `raw/` and
-other paths are excluded via `.prettierignore`):
+Use the Obsidian-safe formatter (`scripts/wiki-maint/format-md.py`), which wraps
+Prettier but masks the pipes inside wikilinks (`[[target|alias]]`) and code
+spans (`` `a|b` ``) so Prettier cannot mistake them for table column separators
+and corrupt the tables. `raw/`, `cache/`, `node_modules/`, `.git/`, `.obsidian/`
+and `docs/superpowers/` are excluded automatically.
+
+Run in write mode on the target (default: the whole repo):
 
 ```bash
-npx -y prettier --write "${ARGUMENTS:-**/*.md}"
+python3 scripts/wiki-maint/format-md.py --write "${ARGUMENTS:-**/*.md}"
 ```
 
 Then confirm it is idempotent:
 
 ```bash
-npx -y prettier --check "${ARGUMENTS:-**/*.md}"
+python3 scripts/wiki-maint/format-md.py --check "${ARGUMENTS:-**/*.md}"
 ```
 
 Report the number of files reformatted. This command is also used for the

--- a/.claude/commands/format.md
+++ b/.claude/commands/format.md
@@ -1,0 +1,24 @@
+---
+description: Format all markdown in the vault with Prettier (on-demand / one-shot normalisation)
+argument-hint: [path-or-folder — empty = whole repo]
+---
+
+Normalise markdown formatting so it stays consistent across the whole wiki and
+passes the CI `format-check` job.
+
+Run Prettier in write mode on the target (default: the whole repo; `raw/` and
+other paths are excluded via `.prettierignore`):
+
+```bash
+npx -y prettier --write "${ARGUMENTS:-**/*.md}"
+```
+
+Then confirm it is idempotent:
+
+```bash
+npx -y prettier --check "${ARGUMENTS:-**/*.md}"
+```
+
+Report the number of files reformatted. This command is also used for the
+**one-shot** normalisation of a vault that predates the formatter (expect a
+large diff the first time — review it stays cosmetic, then commit).

--- a/.claude/commands/ingest-video.md
+++ b/.claude/commands/ingest-video.md
@@ -55,11 +55,13 @@ All expert agents have a `## Visual frames` section in their prompt — they can
 After the expert agent has returned its report, **propose** the extraction mode best suited to this video via `AskUserQuestion`. No silent switch.
 
 **Override flags** (consumed in priority, no proposal shown):
+
 - `--induction` → force mode B (cross-induction).
 - `--mode-a` → force mode A (frame requests from the agent).
 - `--skip-frames` → skip extraction.
 
 **Signals to compute** before the proposal:
+
 - `duration_min`: video duration in minutes (from the `duration` field of the `.meta.md` frontmatter).
 - `visual_mentions`: count of visual-pattern occurrences in the transcript. **Bilingual EN+FR list** (extend with other languages as needed depending on the source-transcript language):
   - **EN patterns**: `look at`, `here's`, `here is`, `you can see`, `you'll see`, `this diagram`, `this table`, `this chart`, `this graph`, `this figure`, `this slide`, `this image`, `this dashboard`, `this pipeline`, `this code`, `on screen`, `on the screen`, `take a look`, `notice this`.
@@ -69,6 +71,7 @@ After the expert agent has returned its report, **propose** the extraction mode 
 - `frame_requests_count`: number of entries in the agent's `## Frame requests` report block (0 if block absent).
 
 **Computed recommendation**:
+
 - **Recommend Mode A** if: `frame_requests_count` > 0 and consistent with `visual_mentions` (typical case: agent declared 2-4 frames on a conceptual video, or more on a dense video with many configurations).
 - **Recommend Mode B** if:
   - `duration_min ≥ 30` AND `mentions_per_min ≥ 0.3` AND `frame_requests_count` ≤ 30% of the "expected" count (`visual_mentions / 3` as a rough heuristic) → suspected under-extraction.
@@ -91,6 +94,7 @@ Options:
 The recommended option is marked "(Recommended)" and placed first.
 
 **Logging**: the final decision (mode + signals + any override) is journaled in `wiki/log.md` on the same line as the ingest:
+
 ```
 ## [YYYY-MM-DD] ingest-video | <title> (agent: <name>, mode: A|B|skip, duration Xm, Y mentions, Z frames)
 ```

--- a/.claude/commands/ingest.md
+++ b/.claude/commands/ingest.md
@@ -6,6 +6,7 @@ argument-hint: [--force] [--frames] [path-or-folder — empty = all of raw/]
 Run the INGEST workflow from CLAUDE.md on: $ARGUMENTS
 
 **Idempotent batch mode.** Behavior:
+
 - No argument → full sweep of `raw/`.
 - Argument = folder → scan that subtree.
 - Argument = file → force re-ingest **of that file only**.
@@ -27,12 +28,14 @@ MODIFIED raw/...    (covered-by: <slug>, sha-changed)   → covered but content 
 Detection is **robust**: it checks exact match on `source_path`, then on `covered_paths` (list of all raw paths covered by a composite page), then on parent directory. This avoids false "NEW" entries when an agent synthesized several files into a single page without listing each file individually.
 
 Arbitration:
+
 - `SKIP` → ignore (unless `--force` → treat as `MODIFIED`).
 - `NEW` / `MODIFIED` → proceed to step 2.
 
 **`--force` mode**: explicitly tell the expert agent in its prompt that the source has **already been ingested** (cite the existing source page) and that it's an **additive** re-ingest. The agent must read existing pages, identify what's missing, add only that, not rewrite content that's already correct. Update `ingested:` only if content was added.
 
 **`--frames` mode**: tell the agent the goal is **exclusively** to produce frame requests for this transcript. Spawn instruction:
+
 - Re-read the source transcript.
 - Produce a `## Frame requests` block per the vault convention (cf. CLAUDE.md).
 - **Don't modify anything else** in existing pages — no textual content update, no `ingested:` bump.
@@ -57,6 +60,7 @@ If video/audio/URL not transcribed → chain `scripts/video/transcribe.sh` first
 Read `.claude/agent-output-contract.md` once at the start of the run; inject it integrally into every spawn prompt below.
 
 For each validated agent, launch an `Agent` call with:
+
 - `subagent_type`: the chosen agent.
 - **Prompt** containing:
   - Path of the raw file to ingest.
@@ -108,10 +112,13 @@ mv "$PENDING.tmp" "$PENDING"
 ### 5. Final overall report
 
 Format:
+
 ```
 N new · M updated · K unchanged (skipped) · L orphans
 ```
+
 Followed by:
+
 - Per source: agent invoked, pages touched, deliverables produced.
 - Evolution suggestions surfaced (pointer to `.suggestions.md` files).
 - Contradictions detected (between sources or against the existing wiki).
@@ -123,3 +130,12 @@ Followed by:
 - One source = one main agent (even if cross-domain, one agent leads the `wiki/sources/` page; the others enrich concepts/entities in their domain).
 - If no expert agent fits and the user picks "other" → the main context performs the generic ingest (current fallback behavior).
 - If the `/evolve-agent <domain>` command exists, it consumes the `.suggestions.md` to evolve the agent's prompt.
+
+## Final step — normalise markdown
+
+After all pages are written/updated, format the produced markdown so it stays
+consistent and the CI `format-check` job passes:
+
+```bash
+npx -y prettier --write "wiki/**/*.md"
+```

--- a/.claude/commands/ingest.md
+++ b/.claude/commands/ingest.md
@@ -137,5 +137,5 @@ After all pages are written/updated, format the produced markdown so it stays
 consistent and the CI `format-check` job passes:
 
 ```bash
-npx -y prettier --write "wiki/**/*.md"
+python3 scripts/wiki-maint/format-md.py --write "wiki/**/*.md"
 ```

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -5,16 +5,20 @@ argument-hint: [domain — empty = whole wiki]
 
 Run the LINT workflow from CLAUDE.md.
 
-If $ARGUMENTS is provided: limit the analysis to domain `$ARGUMENTS`
-  (pages wiki/domains/$ARGUMENTS.md, wiki/entities/, wiki/concepts/, wiki/sources/ with `domains: [$ARGUMENTS]`).
+If $ARGUMENTS is provided: limit the analysis to domain `$ARGUMENTS`  (pages wiki/domains/$ARGUMENTS.md, wiki/entities/, wiki/concepts/, wiki/sources/ with`domains: [$ARGUMENTS]`).
 If empty: full wiki sweep (expensive — reserve for monthly reviews).
 
 Report on:
+
 - Contradictions across pages
 - Stale claims
 - Orphan pages — see criterion below
 - Concepts mentioned without their own page
 - Missing cross-references
+- **Stale raw sources** — for every page, each path listed in `sources:` (and
+  `covered_paths:`) must exist on disk under `raw/`. A missing source means the
+  page references content that was deleted or moved — flag it. (This is the
+  local counterpart of the CI, which cannot see `raw/`.)
 - Data gaps worth researching
 - **L3 readiness**:
   - ADRs (`wiki/decisions/*.md`) older than 90 days without `verdict` (status confirmation overdue).

--- a/.claude/commands/save.md
+++ b/.claude/commands/save.md
@@ -6,8 +6,18 @@ argument-hint: <slug>
 Run the SAVE workflow from CLAUDE.md with slug: $ARGUMENTS
 
 Steps:
+
 1. Identify the latest substantial synthesis/answer in the conversation.
 2. Create `wiki/syntheses/$ARGUMENTS.md` with frontmatter (`type: synthesis`, `created`, `domains`, `sources`).
 3. Include `[[page]]` links to the cited pages.
 4. Update `wiki/index.md` Syntheses section.
 5. Append to `wiki/log.md`: `## [YYYY-MM-DD] save | $ARGUMENTS`.
+
+## Final step — normalise markdown
+
+After all pages are written/updated, format the produced markdown so it stays
+consistent and the CI `format-check` job passes:
+
+```bash
+npx -y prettier --write "wiki/**/*.md"
+```

--- a/.claude/commands/save.md
+++ b/.claude/commands/save.md
@@ -19,5 +19,5 @@ After all pages are written/updated, format the produced markdown so it stays
 consistent and the CI `format-check` job passes:
 
 ```bash
-npx -y prettier --write "wiki/**/*.md"
+python3 scripts/wiki-maint/format-md.py --write "wiki/**/*.md"
 ```

--- a/.claude/commands/sync-repos.md
+++ b/.claude/commands/sync-repos.md
@@ -29,11 +29,13 @@ Avoids an unintended "sync all" (N repos = N clones).
 ### 3. Script invocation
 
 Call `scripts/sync-repos.sh` with the final list of names:
+
 ```bash
 scripts/sync-repos.sh <name1> <name2>
 ```
 
 The script writes to stdout lines of three forms:
+
 - `CREATED <vault-relative-path>` — a new snapshot.
 - `SKIPPED <name> (sha <shortsha> already snapshotted)` — no upstream merge since the last sync.
 - `ERROR <name> <message>` — failure (clone, missing paths, repo unreachable).
@@ -61,6 +63,7 @@ Errors:
 ```
 
 Append to `wiki/log.md`:
+
 ```
 ## [YYYY-MM-DD] sync-repos | N snapshots created
 <list of created and ingested snapshots>

--- a/.claude/commands/update-vault.md
+++ b/.claude/commands/update-vault.md
@@ -42,6 +42,7 @@ echo "Target: ${TARGET_BRANCH} → ${TARGET_VERSION} (${TARGET_SHA:0:12}…)"
 ### 4. Compute the migration chain to apply
 
 A migration enters `MIGRATIONS_TO_APPLY` if either:
+
 - Its slug is NOT in `APPLIED_MIGRATIONS` (the normal "new migration" path), OR
 - Its slug IS in `APPLIED_MIGRATIONS` BUT its frontmatter contains `force-rerun: true` (the "re-evaluate on every update" path, used when a previously-applied migration ships a fix or extension that needs to re-execute on already-migrated vaults).
 
@@ -94,17 +95,31 @@ For each `CONFLICT <f>`, ask the user how to resolve:
 
 ```json
 {
-  "questions": [{
-    "question": "<f> has overlapping edits between your local version and the template update. How do you want to resolve it?",
-    "header": "Conflict: <basename>",
-    "multiSelect": false,
-    "options": [
-      {"label": "Keep merged version with markers", "description": "File contains <<<<<<< / ======= / >>>>>>> showing both sides. Edit it manually after this command, then re-stage."},
-      {"label": "Use template version (discard local edits)", "description": "Overwrite with the upstream template. Your local customisations on this file are lost."},
-      {"label": "Use vault version (discard template update)", "description": "Restore your local version. The file diverges from template until you re-run /update-vault and resolve."},
-      {"label": "Skip this file", "description": "Do not stage. The file stays in its current marker-annotated state until you handle it manually."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "<f> has overlapping edits between your local version and the template update. How do you want to resolve it?",
+      "header": "Conflict: <basename>",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "Keep merged version with markers",
+          "description": "File contains <<<<<<< / ======= / >>>>>>> showing both sides. Edit it manually after this command, then re-stage."
+        },
+        {
+          "label": "Use template version (discard local edits)",
+          "description": "Overwrite with the upstream template. Your local customisations on this file are lost."
+        },
+        {
+          "label": "Use vault version (discard template update)",
+          "description": "Restore your local version. The file diverges from template until you re-run /update-vault and resolve."
+        },
+        {
+          "label": "Skip this file",
+          "description": "Do not stage. The file stays in its current marker-annotated state until you handle it manually."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -136,6 +151,7 @@ Skipped: <files in UNSTAGE>
 For each migration in `MIGRATIONS_TO_APPLY` (ascending version order), invoke it as a sub-workflow. Migration files live under `scripts/migrations/v<X>-*.md` — read the file and execute its steps (AskUserQuestion, edits, commit).
 
 Each migration returns one of three verdicts:
+
 - **Applied**: file updated, dedicated commit by the migration. Append its slug to `APPLIED_MIGRATIONS`.
 - **Manual edit / Skipped**: do NOT append. The migration is re-proposed at the next `/update-vault`.
 
@@ -171,6 +187,7 @@ If `.claude/template-version` did not exist at session start (step 2 detected v1
 ## Notes
 
 Excluded from propagation (consumed at bootstrap or user-owned):
+
 - `*.tpl`, `BOOTSTRAP.md`, `PLACEHOLDERS.md`, `CONTRIBUTING.md` — bootstrap-only.
 - `CLAUDE.md` — user-owned; migrated only through `scripts/migrations/v<X>-*.md`.
 

--- a/.claude/rules/frontmatter.md
+++ b/.claude/rules/frontmatter.md
@@ -33,10 +33,10 @@ updated: YYYY-MM-DD
 ## Fields specific to `type: source` pages
 
 ```yaml
-source_path: "raw/<folder>/<file>.md"        # mandatory, non-empty, real existing path
-source_sha256: "<64-character hex hash>"     # mandatory, non-empty
-ingested: YYYY-MM-DD                         # date of ingestion by the agent
-covered_paths:                               # optional: if the page synthesizes multiple raws
+source_path: "raw/<folder>/<file>.md" # mandatory, non-empty, real existing path
+source_sha256: "<64-character hex hash>" # mandatory, non-empty
+ingested: YYYY-MM-DD # date of ingestion by the agent
+covered_paths: # optional: if the page synthesizes multiple raws
   - "raw/<folder>/<file1>.md"
   - "raw/<folder>/<file2>.md"
 ```
@@ -60,10 +60,10 @@ If the file cannot be hashed (invalid path, access error), the ingestion fails â
 ## Fields specific to `type: decision` pages
 
 ```yaml
-status: pending | accepted                            # mandatory
-verdict: null | validated | invalidated | partial     # optional, null until reality validates
-verdict_date: null | YYYY-MM-DD                       # optional, must accompany verdict
-verdict_evidence: null | "short narrative"            # optional, must accompany verdict
+status: pending | accepted # mandatory
+verdict: null | validated | invalidated | partial # optional, null until reality validates
+verdict_date: null | YYYY-MM-DD # optional, must accompany verdict
+verdict_evidence: null | "short narrative" # optional, must accompany verdict
 ```
 
 ADRs without `verdict` after **90 days** are flagged by `/lint` (forces L3 confrontation with reality).
@@ -71,7 +71,7 @@ ADRs without `verdict` after **90 days** are flagged by `/lint` (forces L3 confr
 ## Optional `revisit_after` field
 
 ```yaml
-revisit_after: YYYY-MM-DD     # on type: decision and type: concept pages
+revisit_after: YYYY-MM-DD # on type: decision and type: concept pages
 ```
 
 `/lint` flags pages whose `revisit_after` date has passed. Use this to schedule a re-read of a concept or decision (e.g. after a related project ships, after a major external change).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,8 @@ jobs:
             !**/raw/**
             !**/.claude/worktrees/**
             !**/cache/**
+            !**/.venv/**
+            !**/.venv-*/**
 
   wiki-integrity:
     name: wiki-integrity

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npx -y prettier --check "**/*.md"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      # Obsidian-safe formatter check (wraps Prettier; preserves pipes in
+      # wikilinks and code spans inside tables — see scripts/wiki-maint/format-md.py).
+      - run: python3 scripts/wiki-maint/format-md.py --check "**/*.md"
 
   markdownlint:
     name: markdownlint
@@ -34,6 +39,8 @@ jobs:
             **/*.md
             !**/node_modules/**
             !**/raw/**
+            !**/.claude/worktrees/**
+            !**/cache/**
 
   wiki-integrity:
     name: wiki-integrity

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,13 +5,26 @@ on:
     branches: [develop, main]
   push:
     branches: [develop, main]
+  schedule:
+    # Weekly external-link report (non-blocking). Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
+  issues: write   # link-check-report opens/updates the dead-links issue
 
 jobs:
+  format-check:
+    name: format-check
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx -y prettier --check "**/*.md"
+
   markdownlint:
     name: markdownlint
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,12 +35,25 @@ jobs:
             !**/node_modules/**
             !**/raw/**
 
-  link-check:
-    name: link-check
+  wiki-integrity:
+    name: wiki-integrity
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: lycheeverse/lychee-action@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: python3 scripts/wiki-maint/validate-wiki.py
+
+  link-check-report:
+    name: link-check-report
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lychee external link report
+        uses: lycheeverse/lychee-action@v2
         with:
           args: >-
             --no-progress
@@ -36,5 +62,5 @@ jobs:
             --exclude 'mailto:'
             --accept '100..=103,200..=299,403,429'
             './**/*.md'
-          fail: true
+          fail: false
           # honors .lycheeignore for files/links generated at bootstrap time

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ cache/
 raw/
 !raw/**/.gitkeep
 Clippings/
-# Superpowers session artifacts (brainstorming specs, implementation plans) — local only, never committed
 docs/superpowers/
 __pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ cache/
 raw/
 !raw/**/.gitkeep
 Clippings/
+# Superpowers session artifacts (brainstorming specs, implementation plans) — local only, never committed
+docs/superpowers/
 __pycache__/
 *.pyc
 debug-*.png

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,18 +1,46 @@
 {
-  // Pragmatic config for a docs/wiki repo with many existing files.
-  // Catches structural issues (broken refs, hard tabs, duplicate titles)
-  // but ignores cosmetic line-level rules.
+  // Semantic linting only. Prettier owns cosmetic formatting (see .prettierrc),
+  // so all purely stylistic rules are disabled here to avoid the two tools
+  // fighting. We keep the rules that catch real rendering/data defects.
   // See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
   "default": true,
-  "MD013": false,          // line length
+
+  // --- Kept (semantic): real defects, repairable ---
+  // MD056 table-column-count   → extra cells silently dropped at render
+  // MD042 no-empty-links       → empty link target
+  // MD051 link-fragments       → anchor points to a missing heading
   "MD024": { "siblings_only": true }, // duplicate headings ok if not siblings
+
+  // --- Disabled: owned by Prettier (cosmetic) ---
+  "MD060": false,          // table-column-style (separator style) — 19k+ on real vault
+  "MD022": false,          // blanks around headings
+  "MD028": false,          // blanks inside blockquote
+  "MD029": false,          // ordered-list prefix style
+  "MD058": false,          // blanks around tables
+  "MD049": false,          // emphasis style
+  "MD050": false,          // strong style
+  "MD012": false,          // multiple consecutive blanks
+  "MD009": false,          // trailing spaces
+  "MD037": false,          // spaces inside emphasis (false positives on "* +")
+  "MD003": false,          // heading style
+  "MD047": false,          // single trailing newline
+  "MD026": false,          // trailing punctuation in heading
+  "MD014": false,          // $ before commands without output
+  "MD004": false,          // unordered-list bullet style
+
+  // --- Disabled: low value on ingested/concatenated content ---
+  "MD025": false,          // single H1 (pages use frontmatter title)
+  "MD001": false,          // heading increment (generated content skips levels)
+
+  // --- Disabled previously (kept for a docs/wiki repo) ---
+  "MD013": false,          // line length
   "MD031": false,          // blanks around fences
   "MD032": false,          // blanks around lists
   "MD033": false,          // inline HTML (used in templates)
   "MD034": false,          // bare URLs
   "MD036": false,          // emphasis-as-heading
-  "MD038": false,          // spaces inside code spans (false positives on indented code spans)
-  "MD040": false,          // fenced-code-language (many docs blocks have no language)
+  "MD038": false,          // spaces inside code spans
+  "MD040": false,          // fenced-code-language
   "MD041": false,          // first line top-level heading
   "MD046": { "style": "fenced" }
 }

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -6,10 +6,16 @@
   "default": true,
 
   // --- Kept (semantic): real defects, repairable ---
-  // MD056 table-column-count   → extra cells silently dropped at render
   // MD042 no-empty-links       → empty link target
   // MD051 link-fragments       → anchor points to a missing heading
   "MD024": { "siblings_only": true }, // duplicate headings ok if not siblings
+
+  // --- Disabled: Obsidian-specific false positives ---
+  // MD056 table-column-count: Obsidian renders `a|b` code spans and [[x|y]]
+  // aliases as a single cell, but GFM/markdownlint count the inner pipe as an
+  // extra column. On a real vault this is ~overwhelmingly false positives
+  // (1700+ code spans). Table alignment is handled safely by format-md.py.
+  "MD056": false,
 
   // --- Disabled: owned by Prettier (cosmetic) ---
   "MD060": false,          // table-column-style (separator style) — 19k+ on real vault

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Raw sources are gitignored in vaults and never present on the remote.
+raw/
+# Generated / vendored.
+node_modules/
+.claude/worktrees/
+cache/
+dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,8 @@ node_modules/
 .claude/worktrees/
 cache/
 dist/
+# Python virtualenvs (LICENSE.md / README.md of installed packages).
+.venv/
+.venv-*/
+**/.venv/
+**/.venv-*/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "proseWrap": "preserve",
+  "printWidth": 100,
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "parser": "markdown"
+      }
+    }
+  ]
+}

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -51,14 +51,15 @@ Ask the questions **sequentially**. Store every answer in an internal variable. 
 
 Ask 2 plain-text questions, sequential, not via `AskUserQuestion`:
 
-1. "What's your full name? (e.g. *Maria Dupont*, *Carlos Silva*)"
+1. "What's your full name? (e.g. _Maria Dupont_, _Carlos Silva_)"
    → Store as `name`. Extract the **first name** (1st token before the space) lowercased to compute `vault_name = <firstname>-vault`.
    → For hyphenated first names ("Jean-Marc"), split on **spaces only**: `vault_name = jean-marc-vault`.
 
-2. "What's your short professional role (1 line)? (e.g. *Lead data engineer at Acme Corp*, *Post-doc researcher in genomics at CNRS*)"
+2. "What's your short professional role (1 line)? (e.g. _Lead data engineer at Acme Corp_, _Post-doc researcher in genomics at CNRS_)"
    → Store as `role`.
 
 **Parsing:**
+
 - `name` = raw answer to Q1.1 (e.g. `"Maria Dupont"`).
 - `role` = raw answer to Q1.2.
 - `vault_name` = `<first_token_lowercase>-vault`. The "first token" is obtained by splitting on **spaces only** (not on hyphens). So `"Maria Dupont"` → `maria-vault`, `"Jean-Marc Lefebvre"` → `jean-marc-vault`. Confirm silently, no dedicated question.
@@ -75,11 +76,13 @@ Tip: cluster rather than splinter when natural. No cap — declare as many as re
 ```
 
 **Parsing:**
+
 - `domains = [slugs...]`. Trim every slug. Validate kebab-case, fix silently otherwise.
 - If 0 domain → re-ask, saying at least 1 is needed.
 - For each slug, infer a `domain_label` via human title-casing (e.g. `astro-physics` → `Astronomy & Physics`, `ai` → `AI`). You will display it at validation time.
 
 **Slug → human-label mapping (domain title)**:
+
 - ASCII kebab-case slug (e.g. `market`, `paleo-dna`).
 - The human label is derived for display: capitalize + accents if relevant (e.g. `marche` → `Marché`, `paleo-dna` → `Paleo-DNA`).
 - On ambiguity (e.g. slug `cs` → `Computer Science` or `Customer Success`?), ask the user to confirm the human label.
@@ -111,6 +114,7 @@ Build the JSON dynamically:
 **Concrete example** for `domains = [poker, ai, factory, work, tech]`: 5 options labeled `poker`/`ai`/.../`tech` + the `none` option. Static description: "The hub pivot is the domain that tools or feeds the others. Example: AI feeds the Factory (agents) and Work (LLM management techniques)."
 
 **Parsing:**
+
 - `hub_pivot = <slug>` or `null` if "none".
 
 ### Q4 — Active projects
@@ -128,6 +132,7 @@ I'm rebuilding my Factory plugin in a multi-agent architecture
 ```
 
 **Automatic parsing**:
+
 - For every non-empty line, extract a kebab-case `slug` (2-4 keywords condensed from the sentence) and keep the full sentence as `description`.
 - Example: `"I'm following an MTT poker masterclass for 2026"` → `{slug: "mtt-poker-masterclass", description: "MTT poker masterclass 2026"}`.
 - If the line is too short to extract a meaningful slug → `project-1`, `project-2`, etc.
@@ -139,23 +144,32 @@ Multi-select 6 options:
 
 ```json
 {
-  "questions": [{
-    "question": "Which source types do you plan to ingest?",
-    "header": "Source types",
-    "multiSelect": true,
-    "options": [
-      {"label": "Personal notes", "description": "Reflections, takeaways, personal drafts."},
-      {"label": "Video transcripts", "description": "YouTube + local files. Enables /ingest-video and the frames pipeline."},
-      {"label": "PDFs", "description": "Papers, ebooks, slides."},
-      {"label": "Web clippings", "description": "Blog articles, threads, posts."},
-      {"label": "Official docs", "description": "SDKs, APIs, frameworks."},
-      {"label": "GitHub repos", "description": "Tracking evolving projects. Enables /sync-repos."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Which source types do you plan to ingest?",
+      "header": "Source types",
+      "multiSelect": true,
+      "options": [
+        { "label": "Personal notes", "description": "Reflections, takeaways, personal drafts." },
+        {
+          "label": "Video transcripts",
+          "description": "YouTube + local files. Enables /ingest-video and the frames pipeline."
+        },
+        { "label": "PDFs", "description": "Papers, ebooks, slides." },
+        { "label": "Web clippings", "description": "Blog articles, threads, posts." },
+        { "label": "Official docs", "description": "SDKs, APIs, frameworks." },
+        {
+          "label": "GitHub repos",
+          "description": "Tracking evolving projects. Enables /sync-repos."
+        }
+      ]
+    }
+  ]
 }
 ```
 
 **Parsing:**
+
 - `source_types = [labels...]`.
 - `ingest_video_enabled = "Video transcripts" in source_types` (boolean).
 - `has_tracked_repos = "GitHub repos" in source_types` (boolean).
@@ -166,20 +180,29 @@ Single-select 3 options:
 
 ```json
 {
-  "questions": [{
-    "question": "At what cadence do you plan to ingest?",
-    "header": "Cadence",
-    "multiSelect": false,
-    "options": [
-      {"label": "< 1 per week", "description": "Low volume. Favors cost (haiku/medium by default)."},
-      {"label": "1 to 3 per week", "description": "Standard cadence."},
-      {"label": "> 3 per week", "description": "High volume. Favors quality (sonnet/high by default on dense non-pivot agents)."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "At what cadence do you plan to ingest?",
+      "header": "Cadence",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "< 1 per week",
+          "description": "Low volume. Favors cost (haiku/medium by default)."
+        },
+        { "label": "1 to 3 per week", "description": "Standard cadence." },
+        {
+          "label": "> 3 per week",
+          "description": "High volume. Favors quality (sonnet/high by default on dense non-pivot agents)."
+        }
+      ]
+    }
+  ]
 }
 ```
 
 **Parsing:**
+
 - `cadence ∈ {"low", "medium", "high"}`.
 
 ### Q7 — Video storage (conditional)
@@ -193,6 +216,7 @@ If you have an external SSD for heavy videos: provide its path (e.g. /Volumes/T7
 ```
 
 **Parsing:**
+
 - `video_cache_path` = answer, default `cache/videos/` if empty.
 
 ---
@@ -208,6 +232,7 @@ Phrases you'd hear in a video transcript of this domain that signal a visual is 
 **Generate the phrases in the vault language** (`{{vault_language}}` — captured at the very start of the interview). Example patterns are given in EN below; use them as a calibration template, then translate / adapt to the target language. If the user is German, generate German phrases; if Spanish, Spanish; etc. Don't mix languages.
 
 Calibration patterns:
+
 - **Data / numbers / matrices** (poker, finance, sport stats) → "look at the table", "here's the grid", "you can see them", "this column", "this cell".
 - **Schemas / architectures / flows** (ai, devops, factory, tech) → "this diagram", "here's the architecture", "this flowchart", "this arrow", "this component".
 - **Formulas / equations** (physics, math, astro) → "this formula", "here's the equation", "this proof", "this calculation".
@@ -221,6 +246,7 @@ Calibration patterns:
 ### B2 — `deliverables` (signature deliverable)
 
 Heuristic:
+
 - **Technical-dense** domain (numbers, ranges, rates, KPIs) → `[cheatsheets]`.
 - **Reflective** domain (patterns, frameworks, takeaways) → `[syntheses]`.
 - **Systems** domain (architectures, flows, components) → `[diagrams]`.
@@ -237,14 +263,15 @@ Always implicitly add the base deliverables: `[sources, entities, concepts]` (un
 
 Decision table:
 
-| Condition | model | effort | maxTurns |
-|---|---|---|---|
-| `is_hub_pivot = true` | `sonnet` | `high` | `80` |
-| Technical-dense domain (B2 contains `cheatsheets`) | `sonnet` | `high` | `60` |
-| `cadence = "high"` AND not pure reflective | `sonnet` | `high` | `60` |
-| Otherwise (default) | `haiku` | `medium` | `60` |
+| Condition                                          | model    | effort   | maxTurns |
+| -------------------------------------------------- | -------- | -------- | -------- |
+| `is_hub_pivot = true`                              | `sonnet` | `high`   | `80`     |
+| Technical-dense domain (B2 contains `cheatsheets`) | `sonnet` | `high`   | `60`     |
+| `cadence = "high"` AND not pure reflective         | `sonnet` | `high`   | `60`     |
+| Otherwise (default)                                | `haiku`  | `medium` | `60`     |
 
 **Priority on conflict**:
+
 1. `is_hub_pivot = true` → always `sonnet/high/80`.
 2. Otherwise, `deliverables` contains `cheatsheets` → `sonnet/high/60` (technical density justifies the cost even at low cadence).
 3. Otherwise, `cadence = high (>3/week)` → `sonnet/high/60` (volume justifies quality).
@@ -259,6 +286,7 @@ Trivial: `is_hub_pivot = (domain_slug == hub_pivot)`.
 For each domain, infer 4-6 useful formats to transcribe video frames into structured markdown.
 
 Patterns by domain type:
+
 - **Data / numbers / matrices** (poker, finance, sport stats): "Markdown table", "table with depth × position columns", "13×13 grid", "numerical leaderboard".
 - **Schemas / architectures / flows** (ai, factory, devops): "Mermaid diagram", "flowchart", "graph LR", "sequenceDiagram".
 - **Formulas / equations / proofs** (physics, math, biostat): "LaTeX block", "inline equation", "variables table", "step-by-step proof".
@@ -303,15 +331,20 @@ Then:
 
 ```json
 {
-  "questions": [{
-    "question": "Domain {{domain_slug}} — do you validate this config?",
-    "header": "Domain validation",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Validate this domain", "description": "Keep the inference as-is."},
-      {"label": "✏️ Adjust", "description": "Edit one or more of the 5 properties (triggers, deliverables, co-ingest, model/effort/maxTurns, hub pivot)."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Domain {{domain_slug}} — do you validate this config?",
+      "header": "Domain validation",
+      "multiSelect": false,
+      "options": [
+        { "label": "✅ Validate this domain", "description": "Keep the inference as-is." },
+        {
+          "label": "✏️ Adjust",
+          "description": "Edit one or more of the 5 properties (triggers, deliverables, co-ingest, model/effort/maxTurns, hub pivot)."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -325,17 +358,22 @@ On "✏️ Adjust":
 
 ```json
 {
-  "questions": [{
-    "question": "Which color for \"{{domain_slug}}\" in the Obsidian graph?",
-    "header": "Graph color",
-    "multiSelect": false,
-    "options": [
-      {"label": "🔵 Turquoise", "description": "#2BC7D3 — AI, tech, digital. rgb=2869203"},
-      {"label": "🟢 Green", "description": "#51C463 — sciences, health, nature. rgb=5358691"},
-      {"label": "🟠 Orange", "description": "#E07B39 — management, sport, competition. rgb=14711609"},
-      {"label": "🔴 Red", "description": "#E05252 — poker, gaming, intensity. rgb=14701138"}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Which color for \"{{domain_slug}}\" in the Obsidian graph?",
+      "header": "Graph color",
+      "multiSelect": false,
+      "options": [
+        { "label": "🔵 Turquoise", "description": "#2BC7D3 — AI, tech, digital. rgb=2869203" },
+        { "label": "🟢 Green", "description": "#51C463 — sciences, health, nature. rgb=5358691" },
+        {
+          "label": "🟠 Orange",
+          "description": "#E07B39 — management, sport, competition. rgb=14711609"
+        },
+        { "label": "🔴 Red", "description": "#E05252 — poker, gaming, intensity. rgb=14701138" }
+      ]
+    }
+  ]
 }
 ```
 
@@ -355,10 +393,12 @@ Once every domain has been individually validated, show a full recap:
 {{ "**Video storage**: " + video_cache_path if ingest_video_enabled else "" }}
 
 **Active projects**:
+
 - {{ project_1.slug }} | {{ project_1.description }}
 - ...
 
 **Domains** ({{N}}):
+
 - {{ domain_1_slug }} {{ "⭐" if pivot }} — {{ deliverables }} — {{ model }}/{{ effort }}/{{ maxTurns }}
 - ...
 ```
@@ -367,15 +407,20 @@ Then:
 
 ```json
 {
-  "questions": [{
-    "question": "All good?",
-    "header": "Final validation",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ All good, scaffold it", "description": "Run vault generation."},
-      {"label": "↩️ Restart the interview from scratch", "description": "Goes back to Q1. All answers are wiped."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "All good?",
+      "header": "Final validation",
+      "multiSelect": false,
+      "options": [
+        { "label": "✅ All good, scaffold it", "description": "Run vault generation." },
+        {
+          "label": "↩️ Restart the interview from scratch",
+          "description": "Goes back to Q1. All answers are wiped."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -392,7 +437,7 @@ Run in **this exact order**. Use `Edit replace_all=true` or `sed` for substituti
 For each `.tpl` file in the repo (CLAUDE.md.tpl, wiki/index.md.tpl, wiki/log.md.tpl, wiki/overview.md.tpl, wiki/radar.md.tpl, wiki/domains/domain.md.tpl, .claude/agents/domain-expert.md.tpl, .claude/agent-memory/domain-memory.md.tpl):
 
 - Load the content.
-- Substitute every **global** placeholder: `{{name}}`, `{{vault_name}}`, `{{vault_language}}` (human label of the language detected at the interview — see *Language persistence* directive at the top of this prompt), `{{role}}`, `{{parcours_short}}`, `{{bootstrap_date}}`, `{{has_tracked_repos}}` (and its conditional sections: `{{slash_commands_extras}}`, `{{tracked_repos_arborescence}}`, `{{tracked_repos_cache}}`, `{{tracked_repos_scripts_extras}}`, `{{sync_repos_section}}`).
+- Substitute every **global** placeholder: `{{name}}`, `{{vault_name}}`, `{{vault_language}}` (human label of the language detected at the interview — see _Language persistence_ directive at the top of this prompt), `{{role}}`, `{{parcours_short}}`, `{{bootstrap_date}}`, `{{has_tracked_repos}}` (and its conditional sections: `{{slash_commands_extras}}`, `{{tracked_repos_arborescence}}`, `{{tracked_repos_cache}}`, `{{tracked_repos_scripts_extras}}`, `{{sync_repos_section}}`).
 - Substitute the computed **cross-domain** placeholders: `{{domains_section}}`, `{{domains_index_section}}`, `{{domains_links}}`, `{{projects_links}}`, `{{agents_section}}`.
 
 **Note**: `tracked-repos.config.json.tpl` contains no placeholder, skip substitution. The final rename is handled in Section 5.6.
@@ -574,15 +619,23 @@ Ask:
 
 ```json
 {
-  "questions": [{
-    "question": "Do you want to enable the MCP server to access your wiki from any Claude Code instance?",
-    "header": "MCP Wiki",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Yes, set it up now", "description": "Runs bash scripts/mcp/setup-mcp.sh. Prerequisites: Python 3 + internet connection for pip."},
-      {"label": "❌ No, I'll do it later", "description": "Run bash scripts/mcp/setup-mcp.sh from the vault whenever you want."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Do you want to enable the MCP server to access your wiki from any Claude Code instance?",
+      "header": "MCP Wiki",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Yes, set it up now",
+          "description": "Runs bash scripts/mcp/setup-mcp.sh. Prerequisites: Python 3 + internet connection for pip."
+        },
+        {
+          "label": "❌ No, I'll do it later",
+          "description": "Run bash scripts/mcp/setup-mcp.sh from the vault whenever you want."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -597,16 +650,27 @@ Ask:
 
 ```json
 {
-  "questions": [{
-    "question": "Do you want to create a GitHub repo for your {{vault_name}} vault?",
-    "header": "Remote",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Yes, private", "description": "gh repo create {{vault_name}} --private --source=. --push"},
-      {"label": "✅ Yes, public", "description": "gh repo create {{vault_name}} --public --source=. --push"},
-      {"label": "❌ No, I'll handle it manually", "description": "No action. You can add a remote later with git remote add origin <url>."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Do you want to create a GitHub repo for your {{vault_name}} vault?",
+      "header": "Remote",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Yes, private",
+          "description": "gh repo create {{vault_name}} --private --source=. --push"
+        },
+        {
+          "label": "✅ Yes, public",
+          "description": "gh repo create {{vault_name}} --public --source=. --push"
+        },
+        {
+          "label": "❌ No, I'll handle it manually",
+          "description": "No action. You can add a remote later with git remote add origin <url>."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -617,6 +681,7 @@ Per the answer:
 - **Manual**: skip.
 
 **If `gh` is not installed or not authenticated** (catch the `gh repo create` error):
+
 - Switch to manual.
 - Show: "`gh` unavailable. To add a remote later: `gh auth login` then `gh repo create {{vault_name}} --private --source=. --push`."
 
@@ -694,6 +759,7 @@ When `has_tracked_repos = true`, copy this block verbatim in place of the `{{syn
 Sync the docs of external GitHub repos (frameworks, tools, projects you follow) into `raw/`, while strictly preserving immutability.
 
 **Manifest**: `tracked-repos.config.json` at the vault root. Fields per source:
+
 - `name` (slug, invocation key), `repo` (`owner/name` GitHub, e.g. `vercel/next.js`, `nf-core/sarek`, `your-org/your-repo`), `branch` (typically `main`)
 - `dest` (vault-relative path, without the `<shortsha>/`) — free, you define the layout
 - `paths` (optional, default `default_paths` of the manifest) — only those paths are copied from the clone
@@ -704,10 +770,12 @@ Manifest-level defaults: `default_paths` and `default_exclude_paths`. These defa
 **SHA-keyed snapshot principle.** Each sync creates `<dest>/<shortsha>/` (shortsha = first 7 chars of the HEAD SHA of `branch`). If that folder already exists → skip. A merge into `main` upstream = a new SHA = a new snapshot beside the old. Old snapshots are **never** modified or deleted.
 
 **Target resolution** (main context):
+
 - no argument → interactive multiSelect (`AskUserQuestion`) over manifest sources, to avoid an unintended "sync all".
 - explicit names (`next sarek`) → those sources.
 
 **Mechanics** (`scripts/sync-repos.sh`):
+
 1. `gh api repos/<repo>/commits/<branch>` → HEAD SHA.
 2. If `<dest>/<shortsha>/` exists → `SKIPPED`.
 3. Otherwise: `gh repo clone --depth=1 -b <branch>` into `cache/sync-repos/<name>/`, copy listed `paths` to `<dest>/<shortsha>/`, write `.sync-meta.json` (repo, branch, sha, synced_at, paths), clean up the clone.
@@ -715,6 +783,7 @@ Manifest-level defaults: `default_paths` and `default_exclude_paths`. These defa
 **Chaining `/ingest`.** For each `CREATED <path>` line surfaced by the script: chain `/ingest <path>` sequentially.
 
 **Logging.** Entry in `wiki/log.md`:
+
 ```
 ## [YYYY-MM-DD] sync-repos | N snapshots created
 <list>
@@ -725,4 +794,4 @@ Manifest-level defaults: `default_paths` and `default_exclude_paths`. These defa
 
 ---
 
-*End of the portable prompt. Now run Section 2.*
+_End of the portable prompt. Now run Section 2._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`revisit_after` frontmatter field** on `type: decision` and `type: concept` pages (opt-in). (#18)
 - **`/lint`**: flag ADRs ≥ 90 days without `verdict`, and pages whose `revisit_after` is past. (#18)
 
+### Added (CI revamp for living vaults)
+
+- **CI recalibrated for content vaults** — `.github/workflows/lint.yml` no longer blocks on inevitable noise. Three blocking jobs on push/PR: `format-check` (Prettier `--check`), `markdownlint` (semantic rules only), and `wiki-integrity` (new); plus a weekly **non-blocking** `link-check-report` for external links (lychee, `fail: false`) instead of failing every push on dead third-party URLs. Rationale: the remote vault is a read-only artifact (`raw/` and the LLM are local-only), so CI does deterministic validation only — it blocks on what is repairable and meaningful, never on inevitable noise (rotting web links, cosmetic style of generated content).
+- **Prettier as the markdown formatter** — new `.prettierrc` (`proseWrap: preserve`) and `.prettierignore` (excludes `raw/`, `node_modules/`, `.claude/worktrees/`). Markdown is clean and consistent by construction. `.markdownlint.jsonc` recalibrated to **semantic rules only** (MD056 table-column-count, MD042 empty-links, MD051 link-fragments, MD024) and disables the cosmetic rules now owned by Prettier — including **MD060** pre-emptively (invisible on the action's markdownlint v0.34 but explodes on upgrade).
+- **`scripts/wiki-maint/validate-wiki.py`** (+ `test_validate_wiki.py`, 18 stdlib `unittest` tests) — deterministic integrity checker for broken `[[wikilinks]]`, broken internal relative links/anchors, and per-type frontmatter conformance (required fields present, `domains` non-empty, `summary_l0` ≤140 mono-line, `summary_l1` present — both required for tiered loading). Vocabulary is **open** (no closed `type`/`status` list — judging vocabulary is the semantic `/lint`'s job). Skips `raw/` targets (local-only) and understands Obsidian table-alias escapes (`[[target\|alias]]`).
+- **`/format`** — new command running `prettier --write` on demand and for the one-shot normalisation of a pre-formatter vault.
+- **Generation commands format their output** — `/ingest`, `/save`, `/evolve-agent`, `/compress-bb` run `prettier --write` on the markdown they produce, keeping the CI `format-check` job green.
+- **`/lint`** — now also verifies that the `raw/` source files cited in each page's `sources:` exist on disk (the local counterpart of the CI, which cannot see `raw/`).
+
 ### Fixed (alpha feedback)
 
 - **`/compress-bb`**: document "When NOT to use" to avoid redundancy with substantive `raw/notes/` (#22).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ Launch readiness pass: every file shipped at bootstrap or propagated by `/update
 
 ### Fixed
 
-- **Source language vs vault language decoupling.** Before this fix, `CLAUDE.md.tpl` had `Français` hardcoded in its writing principles, and `domain-expert.md.tpl` had "titres en français". Consequence: an EN user bootstrapped a vault and every page produced by `/ingest` came out in French regardless of the source. The new `{{vault_language}}` placeholder + the explicit directive (*"Source language has no incidence on output language; quote sources verbatim, write commentary in the vault language"*) close that loop.
+- **Source language vs vault language decoupling.** Before this fix, `CLAUDE.md.tpl` had `Français` hardcoded in its writing principles, and `domain-expert.md.tpl` had "titres en français". Consequence: an EN user bootstrapped a vault and every page produced by `/ingest` came out in French regardless of the source. The new `{{vault_language}}` placeholder + the explicit directive (_"Source language has no incidence on output language; quote sources verbatim, write commentary in the vault language"_) close that loop.
 - **`/ingest-video` visual-mention detection was FR-only.** The `visual_mentions` counter relied on a regex of FR phrases (`regardez`, `voilà`, `cette grille`…), so on EN transcripts the counter silently stayed at 0 and Mode B (cross-induction) was never recommended. The pattern list is now bilingual EN+FR (extensible to other languages), restoring the recommendation logic for non-FR transcripts.
 
 ### Repo-level (post-merge, not in code)
@@ -138,7 +138,7 @@ Launch readiness pass: every file shipped at bootstrap or propagated by `/update
 These actions happen at release time outside the PR diff but are part of the v1.0.3 launch readiness:
 
 - **Default branch** switched from `develop` to `main` (the v1.0.3 commit is the cutover point).
-- **GitHub description** updated to *"Opinionated implementation of Karpathy's LLM Wiki pattern — maintained by domain-expert agents (Claude Code)."* (mentions Karpathy for post-thread discoverability).
+- **GitHub description** updated to _"Opinionated implementation of Karpathy's LLM Wiki pattern — maintained by domain-expert agents (Claude Code)."_ (mentions Karpathy for post-thread discoverability).
 - **GitHub topics** expanded to 8–10 covering `karpathy`, `llm-wiki`, `personal-knowledge-base`, `pkm`, `second-brain`, `claude-code`, `obsidian`, `agent-based`, `wiki-template`.
 - **Seed issues** opened to signal a live project (Bootstrap support for non-Claude-Code agents; "before/after" walkthrough; share-your-instance discussion).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,20 +18,20 @@ Thanks for your interest in BoilingBrain. This project is opinionated — the op
 
 This repo uses a simple [git flow](https://nvie.com/posts/a-successful-git-branching-model/) layout:
 
-| Branch | Role |
-|---|---|
-| `main` | Tagged releases only (`vX.Y.Z`). Updated by merging `develop` at release time. Protected. |
-| `develop` | **Default branch.** Integration line — all contributions land here first. Protected. |
-| `feature/<issue>-slug` | New feature, branched from `develop`, merged back to `develop`. |
-| `fix/<issue>-slug` | Bug fix, branched from `develop`, merged back to `develop`. |
-| `docs/<topic>` | Doc-only change, branched from `develop`, merged back to `develop`. |
+| Branch                 | Role                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `main`                 | Tagged releases only (`vX.Y.Z`). Updated by merging `develop` at release time. Protected. |
+| `develop`              | **Default branch.** Integration line — all contributions land here first. Protected.      |
+| `feature/<issue>-slug` | New feature, branched from `develop`, merged back to `develop`.                           |
+| `fix/<issue>-slug`     | Bug fix, branched from `develop`, merged back to `develop`.                               |
+| `docs/<topic>`         | Doc-only change, branched from `develop`, merged back to `develop`.                       |
 
 Contributor flow:
 
 1. **Open an issue** describing the bug or feature (skip only for trivial doc fixes).
 2. **Fork** the repo (external contributors) or create a branch directly (maintainers).
 3. **Branch from `develop`** with the naming convention above. Example: `feature/42-add-spanish-bootstrap`.
-4. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, …). Describe the *why*, not the *what*.
+4. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, …). Describe the _why_, not the _what_.
 5. **Open a PR targeting `develop`** (not `main`). Fill the PR template, link the issue.
 6. CI must pass and at least one approval is required before merge.
 7. Merges into `develop` use **squash merge** (one clean commit per PR).
@@ -58,7 +58,7 @@ The most consequential file is `BOOTSTRAP.md`. To test a change:
 - All in-prompt user-facing text in `BOOTSTRAP.md` is **French**. Translations (English, Spanish, etc.) would be a separate effort — not blocking for v1.
 - `*.tpl` files use `{{placeholder}}` syntax. New placeholders must be documented in `PLACEHOLDERS.md`.
 - No emojis in code or wiki files unless requested. Status indicators in BOOTSTRAP.md (✅, ⭐, etc.) are an exception.
-- Commit messages : describe the *why*, not the *what*. Reference the relevant phase if applicable (`phase 5c: <fix>`).
+- Commit messages : describe the _why_, not the _what_. Reference the relevant phase if applicable (`phase 5c: <fix>`).
 
 ## Code of Conduct
 

--- a/PLACEHOLDERS.md
+++ b/PLACEHOLDERS.md
@@ -4,27 +4,27 @@ This file documents every `{{placeholder}}` used in the `*.tpl` files of this te
 
 ## Global placeholders (one value per instance)
 
-| Placeholder | Type | Source / How to derive | Used in |
-|---|---|---|---|
-| `{{name}}` | string | Interview Q1 (full name) | `CLAUDE.md.tpl`, `overview.md.tpl`, `index.md.tpl` |
-| `{{vault_name}}` | string | Interview Q (vault name, defaults to a slug of `{{name}}`) | `CLAUDE.md.tpl` |
-| `{{vault_language}}` | human-readable language label | Detected at the very start of the interview from the user's first messages (e.g. `English`, `Français`, `Español`, `Deutsch`, `日本語`). This is the language **all wiki pages will be written in**, regardless of source language. Confirm with the user during validation if uncertain. | `CLAUDE.md.tpl`, `domain-expert.md.tpl` |
-| `{{role}}` | string | Interview Q (current role / title) | `CLAUDE.md.tpl`, `overview.md.tpl` |
-| `{{parcours_short}}` | markdown bullet list, 2-4 lines | Interview Q (career, in 2-3 bullets) | `overview.md.tpl` |
-| `{{bootstrap_date}}` | YYYY-MM-DD | `date +%Y-%m-%d` at bootstrap time | `overview.md.tpl`, `index.md.tpl`, `radar.md.tpl`, `domain.md.tpl` (per-domain) |
-| `{{has_tracked_repos}}` | boolean | Interview Q (do you want to track GitHub repos via `/sync-repos`?) | Conditional: keeps or removes `tracked-repos.config.json.tpl`, `scripts/sync-repos.sh`, `.claude/commands/sync-repos.md`, `docs/tracked-repos-immutable-snapshots.md`, and several blocks inside `CLAUDE.md.tpl` |
+| Placeholder             | Type                            | Source / How to derive                                                                                                                                                                                                                                                                    | Used in                                                                                                                                                                                                          |
+| ----------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{{name}}`              | string                          | Interview Q1 (full name)                                                                                                                                                                                                                                                                  | `CLAUDE.md.tpl`, `overview.md.tpl`, `index.md.tpl`                                                                                                                                                               |
+| `{{vault_name}}`        | string                          | Interview Q (vault name, defaults to a slug of `{{name}}`)                                                                                                                                                                                                                                | `CLAUDE.md.tpl`                                                                                                                                                                                                  |
+| `{{vault_language}}`    | human-readable language label   | Detected at the very start of the interview from the user's first messages (e.g. `English`, `Français`, `Español`, `Deutsch`, `日本語`). This is the language **all wiki pages will be written in**, regardless of source language. Confirm with the user during validation if uncertain. | `CLAUDE.md.tpl`, `domain-expert.md.tpl`                                                                                                                                                                          |
+| `{{role}}`              | string                          | Interview Q (current role / title)                                                                                                                                                                                                                                                        | `CLAUDE.md.tpl`, `overview.md.tpl`                                                                                                                                                                               |
+| `{{parcours_short}}`    | markdown bullet list, 2-4 lines | Interview Q (career, in 2-3 bullets)                                                                                                                                                                                                                                                      | `overview.md.tpl`                                                                                                                                                                                                |
+| `{{bootstrap_date}}`    | YYYY-MM-DD                      | `date +%Y-%m-%d` at bootstrap time                                                                                                                                                                                                                                                        | `overview.md.tpl`, `index.md.tpl`, `radar.md.tpl`, `domain.md.tpl` (per-domain)                                                                                                                                  |
+| `{{has_tracked_repos}}` | boolean                         | Interview Q (do you want to track GitHub repos via `/sync-repos`?)                                                                                                                                                                                                                        | Conditional: keeps or removes `tracked-repos.config.json.tpl`, `scripts/sync-repos.sh`, `.claude/commands/sync-repos.md`, `docs/tracked-repos-immutable-snapshots.md`, and several blocks inside `CLAUDE.md.tpl` |
 
 ### Conditional sections in `CLAUDE.md.tpl`
 
 These are filled or removed based on `{{has_tracked_repos}}` and other flags:
 
-| Placeholder | When `false` | When `true` |
-|---|---|---|
-| `{{slash_commands_extras}}` | `` (empty) | `, /sync-repos` |
-| `{{tracked_repos_arborescence}}` | `` | `  tracked-repos/     # snapshots par SHA des repos GitHub suivis (<repo>/<shortsha>/)\n` |
-| `{{tracked_repos_cache}}` | `` | `  sync-repos/          # clones --depth=1 temporaires utilisés par /sync-repos, purgés en fin de sync\n\n` |
-| `{{tracked_repos_scripts_extras}}` | `` | `, sync-repos` |
-| `{{sync_repos_section}}` | `\n` | full `### SYNC-REPOS` section copied from the reference doc |
+| Placeholder                        | When `false` | When `true`                                                                                                 |
+| ---------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `{{slash_commands_extras}}`        | `` (empty)   | `, /sync-repos`                                                                                             |
+| `{{tracked_repos_arborescence}}`   | ``           | `  tracked-repos/     # snapshots par SHA des repos GitHub suivis (<repo>/<shortsha>/)\n`                   |
+| `{{tracked_repos_cache}}`          | ``           | `  sync-repos/          # clones --depth=1 temporaires utilisés par /sync-repos, purgés en fin de sync\n\n` |
+| `{{tracked_repos_scripts_extras}}` | ``           | `, sync-repos`                                                                                              |
+| `{{sync_repos_section}}`           | `\n`         | full `### SYNC-REPOS` section copied from the reference doc                                                 |
 
 ## Domain-driven placeholders (one set per declared domain)
 
@@ -36,41 +36,41 @@ The bootstrap prompt loops over the domains the user declared (3-6 typically) an
 
 Per-domain placeholders:
 
-| Placeholder | Type | Source | Used in |
-|---|---|---|---|
-| `{{domain_slug}}` | kebab-case slug | Interview (e.g. `poker`, `ai`, `astro-physics`) | all three files |
-| `{{domain_label}}` | human label | Interview (e.g. `Poker`, `AI`, `Astronomy & Physics`) | all three files |
-| `{{is_hub_pivot}}` | boolean | At most one domain marked hub-pivot | `domain.md.tpl`, `domain-expert.md.tpl` |
-| `{{hub_pivot_marker}}` | string | If `is_hub_pivot` → ` **Domaine pivot** : irrigue les autres domaines.` else `` | `domain.md.tpl` |
-| `{{summary_l0}}` | ≤140 chars | LLM-generated from the domain description | `domain.md.tpl` frontmatter |
-| `{{summary_l1}}` | 2-5 sentences | LLM-generated from the domain description | `domain.md.tpl` frontmatter |
-| `{{domain_intro_paragraph}}` | 1-2 lines | LLM-generated short intro (« Hub dédié à X. Y. ») | `domain.md.tpl` |
-| `{{taxonomy_section}}` | bullet list of sub-topics | Interview (3-8 sub-themes per domain) | `domain.md.tpl` |
-| `{{related_domains_section}}` | optional H2 with cross-refs | Computed from cross-domain dependencies declared at interview | `domain.md.tpl` |
-| `{{deliverables}}` | YAML list | Interview (e.g. `[cheatsheets, syntheses]`) | `domain-expert.md.tpl` |
-| `{{deliverables_signature_block}}` | markdown block describing the agent's signature deliverable | Built from `{{deliverables}}` | `domain-expert.md.tpl` |
-| `{{trigger_examples}}` | comma-separated list | LLM-generated from the domain description (4-6 verbal triggers for visual frames) | `domain-expert.md.tpl` |
-| `{{frames_visual_formats}}` | markdown bullet list | LLM-generated from the domain (e.g. `Mermaid diagrams`, `LaTeX equations`, `13×13 grids`) | `domain-expert.md.tpl` |
-| `{{co_ingest_partners}}` | list of domain slugs | Interview (per domain, which other domains often share sources?) | `domain-expert.md.tpl` |
-| `{{co_ingest_section}}` | markdown block | Built from `{{co_ingest_partners}}`; empty if no partners | `domain-expert.md.tpl` |
-| `{{authority_table_enabled}}` | boolean | True for "reflexive" domains where source authority matters (AI, science, industry analysis) | `domain-expert.md.tpl` |
-| `{{authority_table_section}}` | markdown block | Built from `{{authority_table_enabled}}`; empty otherwise | `domain-expert.md.tpl` |
-| `{{confidentiality_block}}` | markdown block | Filled if the domain involves sensitive data (typically work / management); empty otherwise | `domain-expert.md.tpl` |
-| `{{confidentiality_section}}` | markdown block | `{{confidentiality_block}}` wrapped in an H2 heading; empty if no sensitivity flag | `domain-expert.md.tpl` |
-| `{{domain_specific_observation_section}}` | markdown bullet list | LLM-generated from the domain's typical "what you watch for in a source" angles (calqued on poker-expert / ia-expert in the reference instance) | `domain-expert.md.tpl` |
-| `{{model}}` | `sonnet` or `haiku` | Interview / heuristic on domain density (dense reflexive domains → sonnet) | `domain-expert.md.tpl` frontmatter |
-| `{{effort}}` | `high` or `medium` | Same heuristic | `domain-expert.md.tpl` frontmatter |
-| `{{maxTurns}}` | `60` or `80` | Same heuristic | `domain-expert.md.tpl` frontmatter |
+| Placeholder                               | Type                                                        | Source                                                                                                                                          | Used in                                 |
+| ----------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `{{domain_slug}}`                         | kebab-case slug                                             | Interview (e.g. `poker`, `ai`, `astro-physics`)                                                                                                 | all three files                         |
+| `{{domain_label}}`                        | human label                                                 | Interview (e.g. `Poker`, `AI`, `Astronomy & Physics`)                                                                                           | all three files                         |
+| `{{is_hub_pivot}}`                        | boolean                                                     | At most one domain marked hub-pivot                                                                                                             | `domain.md.tpl`, `domain-expert.md.tpl` |
+| `{{hub_pivot_marker}}`                    | string                                                      | If `is_hub_pivot` → ` **Domaine pivot** : irrigue les autres domaines.` else ``                                                                 | `domain.md.tpl`                         |
+| `{{summary_l0}}`                          | ≤140 chars                                                  | LLM-generated from the domain description                                                                                                       | `domain.md.tpl` frontmatter             |
+| `{{summary_l1}}`                          | 2-5 sentences                                               | LLM-generated from the domain description                                                                                                       | `domain.md.tpl` frontmatter             |
+| `{{domain_intro_paragraph}}`              | 1-2 lines                                                   | LLM-generated short intro (« Hub dédié à X. Y. »)                                                                                               | `domain.md.tpl`                         |
+| `{{taxonomy_section}}`                    | bullet list of sub-topics                                   | Interview (3-8 sub-themes per domain)                                                                                                           | `domain.md.tpl`                         |
+| `{{related_domains_section}}`             | optional H2 with cross-refs                                 | Computed from cross-domain dependencies declared at interview                                                                                   | `domain.md.tpl`                         |
+| `{{deliverables}}`                        | YAML list                                                   | Interview (e.g. `[cheatsheets, syntheses]`)                                                                                                     | `domain-expert.md.tpl`                  |
+| `{{deliverables_signature_block}}`        | markdown block describing the agent's signature deliverable | Built from `{{deliverables}}`                                                                                                                   | `domain-expert.md.tpl`                  |
+| `{{trigger_examples}}`                    | comma-separated list                                        | LLM-generated from the domain description (4-6 verbal triggers for visual frames)                                                               | `domain-expert.md.tpl`                  |
+| `{{frames_visual_formats}}`               | markdown bullet list                                        | LLM-generated from the domain (e.g. `Mermaid diagrams`, `LaTeX equations`, `13×13 grids`)                                                       | `domain-expert.md.tpl`                  |
+| `{{co_ingest_partners}}`                  | list of domain slugs                                        | Interview (per domain, which other domains often share sources?)                                                                                | `domain-expert.md.tpl`                  |
+| `{{co_ingest_section}}`                   | markdown block                                              | Built from `{{co_ingest_partners}}`; empty if no partners                                                                                       | `domain-expert.md.tpl`                  |
+| `{{authority_table_enabled}}`             | boolean                                                     | True for "reflexive" domains where source authority matters (AI, science, industry analysis)                                                    | `domain-expert.md.tpl`                  |
+| `{{authority_table_section}}`             | markdown block                                              | Built from `{{authority_table_enabled}}`; empty otherwise                                                                                       | `domain-expert.md.tpl`                  |
+| `{{confidentiality_block}}`               | markdown block                                              | Filled if the domain involves sensitive data (typically work / management); empty otherwise                                                     | `domain-expert.md.tpl`                  |
+| `{{confidentiality_section}}`             | markdown block                                              | `{{confidentiality_block}}` wrapped in an H2 heading; empty if no sensitivity flag                                                              | `domain-expert.md.tpl`                  |
+| `{{domain_specific_observation_section}}` | markdown bullet list                                        | LLM-generated from the domain's typical "what you watch for in a source" angles (calqued on poker-expert / ia-expert in the reference instance) | `domain-expert.md.tpl`                  |
+| `{{model}}`                               | `sonnet` or `haiku`                                         | Interview / heuristic on domain density (dense reflexive domains → sonnet)                                                                      | `domain-expert.md.tpl` frontmatter      |
+| `{{effort}}`                              | `high` or `medium`                                          | Same heuristic                                                                                                                                  | `domain-expert.md.tpl` frontmatter      |
+| `{{maxTurns}}`                            | `60` or `80`                                                | Same heuristic                                                                                                                                  | `domain-expert.md.tpl` frontmatter      |
 
 ## Cross-domain placeholders (computed from the full domain list)
 
-| Placeholder | Type | Computation | Used in |
-|---|---|---|---|
-| `{{domains_section}}` | numbered markdown list with one-line descriptions | Iterate over domains | `CLAUDE.md.tpl` |
-| `{{domains_index_section}}` | bullet list of `[[domains/<slug>]]` links | Iterate over domains | `index.md.tpl` |
-| `{{domains_links}}` | bullet list (same idea, slightly different formatting) | Iterate over domains | `overview.md.tpl` |
-| `{{projects_links}}` | bullet list of personal projects | Interview Q (do you have personal projects to declare in `overview.md`?) — if none, use a placeholder « (à compléter) » | `overview.md.tpl` |
-| `{{agents_section}}` | bullet list of `<domain>-expert` with their signature deliverable | Iterate over domains | `CLAUDE.md.tpl` |
+| Placeholder                 | Type                                                              | Computation                                                                                                             | Used in           |
+| --------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `{{domains_section}}`       | numbered markdown list with one-line descriptions                 | Iterate over domains                                                                                                    | `CLAUDE.md.tpl`   |
+| `{{domains_index_section}}` | bullet list of `[[domains/<slug>]]` links                         | Iterate over domains                                                                                                    | `index.md.tpl`    |
+| `{{domains_links}}`         | bullet list (same idea, slightly different formatting)            | Iterate over domains                                                                                                    | `overview.md.tpl` |
+| `{{projects_links}}`        | bullet list of personal projects                                  | Interview Q (do you have personal projects to declare in `overview.md`?) — if none, use a placeholder « (à compléter) » | `overview.md.tpl` |
+| `{{agents_section}}`        | bullet list of `<domain>-expert` with their signature deliverable | Iterate over domains                                                                                                    | `CLAUDE.md.tpl`   |
 
 ## Total
 
@@ -79,6 +79,7 @@ Per-domain placeholders:
 - **Cross-domain placeholders** (computed from full domain list): 5
 
 The bootstrap prompt's job is to:
+
 1. Run a structured interview filling the global + per-domain inputs.
 2. Compute the cross-domain placeholders from the collected data.
 3. For each `*.tpl` file, substitute placeholders and write to the final path (renaming to drop the `.tpl` suffix).

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ The pattern follows Karpathy's "knowledge compilation" idea: keep the source of 
 
 Karpathy's LLM Wiki is a **concept**: notes maintained by an LLM, with the LLM filling cross-references and refactoring on demand. BoilingBrain is an **opinionated, runnable implementation** of that concept — with concrete trade-offs you can either accept or fork. Specifically :
 
-| Dimension | Karpathy's sketch | BoilingBrain |
-|---|---|---|
-| **Source of truth** | Notes in a folder, LLM rewrites freely | `raw/` is immutable, hash-addressed (`source_sha256`); the wiki layer is always derivable |
-| **Agent topology** | One LLM doing everything | One **expert agent per domain**, declared at bootstrap, with deliverable signatures (cheatsheets, syntheses, diagrams) and per-domain prompts that evolve over time via `/evolve-agent` |
-| **Idempotence** | Manual | `/ingest` is hash-based and idempotent — re-running doesn't duplicate; `--force` re-applies new agent reflexes to existing sources |
-| **Multimodal** | Text-only typically | First-class video pipeline (`/ingest-video`): download → transcribe → frame extraction (mode A declarative or mode B image-diff induction) → markdown transcription of visuals (tables, Mermaid, LaTeX) so queries don't re-OCR each time |
-| **Queries at scale** | Load and read | **Tiered loading**: every page carries `summary_l0` (≤140 chars) + `summary_l1` (~50-150 words). Agents scan a domain via TOC L0, descend to L1 then L2 only when relevant — sublinear in body size |
-| **External code/docs** | Out of scope | `/sync-repos` snapshots GitHub repos by SHA into `raw/tracked-repos/<sha>/`, immutable, never overwritten |
-| **Self-improvement** | Implicit, ad-hoc | Explicit human-curated loop: each agent appends `Evolution suggestions` per ingest, `/evolve-agent <domain>` reviews + applies the diff, archives integrated suggestions |
-| **Architectural decisions** | Mixed into notes | ADR-lite in `wiki/decisions/` with a fixed structure (Problem → Options → Decision → Why → Open questions) |
+| Dimension                   | Karpathy's sketch                      | BoilingBrain                                                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Source of truth**         | Notes in a folder, LLM rewrites freely | `raw/` is immutable, hash-addressed (`source_sha256`); the wiki layer is always derivable                                                                                                                                                 |
+| **Agent topology**          | One LLM doing everything               | One **expert agent per domain**, declared at bootstrap, with deliverable signatures (cheatsheets, syntheses, diagrams) and per-domain prompts that evolve over time via `/evolve-agent`                                                   |
+| **Idempotence**             | Manual                                 | `/ingest` is hash-based and idempotent — re-running doesn't duplicate; `--force` re-applies new agent reflexes to existing sources                                                                                                        |
+| **Multimodal**              | Text-only typically                    | First-class video pipeline (`/ingest-video`): download → transcribe → frame extraction (mode A declarative or mode B image-diff induction) → markdown transcription of visuals (tables, Mermaid, LaTeX) so queries don't re-OCR each time |
+| **Queries at scale**        | Load and read                          | **Tiered loading**: every page carries `summary_l0` (≤140 chars) + `summary_l1` (~50-150 words). Agents scan a domain via TOC L0, descend to L1 then L2 only when relevant — sublinear in body size                                       |
+| **External code/docs**      | Out of scope                           | `/sync-repos` snapshots GitHub repos by SHA into `raw/tracked-repos/<sha>/`, immutable, never overwritten                                                                                                                                 |
+| **Self-improvement**        | Implicit, ad-hoc                       | Explicit human-curated loop: each agent appends `Evolution suggestions` per ingest, `/evolve-agent <domain>` reviews + applies the diff, archives integrated suggestions                                                                  |
+| **Architectural decisions** | Mixed into notes                       | ADR-lite in `wiki/decisions/` with a fixed structure (Problem → Options → Decision → Why → Open questions)                                                                                                                                |
 
-Said otherwise: Karpathy says "let LLMs maintain a wiki." BoilingBrain says "*here's what the wiki layout, the agent contract, the ingest protocol and the evolution loop need to look like for that to actually scale past a few weeks of use.*" The opinions come from real usage — fork them if they don't fit.
+Said otherwise: Karpathy says "let LLMs maintain a wiki." BoilingBrain says "_here's what the wiki layout, the agent contract, the ingest protocol and the evolution loop need to look like for that to actually scale past a few weeks of use._" The opinions come from real usage — fork them if they don't fit.
 
 ## Prerequisites
 
@@ -60,7 +60,7 @@ Then in Claude Code:
 Read BOOTSTRAP.md and run the prompt.
 ```
 
-*Works in any language — the bootstrap interview adapts to your phrasing.*
+_Works in any language — the bootstrap interview adapts to your phrasing._
 
 The interview takes 5-10 minutes. At the end your vault is personalized, the template's git history is reset, and you can run your first `/ingest`. Then open `~/my-vault` in Obsidian and check the graph view.
 
@@ -158,19 +158,19 @@ New scripts should be placed in the existing feature directory that best fits th
 
 ## Slash commands shipped
 
-| Command | Purpose |
-|---|---|
-| `/ingest [path]` | Batch idempotent ingestion of files from `raw/` via domain experts. Hash-based, no duplicates. |
-| `/ingest-video <path-or-url>` | Pipeline: download → transcribe → ingest transcript → propose frame extraction (mode A / B / skip). |
-| `/query <question>` | Answer from indexed pages with citations; optionally archive the synthesis. |
-| `/save <slug>` | Archive the current synthesis into `wiki/syntheses/<slug>.md`. |
-| `/lint [domain]` | Detect contradictions, orphans, missing cross-references, gaps. |
-| `/evolve-agent <domain>` | Curated update to a domain expert's prompt, fed by accumulated `.suggestions.md`. |
+| Command                                | Purpose                                                                                                                                                                                                                        |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/ingest [path]`                       | Batch idempotent ingestion of files from `raw/` via domain experts. Hash-based, no duplicates.                                                                                                                                 |
+| `/ingest-video <path-or-url>`          | Pipeline: download → transcribe → ingest transcript → propose frame extraction (mode A / B / skip).                                                                                                                            |
+| `/query <question>`                    | Answer from indexed pages with citations; optionally archive the synthesis.                                                                                                                                                    |
+| `/save <slug>`                         | Archive the current synthesis into `wiki/syntheses/<slug>.md`.                                                                                                                                                                 |
+| `/lint [domain]`                       | Detect contradictions, orphans, missing cross-references, gaps.                                                                                                                                                                |
+| `/evolve-agent <domain>`               | Curated update to a domain expert's prompt, fed by accumulated `.suggestions.md`.                                                                                                                                              |
 | `/domain <add\|rename\|remove> <slug>` | Manage a domain's lifecycle post-bootstrap. Scans the vault, presents impact by bucket (canonical / frontmatter / wikilink / alias / composed / prose / log-tag / historical / drift), validates ambiguous cases case-by-case. |
-| `/sync-repos [names]` *(optional)* | Snapshot GitHub repos by SHA into `raw/tracked-repos/` (or any `dest` declared per source). |
-| `/update-vault` | Cherry-pick improvements from the upstream template into your vault instance (versioned migration machine). |
-| `/create-issue [type]` | Sanitize a draft and open an issue on the upstream template repo (auto-strips wikilinks, vault-specific slugs, private paths). Always validated by you before `gh issue create`. |
-| `/compress-bb` | Save the current session journal to `raw/notes/sessions/` for later ingestion. |
+| `/sync-repos [names]` _(optional)_     | Snapshot GitHub repos by SHA into `raw/tracked-repos/` (or any `dest` declared per source).                                                                                                                                    |
+| `/update-vault`                        | Cherry-pick improvements from the upstream template into your vault instance (versioned migration machine).                                                                                                                    |
+| `/create-issue [type]`                 | Sanitize a draft and open an issue on the upstream template repo (auto-strips wikilinks, vault-specific slugs, private paths). Always validated by you before `gh issue create`.                                               |
+| `/compress-bb`                         | Save the current session journal to `raw/notes/sessions/` for later ingestion.                                                                                                                                                 |
 
 ## MCP server (optional, v1.1+)
 
@@ -178,16 +178,16 @@ Run `bash scripts/mcp/setup-mcp.sh` once after bootstrap to register the `boilin
 
 **12 tools** are exposed, organised as a tiered-loading hierarchy (orient → drill → read). Full reference: [docs/mcp-tiered-loading.md](docs/mcp-tiered-loading.md).
 
-| Tool | Purpose |
-|---|---|
-| `scan_domain(domain)` | **Orient**: hub `summary_l1` + counts per type + top 10 pages by centrality (backlinks). ~860 tokens. Use FIRST. |
-| `scan_concepts(domain, query="", top=20)` | **Drill**: concepts in a domain, ranked by centrality. Optional query (case + separator insensitive). |
-| `scan_entities`, `scan_decisions`, `scan_syntheses`, `scan_cheatsheets`, `scan_diagrams` | Same semantics, per type. |
-| `scan_sources(domain, query, top=20)` | Same shape but query is **required** (sources too numerous without a target). |
-| `preview_page(page_path)` | L1: frontmatter (whitelisted fields) + `summary_l1`. |
-| `read_page(page_path)` | L2: full body. |
-| `search_wiki(query, limit=10)` | Cross-type, cross-domain. Format enriched: path, type, summary_l0, outgoing wikilinks. |
-| `drop_to_raw(subfolder, filename, content)` | Sanctioned write into `raw/` (server-side, bypasses the `protect-raw.sh` hook by design). Auto-signals via `cache/.pending-ingest`. |
+| Tool                                                                                     | Purpose                                                                                                                             |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `scan_domain(domain)`                                                                    | **Orient**: hub `summary_l1` + counts per type + top 10 pages by centrality (backlinks). ~860 tokens. Use FIRST.                    |
+| `scan_concepts(domain, query="", top=20)`                                                | **Drill**: concepts in a domain, ranked by centrality. Optional query (case + separator insensitive).                               |
+| `scan_entities`, `scan_decisions`, `scan_syntheses`, `scan_cheatsheets`, `scan_diagrams` | Same semantics, per type.                                                                                                           |
+| `scan_sources(domain, query, top=20)`                                                    | Same shape but query is **required** (sources too numerous without a target).                                                       |
+| `preview_page(page_path)`                                                                | L1: frontmatter (whitelisted fields) + `summary_l1`.                                                                                |
+| `read_page(page_path)`                                                                   | L2: full body.                                                                                                                      |
+| `search_wiki(query, limit=10)`                                                           | Cross-type, cross-domain. Format enriched: path, type, summary_l0, outgoing wikilinks.                                              |
+| `drop_to_raw(subfolder, filename, content)`                                              | Sanctioned write into `raw/` (server-side, bypasses the `protect-raw.sh` hook by design). Auto-signals via `cache/.pending-ingest`. |
 
 **Recommended pattern**: `scan_domain` → `scan_<type>(query=...)` → `preview_page` → `read_page`. Measured: ~96% token reduction vs a flat dump on a 388-page domain.
 
@@ -211,7 +211,7 @@ The template ships with **opt-in scaffolding** for the L3 layer of personal know
 
 - You're a **solo dev, researcher, PM or writer** building a personal knowledge base across 3-6 domains.
 - You already use **Claude Code** (CLI, desktop app, IDE extension, or claude.ai/code) and **Obsidian** — or want to.
-- You want a **thinking partner** that grounds its answers in *your* sources (with citations), not a chatbot guessing from training data.
+- You want a **thinking partner** that grounds its answers in _your_ sources (with citations), not a chatbot guessing from training data.
 - You'd rather **have an opinion than a blank page**: hash-keyed `raw/`, one expert agent per domain, mandatory frontmatter — these constraints feel like a feature, not a friction.
 - You want a vault that **scales past a few weeks** without falling into the "200 unlinked notes" trap.
 - You enjoy **owning your wiki layer** (the LLM writes it, you curate the prompts and the diff).
@@ -281,4 +281,4 @@ This template is opinionated. The opinions come from real usage. If you have a g
 
 ---
 
-*Generated as part of the Phase 2 scaffolding of the LLM Wiki bootstrap.*
+_Generated as part of the Phase 2 scaffolding of the LLM Wiki bootstrap._

--- a/docs/extraction-frames-induction-runbook.md
+++ b/docs/extraction-frames-induction-runbook.md
@@ -30,15 +30,16 @@ Long videos (>30 min) — coachings, conferences, software demos, UI tutorials, 
 
 **Default cadence by video type**:
 
-| Video type | Cadence | Typical sample volume |
-|---|---|---|
-| Dense coaching (matrix slides, grids, fast UI demos) | every 20 s | 100–250 |
-| Conference / talk with text slides | every 30 s | 60–150 |
-| Software demo / UI tutorial | every 20–30 s | 80–200 |
-| Punctuated interview / talking head | every 60 s | 30–80 |
-| Quiz / short slides | every 60 s | 30–60 |
+| Video type                                           | Cadence       | Typical sample volume |
+| ---------------------------------------------------- | ------------- | --------------------- |
+| Dense coaching (matrix slides, grids, fast UI demos) | every 20 s    | 100–250               |
+| Conference / talk with text slides                   | every 30 s    | 60–150                |
+| Software demo / UI tutorial                          | every 20–30 s | 80–200                |
+| Punctuated interview / talking head                  | every 60 s    | 30–80                 |
+| Quiz / short slides                                  | every 60 s    | 30–60                 |
 
 **Standard command** (packaged in [scripts/video/sample-frames.sh](../../scripts/video/sample-frames.sh)):
+
 ```bash
 scripts/video/sample-frames.sh "$VIDEO" /tmp/<slug>-samples/ [cadence_seconds]
 ```
@@ -52,6 +53,7 @@ Output: 1280×720 PNGs in the samples folder, plus a `.cadence` file remembering
 **Method**: for each `(sample_n, sample_n+1)` pair, compute the average grayscale pixel difference. Optionally restrict the computation to an **ROI** (region of interest) to ignore an unchanging zone (overlay, watermark, fixed webcam).
 
 **Command** (packaged in [scripts/video/diff-frames.py](../../scripts/video/diff-frames.py)):
+
 ```bash
 scripts/video/diff-frames.py /tmp/<slug>-samples/ \
   [--roi x,y,w,h] \
@@ -89,11 +91,13 @@ For domains with their own UI-recognition heuristics (see Domain annexes), enric
 **Critical goal**: validate every `KEEP` frame by looking at **what the speaker says ±30 s around the timestamp**.
 
 For each `KEEP` frame from the step 3 table:
+
 - Extract the transcript window `[t-30s, t+30s]`.
 - Annotate: main quote (short verbatim), concept addressed, justification (why this frame deserves extraction).
 - If the transcript window mentions **no pedagogical element justifying the frame** → **DOWNGRADE to SKIP** even if marked KEEP at cataloging.
 
 **Benefits**:
+
 - Avoids "pretty but not pedagogical" frames.
 - Allows attaching a quote to every promoted frame (directly reusable in the markdown transcription of step 9).
 - Guarantees that videos are covered proportionally to their actual pedagogical richness.
@@ -116,11 +120,13 @@ ffmpeg -nostdin -i "$VIDEO" -ss 00:HH:MM:SS -frames:v 1 -q:v 1 \
 **Goal**: settle final ambiguities and capture nuances agents miss.
 
 **Single batch mode** (preferred to reduce interruptions):
+
 - All extracted frames presented in a single `AskUserQuestion` multiSelect.
 - Per-frame options: Promote / Duplicate / Skip / Re-extract (±5 s).
 - The main context reads each PNG (Claude vision) and presents a synthetic textual description to help the user decide without manually opening each image.
 
 **Frame-by-frame mode** (fallback for highly ambiguous videos):
+
 - `open /tmp/<slug>-finals/<frame>.png` → opens in Preview.
 - `Read` the frame → description.
 - `AskUserQuestion` one by one.
@@ -130,6 +136,7 @@ ffmpeg -nostdin -i "$VIDEO" -ss 00:HH:MM:SS -frames:v 1 -q:v 1 \
 ### Step 7 — Physical promotion to `raw/frames/`
 
 For each "Promote" frame:
+
 ```bash
 cp /tmp/<slug>-finals/<frame>.png \
    raw/frames/YYYY-MM-DD-<source-slug>-<final-slug>.png
@@ -138,6 +145,7 @@ cp /tmp/<slug>-finals/<frame>.png \
 ### Step 8 — Re-spawn expert agent (forced re-ingest)
 
 Re-spawn the domain expert agent in **forced re-ingest mode** on the source page, with the following context:
+
 - The list of promoted frames (paths `raw/frames/...`).
 - The induction table (transcript quote ±30 s + concept per frame).
 - Explicit instruction to enrich the relevant wiki pages (`wiki/sources/`, `wiki/concepts/`, `wiki/cheatsheets/`, `wiki/syntheses/`) with these frames.
@@ -151,15 +159,15 @@ The expert agent stays free in their editorial choices (which frame goes into wh
 
 For each promoted frame, the expert agent opens the PNG (`Read`) and writes the transcription into the wiki page that consumes the frame. Format depends on the visual type:
 
-| Type | Transcription format | Structural example |
-|---|---|---|
-| **Table / grid** | Markdown table reproducing line by line, column by column | `\| col1 \| col2 \|` |
-| **Schema / diagram** | Mermaid if topology allows, otherwise structured node + relations list | ` ```mermaid\ngraph TD ... ` or `- Node A → Node B (relation)` |
-| **Code / terminal** | Code block with detected language, reproduces the readable content | ` ```python\n... ` or ` ```bash\n... ` |
-| **Dashboard / KPI** | Markdown list of indicators with values and units | `- p95 latency: 312 ms` |
-| **Text slide** | Title + bullets, literal reproduction | `### <title>\n- bullet 1\n- bullet 2` |
-| **Photo / illustration** | Semantic description: subject, composition, caption if visible | "Photograph of a telescope, visible caption 'M51 — 60 min exposure'" |
-| **UI capture** | Structured description: interface zones, buttons / fields / values visible | `Left panel: list of N items. Right panel: form with 3 fields (X, Y, Z).` |
+| Type                     | Transcription format                                                       | Structural example                                                        |
+| ------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Table / grid**         | Markdown table reproducing line by line, column by column                  | `\| col1 \| col2 \|`                                                      |
+| **Schema / diagram**     | Mermaid if topology allows, otherwise structured node + relations list     | ` ```mermaid\ngraph TD ... ` or `- Node A → Node B (relation)`            |
+| **Code / terminal**      | Code block with detected language, reproduces the readable content         | ` ```python\n... ` or ` ```bash\n... `                                    |
+| **Dashboard / KPI**      | Markdown list of indicators with values and units                          | `- p95 latency: 312 ms`                                                   |
+| **Text slide**           | Title + bullets, literal reproduction                                      | `### <title>\n- bullet 1\n- bullet 2`                                     |
+| **Photo / illustration** | Semantic description: subject, composition, caption if visible             | "Photograph of a telescope, visible caption 'M51 — 60 min exposure'"      |
+| **UI capture**           | Structured description: interface zones, buttons / fields / values visible | `Left panel: list of N items. Right panel: form with 3 fields (X, Y, Z).` |
 
 **Non-optional rule**: a promoted frame without markdown transcription is an ingest defect. If the agent can't transcribe (illegible image, insufficient zoom, irreducible ambiguity), it flags it as `> [!question]` rather than leaving the image orphaned.
 
@@ -177,10 +185,12 @@ Signals that orient toward `KEEP` rather than `DUPLICATE` or `SKIP` at Step 3:
 - **New chart / number** displayed.
 
 Signals that orient toward `DUPLICATE`:
+
 - Minor variant of the previous slide (cursor moved, progress bar advanced, value incremented).
 - Same slide commented over time.
 
 Signals that orient toward `SKIP`:
+
 - Talking head, library backdrop, pure transition (fade, black screen).
 - Intro / outro slide with no pedagogical content.
 

--- a/docs/ingest-video-modes-a-b-generalisation.md
+++ b/docs/ingest-video-modes-a-b-generalisation.md
@@ -11,6 +11,7 @@ Before this decision, two video frame-extraction pipelines coexisted but neither
 2. **Heavy mode ("cross-induction")** — 8-step pipeline documented in [extraction-frames-induction-runbook](extraction-frames-induction-runbook.md). No integration into `/ingest-video`, no packaged script (ffmpeg/Python commands inline in the runbook), runbook initially scoped to a single use case.
 
 Consequences:
+
 - Several agents could capture nothing visual from their videos.
 - Heavy mode stayed a sub-case, while visually dense videos exist in every domain (software demos, tool captures, dashboards, schemas).
 - No tooling to reproduce the heavy mode outside of a human copy-pasting ffmpeg commands.
@@ -28,7 +29,7 @@ Consequences:
 ### A. The two modes coexist and are usable by every agent
 
 - **Mode A (light, frame requests)**: `## Visual frames` section inserted into every expert agent prompt generated from the template, with domain-specific verbal triggers.
-- **Mode B (heavy, cross-induction)**: [extraction-frames-induction-runbook](extraction-frames-induction-runbook.md) runbook *domain-agnostic*, domain specifics moved to **Domain annexes**. The pipeline is driven by `/ingest-video` and the main context, not by the agent — so no agent prompt changes for mode B.
+- **Mode B (heavy, cross-induction)**: [extraction-frames-induction-runbook](extraction-frames-induction-runbook.md) runbook _domain-agnostic_, domain specifics moved to **Domain annexes**. The pipeline is driven by `/ingest-video` and the main context, not by the agent — so no agent prompt changes for mode B.
 
 ### B. `/ingest-video` proposes the right mode, the user picks
 
@@ -52,14 +53,14 @@ Every promoted frame (mode A as well as mode B) **must** be transcribed as struc
 
 ## Scope of changes
 
-| File | Action |
-|---|---|
-| [extraction-frames-induction-runbook](extraction-frames-induction-runbook.md) | Domain-agnostic rewrite + Domain annexes (empty skeletons to enrich as ingests come in) + Step 9 |
-| `.claude/agents/<domain>-expert.md` (all) | `## Visual frames` section (mode A) with domain triggers + mandatory markdown transcription |
-| [scripts/video/sample-frames.sh](../../scripts/video/sample-frames.sh), [scripts/video/diff-frames.py](../../scripts/video/diff-frames.py) | Packaged in the template |
-| [.claude/commands/ingest-video.md](../../.claude/commands/ingest-video.md) | A/B dispatcher (user proposal) + mode B pipeline branch |
-| [CLAUDE.md](../../CLAUDE.md) | INGEST-VIDEO section updated |
-| `wiki/domains/<d>.md` | Cross-ref to the runbook |
+| File                                                                                                                                       | Action                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| [extraction-frames-induction-runbook](extraction-frames-induction-runbook.md)                                                              | Domain-agnostic rewrite + Domain annexes (empty skeletons to enrich as ingests come in) + Step 9 |
+| `.claude/agents/<domain>-expert.md` (all)                                                                                                  | `## Visual frames` section (mode A) with domain triggers + mandatory markdown transcription      |
+| [scripts/video/sample-frames.sh](../../scripts/video/sample-frames.sh), [scripts/video/diff-frames.py](../../scripts/video/diff-frames.py) | Packaged in the template                                                                         |
+| [.claude/commands/ingest-video.md](../../.claude/commands/ingest-video.md)                                                                 | A/B dispatcher (user proposal) + mode B pipeline branch                                          |
+| [CLAUDE.md](../../CLAUDE.md)                                                                                                               | INGEST-VIDEO section updated                                                                     |
+| `wiki/domains/<d>.md`                                                                                                                      | Cross-ref to the runbook                                                                         |
 
 ## Open questions
 

--- a/docs/tracked-repos-immutable-snapshots.md
+++ b/docs/tracked-repos-immutable-snapshots.md
@@ -7,6 +7,7 @@
 The LLM Wiki rests on a strong Karpathy principle: **`raw/` is immutable**. One source = one hashed snapshot, never modified, referenced by `wiki/sources/` via `source_path` + `source_sha256`. The idempotence of `/ingest` depends on it, and the wiki layer is always derivable from `raw/`.
 
 But we often want to make queryable content that is **alive**:
+
 - Technical docs of components or frameworks we follow (release notes, README, docs/).
 - Standards specs that evolve (MCP, Agent Skills, etc.).
 - Project docs of repos under active development.
@@ -38,15 +39,15 @@ Two regimes coexist, increased complexity for `/ingest` and `/lint`. And above a
 
 - **Immutability preserved, zero exception.** Each snapshot is a new folder. Old ones are never modified or deleted.
 - **The event, not the date.** The shortsha is the natural unit: one merge = one snapshot, no noise if nothing moved.
-- **History becomes signal.** Contradictions between successive versions (v1 said X, v2 says Y) become capturable by `/lint` — exactly what Karpathy calls *knowledge compilation*.
+- **History becomes signal.** Contradictions between successive versions (v1 said X, v2 says Y) become capturable by `/lint` — exactly what Karpathy calls _knowledge compilation_.
 - **Hash-based idempotence keeps working.** `/ingest` detects via `source_sha256` that a snapshot's doc is identical to a previous one and skips.
 
 ### User interface
 
-| Invocation | Effect |
-|---|---|
-| `/sync-repos` | interactive multiSelect (avoids the unintended big run on N repos) |
-| `/sync-repos <name1> <name2>` | those sources only |
+| Invocation                    | Effect                                                             |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `/sync-repos`                 | interactive multiSelect (avoids the unintended big run on N repos) |
+| `/sync-repos <name1> <name2>` | those sources only                                                 |
 
 ### Manifest schema
 

--- a/scripts/migrations/v1.0.2-claude-md-slim.md
+++ b/scripts/migrations/v1.0.2-claude-md-slim.md
@@ -37,6 +37,7 @@ Composer un nouveau `CLAUDE.md` qui :
 2. **Conserve `## Architecture`** intacte (instance-specific via les placeholders consommés au bootstrap, peut contenir des refs aux tracked-repos de l'utilisateur).
 3. **Conserve `## Domaines de l'utilisateur`** intact (liste des domaines générée au bootstrap).
 4. **Remplace `## Conventions`** par un bloc compact :
+
    ```markdown
    ## Conventions
 
@@ -51,34 +52,39 @@ Composer un nouveau `CLAUDE.md` qui :
    - **Frontmatter YAML obligatoire** sur chaque page wiki, avec `source_sha256` calculé via `shasum -a 256` (jamais un placeholder).
    - **Slugs en `kebab-case.md`**, liens internes en `[[wikilinks]]`.
    ```
+
 5. **Conserve `## Agents experts par domaine`** intact (liste générée au bootstrap, plus la sous-section `### Dispatch (/ingest)` et `### Évolution des agents (/evolve-agent <domain>)` qui sont template-standard mais courtes — peuvent être compactées en pointeurs vers `.claude/commands/ingest.md` et `.claude/commands/evolve-agent.md`).
 6. **Remplace `## Workflows`** par une table compacte :
+
    ```markdown
    ## Workflows
 
    Les workflows détaillés vivent dans `.claude/commands/`. Tableau récapitulatif :
 
-   | Slash-command | Rôle |
-   |---|---|
-   | `/ingest [chemin]` | Ingestion idempotente des `raw/` via agent expert du domaine |
-   | `/ingest-video <url-ou-path>` | Pipeline vidéo → transcript → ingest → frames (optionnel) |
-   | `/sync-repos [noms]` | Snapshot immuable des repos GitHub trackés (si `tracked-repos.config.json` présent) |
-   | `/query <question>` | Recherche dans le wiki avec citations, archive optionnelle |
-   | `/save <slug>` | Archive la dernière synthèse dans `wiki/syntheses/` |
-   | `/lint` | Détection de contradictions, orphelins, lacunes |
-   | `/evolve-agent <domain>` | Évolution curée du prompt d'un agent depuis ses suggestions accumulées |
-   | `/update-vault` | Récupère les améliorations upstream du template (machine de migration versionnée) |
+   | Slash-command                 | Rôle                                                                                |
+   | ----------------------------- | ----------------------------------------------------------------------------------- |
+   | `/ingest [chemin]`            | Ingestion idempotente des `raw/` via agent expert du domaine                        |
+   | `/ingest-video <url-ou-path>` | Pipeline vidéo → transcript → ingest → frames (optionnel)                           |
+   | `/sync-repos [noms]`          | Snapshot immuable des repos GitHub trackés (si `tracked-repos.config.json` présent) |
+   | `/query <question>`           | Recherche dans le wiki avec citations, archive optionnelle                          |
+   | `/save <slug>`                | Archive la dernière synthèse dans `wiki/syntheses/`                                 |
+   | `/lint`                       | Détection de contradictions, orphelins, lacunes                                     |
+   | `/evolve-agent <domain>`      | Évolution curée du prompt d'un agent depuis ses suggestions accumulées              |
+   | `/update-vault`               | Récupère les améliorations upstream du template (machine de migration versionnée)   |
 
    Pour le radar : « montre le radar » / « qu'est-ce qu'il y a à faire aujourd'hui » → lecture
    de `wiki/radar.md` + suggestions accumulées des agents.
    ```
+
 7. **Conserve `## Décisions d'architecture`** raccourci à 2-3 lignes pointer vers `wiki/decisions/` :
+
    ```markdown
    ## Décisions d'architecture
 
    Les choix structurants sur le vault (workflows, conventions, outillage) vont dans
    `wiki/decisions/` au format ADR-lite (Problème → Options écartées → Décision → Pourquoi).
    ```
+
 8. **Conserve `## Principes d'écriture`** intact (court, instance-relevant).
 9. **Conserve `## Ce qu'il ne faut PAS faire`** intact (court et critique).
 10. **Insère toutes les sections customisées détectées en étape 1** à la fin (ou à leur position d'origine si possible) avec un commentaire `<!-- préservé depuis CLAUDE.md pré-v1.0.2 -->`.
@@ -89,16 +95,27 @@ Calculer la diff entre le `CLAUDE.md` actuel et la cible composée. Présenter v
 
 ```json
 {
-  "questions": [{
-    "question": "CLAUDE.md va être réduit de N lignes à M lignes (suppressions surtout dans Workflows/Conventions). Que faire ?",
-    "header": "Migration CLAUDE.md",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Appliquer la migration", "description": "Écrit le nouveau CLAUDE.md. Customizations utilisateur préservées. Commit dédié."},
-      {"label": "✏️ Éditer manuellement", "description": "Affiche le diff complet, l'utilisateur applique à la main. La migration ne touche pas le fichier."},
-      {"label": "⏭️ Skip pour cette session", "description": "Ne touche pas CLAUDE.md. La migration sera reproposée à la prochaine /update-vault."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "CLAUDE.md va être réduit de N lignes à M lignes (suppressions surtout dans Workflows/Conventions). Que faire ?",
+      "header": "Migration CLAUDE.md",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Appliquer la migration",
+          "description": "Écrit le nouveau CLAUDE.md. Customizations utilisateur préservées. Commit dédié."
+        },
+        {
+          "label": "✏️ Éditer manuellement",
+          "description": "Affiche le diff complet, l'utilisateur applique à la main. La migration ne touche pas le fichier."
+        },
+        {
+          "label": "⏭️ Skip pour cette session",
+          "description": "Ne touche pas CLAUDE.md. La migration sera reproposée à la prochaine /update-vault."
+        }
+      ]
+    }
+  ]
 }
 ```
 

--- a/scripts/migrations/v1.0.3-vault-language.md
+++ b/scripts/migrations/v1.0.3-vault-language.md
@@ -10,12 +10,12 @@ Without this script, `/update-vault` propagates the upstream-tracked files (`.cl
 
 ## Context
 
-Before v1.0.3, `CLAUDE.md.tpl` had `Français.` hardcoded in the *Writing principles* section, and `domain-expert.md.tpl` had `"titres en français"` in the *Wiki rules* section. Consequence: an EN user bootstrapped a vault, and every page produced by `/ingest` came out in French regardless of the source language.
+Before v1.0.3, `CLAUDE.md.tpl` had `Français.` hardcoded in the _Writing principles_ section, and `domain-expert.md.tpl` had `"titres en français"` in the _Wiki rules_ section. Consequence: an EN user bootstrapped a vault, and every page produced by `/ingest` came out in French regardless of the source language.
 
 v1.0.3 introduced:
 
 - A new `{{vault_language}}` placeholder (29th global) capturing the language detected at the bootstrap interview.
-- A directive in `CLAUDE.md.tpl` and `domain-expert.md.tpl`: *"Source language is independent of vault language. Sources can be in any language; wiki pages must always be written in the vault language."*
+- A directive in `CLAUDE.md.tpl` and `domain-expert.md.tpl`: _"Source language is independent of vault language. Sources can be in any language; wiki pages must always be written in the vault language."_
 
 For new vaults, this is handled automatically at bootstrap. For **existing** vaults migrating from v1.0.x to v1.0.3, this script does the equivalent retrofit.
 
@@ -29,7 +29,7 @@ Always ask, never guess silently. The user may want to change the vault language
 
 First, **detect the current language** by reading `CLAUDE.md`:
 
-- Look for the *Writing principles* section (`## Principes d'écriture`, `## Writing principles`, or any localized variant).
+- Look for the _Writing principles_ section (`## Principes d'écriture`, `## Writing principles`, or any localized variant).
 - Inside it, look for a line that declares the language. Typical patterns:
   - `Français.` or `Français — ...`
   - `English.` or `English — ...`
@@ -42,18 +42,23 @@ Then ask via `AskUserQuestion`:
 
 ```json
 {
-  "questions": [{
-    "question": "Which language do you want to use for this vault? (every wiki page produced by /ingest will be written in this language, regardless of source language)",
-    "header": "Vault language",
-    "multiSelect": false,
-    "options": [
-      {"label": "English", "description": "All wiki pages in English."},
-      {"label": "Français", "description": "Toutes les pages wiki en français."},
-      {"label": "Español", "description": "Todas las páginas wiki en español."},
-      {"label": "Deutsch", "description": "Alle Wiki-Seiten auf Deutsch."},
-      {"label": "Other", "description": "Free-text another language label (e.g. 日本語, Português, Italiano)."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Which language do you want to use for this vault? (every wiki page produced by /ingest will be written in this language, regardless of source language)",
+      "header": "Vault language",
+      "multiSelect": false,
+      "options": [
+        { "label": "English", "description": "All wiki pages in English." },
+        { "label": "Français", "description": "Toutes les pages wiki en français." },
+        { "label": "Español", "description": "Todas las páginas wiki en español." },
+        { "label": "Deutsch", "description": "Alle Wiki-Seiten auf Deutsch." },
+        {
+          "label": "Other",
+          "description": "Free-text another language label (e.g. 日本語, Português, Italiano)."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -61,13 +66,13 @@ If `current_language` was detected, mark its option label with `(Recommended —
 
 If the user picks `Other`, prompt for a free-text language label and store it as `vault_language`.
 
-If the user picks a language **different** from `current_language`, note it explicitly. The migration will be flagged as a *language change* (vs *language label retrofit*) in the commit message and `wiki/log.md`.
+If the user picks a language **different** from `current_language`, note it explicitly. The migration will be flagged as a _language change_ (vs _language label retrofit_) in the commit message and `wiki/log.md`.
 
 Store the resolved value in `vault_language`.
 
 ### 2. Migrate `CLAUDE.md`
 
-Locate the *Writing principles* section in `CLAUDE.md`. Look for the language line. Examples that should be replaced:
+Locate the _Writing principles_ section in `CLAUDE.md`. Look for the language line. Examples that should be replaced:
 
 - `- Français. Termes techniques en VO si l'usage VO est dominant.`
 - `- English. Technical terms in VO when the VO usage is dominant.`
@@ -89,22 +94,33 @@ If the surrounding language is **Français**:
 
 For other languages, translate the directive accordingly while keeping the placeholder substitution `<vault_language>` resolved.
 
-If no language line is found in *Writing principles*, propose to **insert** the new directive at the top of the section.
+If no language line is found in _Writing principles_, propose to **insert** the new directive at the top of the section.
 
 Show a clean diff (3 lines of context before / after) and ask via `AskUserQuestion`:
 
 ```json
 {
-  "questions": [{
-    "question": "Apply this CLAUDE.md change?",
-    "header": "CLAUDE.md",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Apply", "description": "Writes the change. The rest of CLAUDE.md is untouched."},
-      {"label": "✏️ Edit manually", "description": "Shows the diff and lets you handle it. The migration does not touch the file."},
-      {"label": "⏭️ Skip", "description": "Don't touch CLAUDE.md. Migration will be re-proposed at the next /update-vault."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Apply this CLAUDE.md change?",
+      "header": "CLAUDE.md",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Apply",
+          "description": "Writes the change. The rest of CLAUDE.md is untouched."
+        },
+        {
+          "label": "✏️ Edit manually",
+          "description": "Shows the diff and lets you handle it. The migration does not touch the file."
+        },
+        {
+          "label": "⏭️ Skip",
+          "description": "Don't touch CLAUDE.md. Migration will be re-proposed at the next /update-vault."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -121,7 +137,7 @@ For each domain-expert agent, locate the line that declares writing language. Ty
 
 - `- Les pages sont en \`kebab-case.md\`, les titres en français (termes VO si usage consacré).`
 - `- Pages are in \`kebab-case.md\`, titles in English (VO terms if standard usage).`
-- Any single-language declaration in the *Wiki rules / Règles du wiki* section.
+- Any single-language declaration in the _Wiki rules / Règles du wiki_ section.
 
 Propose the replacement (rendered in the agent file's language — typically same as `CLAUDE.md`'s language, but agents may have been customized differently). For an EN agent file:
 
@@ -135,16 +151,27 @@ Before iterating, ask via `AskUserQuestion` how the user wants to handle the bat
 
 ```json
 {
-  "questions": [{
-    "question": "How do you want to migrate the per-domain agents (N files detected)?",
-    "header": "Agent migration",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Apply to all", "description": "Apply the same change to every <domain>-expert.md without per-file confirmation. Recommended if you haven't customized the writing-language line of each agent."},
-      {"label": "🔍 Review one by one", "description": "Show a diff and ask for each file. Recommended if some agents have non-standard writing-language wording."},
-      {"label": "⏭️ Skip all", "description": "Don't touch any agent. Migration will be re-proposed at next /update-vault."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "How do you want to migrate the per-domain agents (N files detected)?",
+      "header": "Agent migration",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Apply to all",
+          "description": "Apply the same change to every <domain>-expert.md without per-file confirmation. Recommended if you haven't customized the writing-language line of each agent."
+        },
+        {
+          "label": "🔍 Review one by one",
+          "description": "Show a diff and ask for each file. Recommended if some agents have non-standard writing-language wording."
+        },
+        {
+          "label": "⏭️ Skip all",
+          "description": "Don't touch any agent. Migration will be re-proposed at next /update-vault."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -188,22 +215,22 @@ If nothing was modified (everything skipped), do not commit.
 
 If **all** proposed changes were Applied (CLAUDE.md + every detected agent) → migration is **complete** → `/update-vault` is allowed to bump `.claude/template-version` to 1.0.3.
 
-If **any** change was skipped or edited manually → migration is **partial** → `/update-vault` must NOT bump `.claude/template-version`. Migration will be re-proposed at the next `/update-vault` (and will skip what was already applied — see *Idempotence* below).
+If **any** change was skipped or edited manually → migration is **partial** → `/update-vault` must NOT bump `.claude/template-version`. Migration will be re-proposed at the next `/update-vault` (and will skip what was already applied — see _Idempotence_ below).
 
 ## Idempotence
 
 The migration is idempotent at the file level:
 
-- For `CLAUDE.md`: if the *Writing principles* section already contains the new `Vault language: ...` directive, skip the proposal (no duplicate insertion). Detect via regex on the directive shape.
-- For agents: if the agent's writing-language line already mentions *"original source language has no incidence"* (or equivalent translation), skip.
+- For `CLAUDE.md`: if the _Writing principles_ section already contains the new `Vault language: ...` directive, skip the proposal (no duplicate insertion). Detect via regex on the directive shape.
+- For agents: if the agent's writing-language line already mentions _"original source language has no incidence"_ (or equivalent translation), skip.
 
 This means a partial migration can be safely re-run by the next `/update-vault` without double-applying.
 
 ## Preserving user customizations
 
-Both `CLAUDE.md` and `.claude/agents/<domain>-expert.md` may contain user customizations (sections added beyond the template, refinements, custom rules). The migration touches **only the writing-language line** in the *Writing principles* / *Wiki rules* section. Any other customization is preserved intact — this script never deletes or rearranges sections.
+Both `CLAUDE.md` and `.claude/agents/<domain>-expert.md` may contain user customizations (sections added beyond the template, refinements, custom rules). The migration touches **only the writing-language line** in the _Writing principles_ / _Wiki rules_ section. Any other customization is preserved intact — this script never deletes or rearranges sections.
 
-If, in some edge case, the user has moved or renamed the *Writing principles* section, the migration will fail to locate it and report:
+If, in some edge case, the user has moved or renamed the _Writing principles_ section, the migration will fail to locate it and report:
 
 > ⚠️ Could not locate the Writing principles section in `<file>`. Please apply the change manually using the snippet shown, then re-run `/update-vault`.
 

--- a/scripts/migrations/v1.1.0.md
+++ b/scripts/migrations/v1.1.0.md
@@ -1,5 +1,5 @@
 ---
-description: Migration v1.1.0 — enables the MCP server + Stop hook (existing), and migrates the vault's scripts/ layout to the new feature-based subdirectories (new in v1.1.0 final release)
+description: Migration v1.1.0 — enables the MCP server + Stop hook (existing), migrates the vault's scripts/ layout to the new feature-based subdirectories, and revamps CI for living vaults (Prettier formatter + semantic-only markdownlint + deterministic wiki-integrity checker, web link-check moved to a weekly non-blocking report)
 force-rerun: true
 ---
 
@@ -430,3 +430,87 @@ Part D performs an idempotent in-place rewrite of these references in user-owned
 - A negative lookbehind on the script path regex prevents double-substitution: once a path is rewritten to `scripts/video/scan-raw.sh`, scanning again for the bare `scripts/scan-raw.sh` substring would falsely match the tail of the rewritten path; the lookbehind blocks that. Re-running Part D on an already-patched vault is a clean no-op.
 - The wikilink substitution rewrites both `[[slug]]` and `[[slug|alias]]` forms. Already-rewritten markdown links (`[alias](https://...)`) are not matched.
 - Covered by `force-rerun: true` on this migration: even if a user adds a new agent file `.claude/agents/<new>-expert.md.tpl` with stale references after a partial migration, the next `/update-vault` will re-evaluate and patch.
+
+## Part E — CI revamp for living vaults (v1.1.0 finalize)
+
+The pre-v1.1.0 `lint.yml` was calibrated for the template (a few controlled files). Applied
+to a **living content vault** it failed on every push: lychee flagged hundreds of inevitable
+external 404s, and markdownlint flagged hundreds of cosmetic violations in LLM-generated
+content. Part E recalibrates CI to block only on **repairable, meaningful** defects, and
+adopts **Prettier** so markdown stays clean by construction instead of by disabling rules.
+
+The remote vault is a read-only artifact (`raw/` and the LLM are local-only — no generative
+CD). CI therefore does deterministic validation only: Prettier `--check` (format), markdownlint
+(semantic rules only), and `validate-wiki.py` (wikilinks, internal links, frontmatter — `raw/`
+targets omitted). External web links move to a **weekly non-blocking** report.
+
+### What `/update-vault` step 5 propagates (automatic, 3-way merge)
+
+- `.prettierrc`, `.prettierignore` (new)
+- `.markdownlint.jsonc` (semantic-only rule set — cosmetic rules now owned by Prettier)
+- `.github/workflows/lint.yml` (format-check + markdownlint + wiki-integrity + weekly report)
+- `scripts/wiki-maint/validate-wiki.py` (+ `test_validate_wiki.py`)
+- `.claude/commands/format.md` (new)
+- `.claude/commands/{ingest,save,evolve-agent,compress-bb,lint}.md` (modified)
+
+### Workflow (actions on user content, after step 5)
+
+1. **Announce what's new**
+
+   > **v1.1.0 — CI revamp for living vaults**
+   >
+   > - Prettier formats all markdown (clean, consistent tables/structure).
+   > - markdownlint keeps only semantic rules (MD056 table-column-count, etc.).
+   > - New `wiki-integrity` CI job: broken wikilinks / internal links / frontmatter.
+   > - External web links move to a **weekly non-blocking** report (no more red push).
+   > - New `/format` command; generation commands now format their output.
+   >
+   > One mutation on your content: a **one-shot Prettier pass** over existing markdown
+   > (large but cosmetic diff the first time).
+
+2. **One-shot format** of the vault's existing markdown (idempotent; `raw/` excluded via
+   `.prettierignore`):
+
+   ```bash
+   npx -y prettier --write "**/*.md"
+   ```
+
+   Review the diff is cosmetic (frontmatter and `[[wikilinks]]` are preserved — verified on
+   the reference vault), then commit on the migration branch.
+
+3. **Run the integrity checker** and present its report — these are genuine defects the CI
+   `wiki-integrity` job will block on until fixed:
+
+   ```bash
+   python3 scripts/wiki-maint/validate-wiki.py
+   ```
+
+   The checker reports broken `[[wikilinks]]` (renamed/missing pages), broken internal relative
+   links, and frontmatter that misses a required field or whose `summary_l0` exceeds 140 chars.
+   It does **not** flag `raw/` targets (absent on the remote — that is `/lint`'s job), nor
+   external links, nor table-alias escapes (`[[target\|alias]]`). Fix the reported defects with
+   `/lint` and manual edits before the next push. The CI is **legitimately red** until they are
+   resolved — unlike the old noise, every remaining defect is real and repairable.
+
+4. **Residual `MD056`** (table-column-count) — Prettier realigns tables but cannot guess a
+   missing column, so fix each remaining finding by hand (add the missing header column or move
+   the stray cell into an existing column — these are real "data dropped at render" defects):
+
+   ```bash
+   npx -y markdownlint-cli2 "**/*.md" "#**/node_modules/**" "#**/raw/**"
+   ```
+
+5. **Verify green locally**, then push:
+
+   ```bash
+   python3 scripts/wiki-maint/validate-wiki.py
+   npx -y prettier --check "**/*.md"
+   npx -y markdownlint-cli2 "**/*.md" "#**/node_modules/**" "#**/raw/**"
+   ```
+
+### Idempotence notes
+
+- `prettier --write` is idempotent: re-running on already-formatted files is a no-op.
+- `validate-wiki.py` is read-only (a report) — safe to re-run any time.
+- The propagated files (step 5) use the standard 3-way merge; re-running is a no-op when the
+  vault already carries the v1.1.0 versions.

--- a/scripts/migrations/v1.1.0.md
+++ b/scripts/migrations/v1.1.0.md
@@ -31,11 +31,13 @@ Before any action, present to the user what the migration will do:
 > **v1.1.0 — MCP + hooks + /compress-bb**
 >
 > This migration installs:
+>
 > - An MCP server `boiling-brain-wiki` accessible from **any project** (`scan_domain`, `preview_page`, `read_page`, `search_wiki`, `drop_to_raw`).
 > - A global `Stop` hook that detects productive sessions and writes `cache/.session-pending` in the vault.
 > - A "Session start" section in the vault's `CLAUDE.md` so that Claude proposes `/compress-bb` or `/ingest` on the next launch.
 >
 > Mutations performed:
+>
 > - MCP server registered via `claude mcp add -s user` (user-scope, not stored in `settings.json`).
 > - `~/.claude/settings.json` (`hooks.Stop` only).
 > - `~/.claude/CLAUDE.md` (`<!-- boiling-brain-wiki-mcp -->` block).
@@ -48,16 +50,27 @@ Before any action, present to the user what the migration will do:
 
 ```json
 {
-  "questions": [{
-    "question": "Enable the v1.1 MCP + hooks stack?",
-    "header": "v1.1 setup",
-    "multiSelect": false,
-    "options": [
-      {"label": "✅ Enable", "description": "Runs setup-mcp.sh (mutates settings.json + global CLAUDE.md) and patches the vault CLAUDE.md. Idempotent."},
-      {"label": "✏️ Patch vault CLAUDE.md only", "description": "Skip the MCP server and the global Stop hook. Just add the Session start section to the vault's CLAUDE.md. Useful if you already installed MCP another way or don't want any global mutation."},
-      {"label": "⏭️ Skip for this session", "description": "Touch nothing. The migration will be re-proposed at the next /update-vault. .claude/template-version stays at 1.0.x."}
-    ]
-  }]
+  "questions": [
+    {
+      "question": "Enable the v1.1 MCP + hooks stack?",
+      "header": "v1.1 setup",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Enable",
+          "description": "Runs setup-mcp.sh (mutates settings.json + global CLAUDE.md) and patches the vault CLAUDE.md. Idempotent."
+        },
+        {
+          "label": "✏️ Patch vault CLAUDE.md only",
+          "description": "Skip the MCP server and the global Stop hook. Just add the Session start section to the vault's CLAUDE.md. Useful if you already installed MCP another way or don't want any global mutation."
+        },
+        {
+          "label": "⏭️ Skip for this session",
+          "description": "Touch nothing. The migration will be re-proposed at the next /update-vault. .claude/template-version stays at 1.0.x."
+        }
+      ]
+    }
+  ]
 }
 ```
 
@@ -70,6 +83,7 @@ bash scripts/mcp/setup-mcp.sh --vault-path "$(pwd)"
 ```
 
 The script (existing, shipped by v1.1) does:
+
 - Checks Python 3 and the `claude` command (Claude Code CLI).
 - Installs `fastmcp` if absent — pipx is prioritized (clean, isolated venv), pip --user as fallback. If both fail (PEP 668 + no pipx), explicit error.
 - Resolves the Python interpreter that can actually `import fastmcp`: when pipx is used, it's the python from the pipx venv (`$PIPX_LOCAL_VENVS/fastmcp/bin/python`), **not** the system `python3` — this is the fix for the import-fastmcp error on PEP 668 systems.
@@ -81,9 +95,10 @@ The script (existing, shipped by v1.1) does:
 Capture the script's stdout and present it to the user. If the fastmcp install or `claude mcp add` fails, stop and report.
 
 > **Note for vaults already migrated to v1.1.0 (pre-#47)**: if your vault has `v1.1.0` in `applied-migrations` of `.claude/template-version` but was migrated before the MCP tiered-loading refactor (#47), `/update-vault` will not re-trigger this migration (slug-deduplicated). Two options to refresh the global `~/.claude/CLAUDE.md` block:
+>
 > - **Simple**: re-run `bash <vault>/scripts/mcp/setup-mcp.sh --vault-path "$(pwd)"` directly. The script's self-healing logic detects and replaces the outdated 5-tool block with the new 12-tool + tiered-loading version.
 > - **Full re-run**: edit `.claude/template-version` to remove the `v1.1.0` line from `applied-migrations`, then re-run `/update-vault`. The full Part A workflow will execute again (idempotent on its other steps).
-> The MCP tools (scan_concepts, scan_entities, etc.) themselves are auto-discovered by Claude Code at session start — only the LLM-facing instructions (the global block) need this refresh.
+>   The MCP tools (scan_concepts, scan_entities, etc.) themselves are auto-discovered by Claude Code at session start — only the LLM-facing instructions (the global block) need this refresh.
 
 #### 3.2. Patch the vault's `CLAUDE.md`
 
@@ -120,6 +135,7 @@ Only `CLAUDE.md` is added (setup-mcp.sh does not touch any vault file).
 Display:
 
 > ✅ Migration v1.1.0 applied.
+>
 > - MCP `boiling-brain-wiki` registered (user scope, via `claude mcp`).
 > - Global `Stop` hook registered in `~/.claude/settings.json`.
 > - "Session start" section added to `<vault>/CLAUDE.md`.
@@ -171,7 +187,6 @@ The template's `scripts/` directory has moved to a feature-based layout. Existin
 ### Workflow
 
 1. **Detect the stale flat paths**. For each of the following paths in the vault, if it exists as a flat file at the root of `scripts/`, mark it for removal:
-
    - `scripts/extract-frames.sh`
    - `scripts/sample-frames.sh`
    - `scripts/diff-frames.py`
@@ -199,7 +214,6 @@ The template's `scripts/` directory has moved to a feature-based layout. Existin
 3. **If confirmed, `git rm` the stale files** in the vault. If declined, stop the migration here without marking it as applied (the user can re-run `/update-vault` later).
 
 4. **Re-align global Claude Code config to the new script paths**. Three places hold absolute paths that point at the old flat layout and must be re-aligned:
-
    - The **MCP server registration** in `claude mcp` registry (was `<vault>/scripts/mcp-wiki.py`, now `<vault>/scripts/mcp/mcp-wiki.py`).
    - The **Stop hook entry** in `~/.claude/settings.json` (was `bash <vault>/scripts/check-session-activity.sh`, now `bash <vault>/scripts/hooks/check-session-activity.sh`). Without cleanup, `setup-mcp.sh` adds a new entry at the new path but leaves the old one in place — Claude Code would then fire the stale entry too and fail because Step 3 already `git rm`'d the old script.
    - The **block in `~/.claude/CLAUDE.md` global** (under the `<!-- boiling-brain-wiki-mcp -->` marker): no path is hard-coded inside the block, so it does NOT need rewriting. `setup-mcp.sh` will detect the marker and skip it. Mentioned here only for clarity.
@@ -227,7 +241,6 @@ The template's `scripts/` directory has moved to a feature-based layout. Existin
    `setup-mcp.sh` is idempotent and reuses Part A's full setup path: it resolves the right Python interpreter (pipx venv first to avoid the `Failed to reconnect: -32000` crash on PEP 668 systems, fallback to system `python3` only if `import fastmcp` works there), re-registers the MCP server via `claude mcp add -s user` with the correct `-e WIKI_PATH=<vault>`, appends the new Stop hook entry (since 4.a removed the stale one, the new entry will be the only one), and leaves the `~/.claude/CLAUDE.md` global block untouched (marker-detected).
 
 5. **Confirm the user has re-aligned the global config** before marking the migration as applied. The user can verify with:
-
    - `/mcp` inside Claude Code (after a Claude Code restart) — `boiling-brain-wiki` should appear without a `Failed to reconnect` error.
    - `grep -c "scripts/check-session-activity.sh" ~/.claude/settings.json` should return `0` if you don't have any other unrelated vault registered, OR each remaining match should include `/scripts/hooks/check-session-activity.sh` (the new path).
 
@@ -250,7 +263,6 @@ Vaults migrated to v1.1.0 before this move still have these 3 files at the old l
 ### Workflow
 
 1. **Detect the stale paths** in the vault:
-
    - `wiki/decisions/extraction-frames-induction-runbook.md`
    - `wiki/decisions/tracked-repos-immutable-snapshots.md`
    - `wiki/decisions/ingest-video-modes-a-b-generalisation.md`

--- a/scripts/wiki-maint/format-md.py
+++ b/scripts/wiki-maint/format-md.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+format-md.py — Obsidian-safe markdown formatter (wraps Prettier).
+
+Prettier's GFM table formatter treats a bare `|` inside a wikilink alias
+(`[[target|alias]]`) or a code span (`` `a|b` ``) as a column separator and
+corrupts the table (splits the cell, shifts every following column). Those
+pipes are legitimate Obsidian syntax. This wrapper masks the interior pipes
+with a private-use sentinel before running Prettier, then restores them — so
+Prettier still aligns and normalises everything without ever seeing an
+ambiguous pipe.
+
+Usage:
+  format-md.py --write <glob-or-path>...   # format in place
+  format-md.py --check <glob-or-path>...   # exit 1 if any file is not formatted
+
+Both modes invoke Prettier ONCE for the whole batch (npx startup is the cost),
+so they scale to thousands of files. --check never mutates the working tree
+(it formats masked copies in a temp dir and diffs).
+"""
+import argparse
+import glob as globlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Unicode private-use codepoint, width 1, never present in real markdown.
+SENTINEL = ""
+
+WIKILINK_RE = re.compile(r"\[\[[^\]\n]*\]\]")
+# Matched run of backticks ... same run of backticks (code span), single line.
+CODESPAN_RE = re.compile(r"(`+)(?:[^`\n]|(?!\1)`)*?\1")
+
+
+def mask(text: str) -> str:
+    """Replace `|` inside wikilinks and code spans with the sentinel."""
+    text = WIKILINK_RE.sub(lambda m: m.group(0).replace("|", SENTINEL), text)
+    text = CODESPAN_RE.sub(lambda m: m.group(0).replace("|", SENTINEL), text)
+    return text
+
+
+def unmask(text: str) -> str:
+    return text.replace(SENTINEL, "|")
+
+
+# Directories never formatted (mirrors .prettierignore + VCS/editor dirs).
+# A path is excluded if any of its segments matches one of these.
+# "superpowers" = docs/superpowers/ (session artifacts, gitignored, never committed).
+EXCLUDE_DIRS = {"node_modules", "raw", "cache", "dist", "worktrees", ".git", ".obsidian", "superpowers"}
+
+
+def _excluded(path: str) -> bool:
+    return any(seg in EXCLUDE_DIRS for seg in Path(path).parts)
+
+
+def expand(paths):
+    files = []
+    for p in paths:
+        if os.path.isfile(p):
+            files.append(p)
+        else:
+            # include_hidden=True (Python 3.11+) so `**/*.md` descends into
+            # dotted dirs like .claude/ and .github/ (excluded ones dropped below).
+            files.extend(globlib.glob(p, recursive=True, include_hidden=True))
+    # dedupe, keep markdown only, drop excluded dirs
+    seen, out = set(), []
+    for f in files:
+        if f.endswith(".md") and os.path.isfile(f) and f not in seen and not _excluded(f):
+            seen.add(f)
+            out.append(f)
+    return out
+
+
+def run_prettier(files, cwd=None):
+    proc = subprocess.run(
+        ["npx", "-y", "prettier", "--write", *files],
+        capture_output=True, text=True, cwd=cwd,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"prettier failed:\n{proc.stderr}")
+
+
+def do_write(files):
+    """Mask in place → prettier --write (one call) → unmask in place."""
+    masked = []
+    try:
+        for f in files:
+            orig = Path(f).read_text(encoding="utf-8")
+            if SENTINEL in orig:
+                print(f"skip (sentinel already present): {f}", file=sys.stderr)
+                continue
+            Path(f).write_text(mask(orig), encoding="utf-8")
+            masked.append(f)
+        run_prettier(masked)
+    finally:
+        # Always restore, even if prettier raised, so we never leave masked files.
+        for f in masked:
+            Path(f).write_text(unmask(Path(f).read_text(encoding="utf-8")), encoding="utf-8")
+    return 0
+
+
+def do_check(files):
+    """Format masked copies in a temp tree, diff against originals. No mutation."""
+    if not files:
+        return 0
+    repo_root = Path.cwd()
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        # Carry the Prettier config so formatting matches the real run.
+        for cfg in (".prettierrc", ".prettierignore", ".prettierrc.json", ".prettierrc.yaml"):
+            if (repo_root / cfg).is_file():
+                shutil.copy(repo_root / cfg, tmp / cfg)
+        rel_copies = []
+        skipped = []
+        for f in files:
+            orig = Path(f).read_text(encoding="utf-8")
+            if SENTINEL in orig:
+                skipped.append(f)
+                continue
+            rel = Path(f)
+            dest = tmp / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(mask(orig), encoding="utf-8")
+            rel_copies.append(str(rel))
+        run_prettier(rel_copies, cwd=str(tmp))
+        unformatted = []
+        for f in rel_copies:
+            formatted = unmask((tmp / f).read_text(encoding="utf-8"))
+            if formatted != Path(f).read_text(encoding="utf-8"):
+                unformatted.append(f)
+    for f in skipped:
+        print(f"skip (sentinel already present): {f}", file=sys.stderr)
+    if unformatted:
+        print("Not formatted (run: python3 scripts/wiki-maint/format-md.py --write ...):")
+        for f in unformatted:
+            print(f"  {f}")
+        return 1
+    print(f"✓ format: {len(files)} file(s) clean")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Obsidian-safe markdown formatter (wraps Prettier).")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true", help="format files in place")
+    mode.add_argument("--check", action="store_true", help="exit 1 if any file is unformatted")
+    ap.add_argument("paths", nargs="+", help="files or globs (e.g. '**/*.md')")
+    args = ap.parse_args()
+    files = expand(args.paths)
+    return do_write(files) if args.write else do_check(files)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wiki-maint/format-md.py
+++ b/scripts/wiki-maint/format-md.py
@@ -47,14 +47,15 @@ def unmask(text: str) -> str:
     return text.replace(SENTINEL, "|")
 
 
-# Directories never formatted (mirrors .prettierignore + VCS/editor dirs).
-# A path is excluded if any of its segments matches one of these.
+# Directories never formatted. KEEP ALIGNED with .prettierignore and the
+# markdownlint globs in .github/workflows/lint.yml. A path is excluded if any
+# of its segments matches one of these (or starts with ".venv": virtualenvs).
 # "superpowers" = docs/superpowers/ (session artifacts, gitignored, never committed).
 EXCLUDE_DIRS = {"node_modules", "raw", "cache", "dist", "worktrees", ".git", ".obsidian", "superpowers"}
 
 
 def _excluded(path: str) -> bool:
-    return any(seg in EXCLUDE_DIRS for seg in Path(path).parts)
+    return any(seg in EXCLUDE_DIRS or seg.startswith(".venv") for seg in Path(path).parts)
 
 
 def expand(paths):
@@ -84,8 +85,11 @@ def run_prettier(files, cwd=None):
         raise RuntimeError(f"prettier failed:\n{proc.stderr}")
 
 
-def do_write(files):
-    """Mask in place → prettier --write (one call) → unmask in place."""
+MAX_WRITE_PASSES = 5
+
+
+def _format_pass(files):
+    """One mask in place → prettier --write (one call) → unmask in place."""
     masked = []
     try:
         for f in files:
@@ -100,6 +104,21 @@ def do_write(files):
         # Always restore, even if prettier raised, so we never leave masked files.
         for f in masked:
             Path(f).write_text(unmask(Path(f).read_text(encoding="utf-8")), encoding="utf-8")
+
+
+def do_write(files):
+    """Format to a fixed point: repeat the mask/prettier/unmask pass until a
+    pass changes nothing (some markdown needs 2+ passes to stabilise). Bounded
+    by MAX_WRITE_PASSES so we never loop forever."""
+    if not files:
+        return 0
+    for _ in range(MAX_WRITE_PASSES):
+        before = {f: Path(f).read_text(encoding="utf-8") for f in files}
+        _format_pass(files)
+        if all(Path(f).read_text(encoding="utf-8") == before[f] for f in files):
+            return 0
+    print(f"warning: did not reach a fixed point after {MAX_WRITE_PASSES} passes "
+          f"(run --check to see remaining files)", file=sys.stderr)
     return 0
 
 

--- a/scripts/wiki-maint/test_format_md.py
+++ b/scripts/wiki-maint/test_format_md.py
@@ -102,6 +102,26 @@ class CheckTest(unittest.TestCase):
             r = run(["--check", "t.md"], cwd=str(tmp))
             self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
 
+    def test_venv_is_excluded(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / ".prettierrc").write_text('{"proseWrap":"preserve"}', encoding="utf-8")
+            pkg = tmp / ".venv-voice" / "lib" / "numpy"
+            pkg.mkdir(parents=True)
+            # deliberately unformatted file inside a virtualenv
+            (pkg / "README.md").write_text("#  Bad\n\n\n\nx\n", encoding="utf-8")
+            r = run(["--check", "**/*.md"], cwd=str(tmp))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)  # venv ignored → clean
+
+
+class ExpandTest(unittest.TestCase):
+    def test_excluded_dirs(self):
+        self.assertTrue(fmt._excluded(".venv-voice/lib/x.md"))
+        self.assertTrue(fmt._excluded("node_modules/p/README.md"))
+        self.assertTrue(fmt._excluded("docs/superpowers/specs/x.md"))
+        self.assertFalse(fmt._excluded("wiki/concepts/foo.md"))
+        self.assertFalse(fmt._excluded("docs/guide.md"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/wiki-maint/test_format_md.py
+++ b/scripts/wiki-maint/test_format_md.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""unittest suite for format-md.py — verifies Obsidian-safe formatting.
+
+Run: cd scripts/wiki-maint && python3 -m unittest test_format_md
+(Invokes Prettier via npx; first run may download it.)
+"""
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "format-md.py"
+
+_spec = importlib.util.spec_from_file_location("format_md", SCRIPT)
+fmt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fmt)
+
+
+def run(args, cwd):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True, text=True, cwd=cwd,
+    )
+
+
+class MaskUnmaskTest(unittest.TestCase):
+    def test_roundtrip_wikilink_alias(self):
+        s = "| a | [[entities/y|Alias]] |\n"
+        self.assertNotIn("|Alias", fmt.mask(s).split("[[")[1])  # pipe masked inside
+        self.assertEqual(fmt.unmask(fmt.mask(s)), s)
+
+    def test_roundtrip_codespan(self):
+        s = "| a | `skip|rewrite` |\n"
+        self.assertEqual(fmt.unmask(fmt.mask(s)), s)
+
+    def test_separator_pipes_untouched(self):
+        # pipes outside wikilinks/code spans must NOT be masked
+        s = "| a | b |\n"
+        self.assertEqual(fmt.mask(s), s)
+
+
+class WriteTest(unittest.TestCase):
+    def _table(self):
+        return textwrap.dedent("""\
+            # T
+
+            | Col | Lien | Détail |
+            | --- | --- | --- |
+            | a | [[entities/y|Alias non échappé]] | `skip|rewrite` |
+            | b | [[entities/z]] | plain |
+            """)
+
+    def test_alias_and_codespan_survive_format(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            f = tmp / "t.md"
+            f.write_text(self._table(), encoding="utf-8")
+            r = run(["--write", "t.md"], cwd=str(tmp))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            out = f.read_text(encoding="utf-8")
+            # wikilink alias kept in ONE cell (pipe not turned into separator)
+            self.assertIn("[[entities/y|Alias non échappé]]", out)
+            # code span kept intact
+            self.assertIn("`skip|rewrite`", out)
+            # table still has exactly 3 columns on the separator row
+            sep = [ln for ln in out.splitlines() if ln.strip().startswith("|") and "---" in ln][0]
+            self.assertEqual(sep.count("|"), 4)  # 3 cols → 4 pipes
+
+    def test_no_sentinel_leaks(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            f = tmp / "t.md"
+            f.write_text(self._table(), encoding="utf-8")
+            run(["--write", "t.md"], cwd=str(tmp))
+            self.assertNotIn(fmt.SENTINEL, f.read_text(encoding="utf-8"))
+
+
+class CheckTest(unittest.TestCase):
+    def test_check_flags_unformatted(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / ".prettierrc").write_text('{"proseWrap":"preserve"}', encoding="utf-8")
+            f = tmp / "t.md"
+            f.write_text("#  Bad   heading\n\n\n\nextra blanks\n", encoding="utf-8")
+            r = run(["--check", "t.md"], cwd=str(tmp))
+            self.assertEqual(r.returncode, 1)
+            # original file untouched by --check
+            self.assertIn("extra blanks", f.read_text(encoding="utf-8"))
+
+    def test_check_passes_after_write(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / ".prettierrc").write_text('{"proseWrap":"preserve"}', encoding="utf-8")
+            f = tmp / "t.md"
+            f.write_text("| a | [[x|y]] | `p|q` |\n| --- | --- | --- |\n| 1 | 2 | 3 |\n",
+                         encoding="utf-8")
+            run(["--write", "t.md"], cwd=str(tmp))
+            r = run(["--check", "t.md"], cwd=str(tmp))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/wiki-maint/test_validate_wiki.py
+++ b/scripts/wiki-maint/test_validate_wiki.py
@@ -214,6 +214,26 @@ class ValidateWikiTest(unittest.TestCase):
             r = run(tmp)
             self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
 
+    def test_wikilink_escaped_alias_in_table_resolves(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\n| x | [[concepts/bar\\|the bar]] |\n",
+                "concepts/bar.md": GOOD_FM,
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_wikilink_escaped_alias_still_detects_broken(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\n| x | [[concepts/missing\\|alias]] |\n",
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("missing", r.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/wiki-maint/test_validate_wiki.py
+++ b/scripts/wiki-maint/test_validate_wiki.py
@@ -151,14 +151,36 @@ class ValidateWikiTest(unittest.TestCase):
             self.assertEqual(r.returncode, 1)
             self.assertIn("summary_l0", r.stdout)
 
-    def test_decision_requires_status(self):
+    def test_unconstrained_type_is_accepted(self):
         with tempfile.TemporaryDirectory() as d:
             tmp = Path(d)
-            body = GOOD_FM.replace("type: concept", "type: decision")
+            body = GOOD_FM.replace("type: concept", "type: index")
+            make_vault(tmp, {"index.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_decision_status_not_constrained(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = GOOD_FM.replace("type: concept", "type: decision") + "status: redirect\n"
+            # note: status line is in body here, but even a decision with an
+            # arbitrary status in frontmatter must be accepted — build it properly:
+            body = textwrap.dedent("""\
+                ---
+                type: decision
+                domains: [poker]
+                created: 2026-05-01
+                status: redirect
+                summary_l0: "Short line"
+                summary_l1: |
+                  Two sentences of description here.
+                ---
+
+                # ADR
+                """)
             make_vault(tmp, {"decisions/adr.md": body})
             r = run(tmp)
-            self.assertEqual(r.returncode, 1)
-            self.assertIn("status", r.stdout)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
 
     def test_wikilink_inside_fenced_code_is_ignored(self):
         with tempfile.TemporaryDirectory() as d:

--- a/scripts/wiki-maint/test_validate_wiki.py
+++ b/scripts/wiki-maint/test_validate_wiki.py
@@ -234,6 +234,26 @@ class ValidateWikiTest(unittest.TestCase):
             self.assertEqual(r.returncode, 1)
             self.assertIn("missing", r.stdout)
 
+    def test_conflict_marker_detected_repo_wide(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {"concepts/foo.md": GOOD_FM})
+            (tmp / "docs").mkdir()
+            (tmp / "docs" / "x.md").write_text(
+                "# X\n\n<<<<<<< HEAD\na\n=======\nb\n>>>>>>> other\n", encoding="utf-8")
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("conflict marker", r.stdout)
+
+    def test_conflict_marker_in_excluded_dir_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {"concepts/foo.md": GOOD_FM})
+            (tmp / "raw").mkdir()
+            (tmp / "raw" / "x.md").write_text("<<<<<<< HEAD\n", encoding="utf-8")
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/wiki-maint/test_validate_wiki.py
+++ b/scripts/wiki-maint/test_validate_wiki.py
@@ -160,6 +160,38 @@ class ValidateWikiTest(unittest.TestCase):
             self.assertEqual(r.returncode, 1)
             self.assertIn("status", r.stdout)
 
+    def test_wikilink_inside_fenced_code_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = GOOD_FM + "\n```bash\nif [[concepts/missing]]; then :; fi\n```\n"
+            make_vault(tmp, {"concepts/foo.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_wikilink_inside_inline_code_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = GOOD_FM + "\nUse `[[concepts/missing]]` in shell.\n"
+            make_vault(tmp, {"concepts/foo.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_relative_link_inside_fenced_code_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = GOOD_FM + "\n```\nsee [x](./nope.md)\n```\n"
+            make_vault(tmp, {"concepts/foo.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_raw_prefixed_relative_link_is_skipped(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = GOOD_FM + "\n[src](raw/articles/x.md)\n"
+            make_vault(tmp, {"sources/s.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/wiki-maint/test_validate_wiki.py
+++ b/scripts/wiki-maint/test_validate_wiki.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""unittest suite for validate-wiki.py — drives the CLI on temp fixture vaults.
+
+Run: python3 -m unittest scripts.wiki-maint.test_validate_wiki
+  (or: cd scripts/wiki-maint && python3 -m unittest test_validate_wiki)
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "validate-wiki.py"
+
+GOOD_FM = textwrap.dedent("""\
+    ---
+    type: concept
+    domains: [poker]
+    created: 2026-05-01
+    summary_l0: "Short scannable line"
+    summary_l1: |
+      A couple of sentences describing the page in enough depth.
+    ---
+
+    # Title
+    """)
+
+
+def make_vault(tmp: Path, pages: dict):
+    """pages: {relpath_under_wiki: file_body}. Creates wiki/ tree."""
+    for rel, body in pages.items():
+        p = tmp / "wiki" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+
+def run(tmp: Path):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(tmp)],
+        capture_output=True, text=True,
+    )
+
+
+class ValidateWikiTest(unittest.TestCase):
+    def test_clean_vault_exits_zero(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\nSee [[concepts/bar]].\n",
+                "concepts/bar.md": GOOD_FM,
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_broken_wikilink_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\nSee [[concepts/missing]].\n",
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("missing", r.stdout)
+
+    def test_bare_slug_wikilink_resolves(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\nSee [[bar]].\n",
+                "concepts/bar.md": GOOD_FM,
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_wikilink_with_alias_resolves(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\nSee [[concepts/bar|the bar]].\n",
+                "concepts/bar.md": GOOD_FM,
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_raw_link_is_skipped(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            # raw/ does not exist on disk (gitignored) — must NOT be flagged.
+            make_vault(tmp, {
+                "sources/s.md": GOOD_FM + "\n[src](../../raw/notes/x.md)\n",
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_broken_relative_link_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\n[x](./nope.md)\n",
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("nope.md", r.stdout)
+
+    def test_external_link_is_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            make_vault(tmp, {
+                "concepts/foo.md": GOOD_FM + "\n[ext](https://example.com/404)\n",
+            })
+            r = run(tmp)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+
+    def test_missing_summary_l1_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = textwrap.dedent("""\
+                ---
+                type: concept
+                domains: [poker]
+                created: 2026-05-01
+                summary_l0: "Short line"
+                ---
+
+                # Title
+                """)
+            make_vault(tmp, {"concepts/foo.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("summary_l1", r.stdout)
+
+    def test_empty_domains_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = GOOD_FM.replace("domains: [poker]", "domains: []")
+            make_vault(tmp, {"concepts/foo.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("domains", r.stdout)
+
+    def test_summary_l0_too_long_detected(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            long = "x" * 141
+            body = GOOD_FM.replace('summary_l0: "Short scannable line"',
+                                   f'summary_l0: "{long}"')
+            make_vault(tmp, {"concepts/foo.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("summary_l0", r.stdout)
+
+    def test_decision_requires_status(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            body = GOOD_FM.replace("type: concept", "type: decision")
+            make_vault(tmp, {"decisions/adr.md": body})
+            r = run(tmp)
+            self.assertEqual(r.returncode, 1)
+            self.assertIn("status", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/wiki-maint/validate-wiki.py
+++ b/scripts/wiki-maint/validate-wiki.py
@@ -47,10 +47,6 @@ def iter_prose_lines(text):
 
 
 REQUIRED_COMMON = ["type", "domains", "created", "summary_l0", "summary_l1"]
-VALID_TYPES = {
-    "concept", "entity", "decision", "synthesis",
-    "cheatsheet", "diagram", "source", "domain",
-}
 
 
 def parse_frontmatter(text):
@@ -89,9 +85,6 @@ def check_frontmatter(relpath, text, defects):
     for key in REQUIRED_COMMON:
         if key not in fm:
             defects.append(f"{relpath}:1 — frontmatter missing required field '{key}'")
-    t = fm.get("type", "")
-    if t and t not in VALID_TYPES:
-        defects.append(f"{relpath}:1 — frontmatter 'type: {t}' not in {sorted(VALID_TYPES)}")
     dom = fm.get("domains", "")
     if dom in ("", "[]", "[ ]"):
         defects.append(f"{relpath}:1 — frontmatter 'domains' is empty")
@@ -104,10 +97,6 @@ def check_frontmatter(relpath, text, defects):
         # present-but-empty block, or missing handled above
         if "summary_l1" in fm:
             defects.append(f"{relpath}:1 — frontmatter 'summary_l1' is empty")
-    if t == "decision":
-        status = fm.get("status", "")
-        if status not in ("pending", "accepted"):
-            defects.append(f"{relpath}:1 — decision frontmatter 'status' must be pending|accepted")
 
 
 def build_page_index(wiki_root):

--- a/scripts/wiki-maint/validate-wiki.py
+++ b/scripts/wiki-maint/validate-wiki.py
@@ -6,6 +6,8 @@ Runs in CI (where raw/ is absent) and locally. For every wiki/**/*.md it checks:
   - [[wikilinks]] resolve to an existing wiki page (full path or bare slug)
   - internal relative markdown links / anchors resolve (non-raw, non-external)
   - frontmatter conforms to the per-type schema (see SCHEMA below)
+Plus a repo-wide scan for leftover git conflict markers in any markdown
+(`<<<<<<<` / `>>>>>>>`) — e.g. from an unresolved /update-vault 3-way merge.
 
 References under raw/ are SKIPPED: raw/ is gitignored and never present on the
 remote — its existence is the job of the local /lint command. External links
@@ -26,6 +28,9 @@ MDLINK_RE = re.compile(r"(?<!!)\[[^\]]*\]\(([^)]+)\)")
 EXTERNAL_RE = re.compile(r"^(https?:|mailto:|tel:)", re.IGNORECASE)
 FENCE_RE = re.compile(r"^(```|~~~)")
 INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+# Dirs excluded from the repo-wide conflict-marker scan (gitignored / VCS / editor).
+SCAN_EXCLUDE = {"node_modules", "raw", "cache", "dist", "worktrees", ".git", ".obsidian", "superpowers"}
 
 
 def iter_prose_lines(text):
@@ -149,6 +154,22 @@ def check_relative_links(relpath, abspath, text, wiki_root, repo_root, defects):
                 defects.append(f"{relpath}:{n} — broken relative link ({url})")
 
 
+def check_conflict_markers(repo_root, defects):
+    """Flag leftover git conflict markers in any markdown (repo-wide).
+
+    A 3-way merge (e.g. /update-vault propagation) writes `<<<<<<<` / `>>>>>>>`
+    markers on conflict; if left unresolved they must never reach a commit. We
+    scan all markdown outside gitignored/VCS dirs so the CI catches them.
+    """
+    for p in sorted(repo_root.rglob("*.md")):
+        if any(seg in SCAN_EXCLUDE for seg in p.relative_to(repo_root).parts):
+            continue
+        rel = str(p.relative_to(repo_root)).replace("\\", "/")
+        for n, line in enumerate(p.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            if line.startswith("<<<<<<<") or line.startswith(">>>>>>>"):
+                defects.append(f"{rel}:{n} — git conflict marker ({line[:7]})")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--root", default=str(Path(__file__).resolve().parent.parent.parent),
@@ -168,6 +189,8 @@ def main():
         check_frontmatter(rel, text, defects)
         check_wikilinks(rel, text, relpaths, bare, defects)
         check_relative_links(rel, p, text, wiki_root, repo_root, defects)
+
+    check_conflict_markers(repo_root, defects)
 
     if defects:
         print(f"✗ wiki integrity: {len(defects)} defect(s)\n")

--- a/scripts/wiki-maint/validate-wiki.py
+++ b/scripts/wiki-maint/validate-wiki.py
@@ -24,6 +24,27 @@ from pathlib import Path
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
 MDLINK_RE = re.compile(r"(?<!!)\[[^\]]*\]\(([^)]+)\)")
 EXTERNAL_RE = re.compile(r"^(https?:|mailto:|tel:)", re.IGNORECASE)
+FENCE_RE = re.compile(r"^(```|~~~)")
+INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def iter_prose_lines(text):
+    """Yield (line_number, code-stripped line) for lines outside code.
+
+    Skips fenced code blocks (``` / ~~~, incl. indented fences) entirely and
+    strips inline code spans (`...`) from the remaining lines, so that
+    [[wikilinks]] and [x](y) links inside code are never flagged. Line numbers
+    stay accurate (fenced lines are skipped, not renumbered).
+    """
+    in_fence = False
+    for n, line in enumerate(text.splitlines(), 1):
+        if FENCE_RE.match(line.strip()):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        yield n, INLINE_CODE_RE.sub("", line)
+
 
 REQUIRED_COMMON = ["type", "domains", "created", "summary_l0", "summary_l1"]
 VALID_TYPES = {
@@ -100,7 +121,7 @@ def build_page_index(wiki_root):
 
 
 def check_wikilinks(relpath, text, relpaths, bare, defects):
-    for n, line in enumerate(text.splitlines(), 1):
+    for n, line in iter_prose_lines(text):
         for m in WIKILINK_RE.finditer(line):
             target = m.group(1).strip()
             if target.startswith("raw/"):
@@ -114,13 +135,17 @@ def check_wikilinks(relpath, text, relpaths, bare, defects):
 
 def check_relative_links(relpath, abspath, text, wiki_root, repo_root, defects):
     base = abspath.parent
-    for n, line in enumerate(text.splitlines(), 1):
+    for n, line in iter_prose_lines(text):
         for m in MDLINK_RE.finditer(line):
             url = m.group(1).split()[0].strip()  # drop optional "title"
             if EXTERNAL_RE.match(url) or url.startswith("#") or url.startswith("[["):
                 continue
             path_part = url.split("#", 1)[0]
             if not path_part:
+                continue
+            # Links written as raw/... point at the top-level raw store (absent
+            # on the remote) — skip before any path resolution.
+            if path_part.startswith("raw/"):
                 continue
             target = (base / path_part).resolve()
             # Skip anything that resolves under raw/ (absent on the remote).

--- a/scripts/wiki-maint/validate-wiki.py
+++ b/scripts/wiki-maint/validate-wiki.py
@@ -162,7 +162,7 @@ def check_conflict_markers(repo_root, defects):
     scan all markdown outside gitignored/VCS dirs so the CI catches them.
     """
     for p in sorted(repo_root.rglob("*.md")):
-        if any(seg in SCAN_EXCLUDE for seg in p.relative_to(repo_root).parts):
+        if any(seg in SCAN_EXCLUDE or seg.startswith(".venv") for seg in p.relative_to(repo_root).parts):
             continue
         rel = str(p.relative_to(repo_root)).replace("\\", "/")
         for n, line in enumerate(p.read_text(encoding="utf-8", errors="replace").splitlines(), 1):

--- a/scripts/wiki-maint/validate-wiki.py
+++ b/scripts/wiki-maint/validate-wiki.py
@@ -113,6 +113,7 @@ def check_wikilinks(relpath, text, relpaths, bare, defects):
     for n, line in iter_prose_lines(text):
         for m in WIKILINK_RE.finditer(line):
             target = m.group(1).strip()
+            target = target.rstrip("\\")  # handle Obsidian table alias escape [[t\|alias]]
             if target.startswith("raw/"):
                 continue
             norm = target[len("wiki/"):] if target.startswith("wiki/") else target

--- a/scripts/wiki-maint/validate-wiki.py
+++ b/scripts/wiki-maint/validate-wiki.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+validate-wiki.py — Deterministic integrity checker for a vault's wiki/ tree.
+
+Runs in CI (where raw/ is absent) and locally. For every wiki/**/*.md it checks:
+  - [[wikilinks]] resolve to an existing wiki page (full path or bare slug)
+  - internal relative markdown links / anchors resolve (non-raw, non-external)
+  - frontmatter conforms to the per-type schema (see SCHEMA below)
+
+References under raw/ are SKIPPED: raw/ is gitignored and never present on the
+remote — its existence is the job of the local /lint command. External links
+(http/https/mailto) are ignored: the weekly link-check-report job covers them.
+
+Exit code: 0 if clean, 1 if any defect. Defects are printed as
+`relpath:line — message`, grouped, with a final count.
+
+Usage: validate-wiki.py [--root <repo-root>]   (default root: ../../ from this file)
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
+MDLINK_RE = re.compile(r"(?<!!)\[[^\]]*\]\(([^)]+)\)")
+EXTERNAL_RE = re.compile(r"^(https?:|mailto:|tel:)", re.IGNORECASE)
+
+REQUIRED_COMMON = ["type", "domains", "created", "summary_l0", "summary_l1"]
+VALID_TYPES = {
+    "concept", "entity", "decision", "synthesis",
+    "cheatsheet", "diagram", "source", "domain",
+}
+
+
+def parse_frontmatter(text):
+    """Return (dict-of-raw-lines, body_start_line) or (None, 0) if no frontmatter.
+
+    Light parser (no PyYAML dep): captures the first `key:` of each top-level
+    line in the leading --- block, with the raw remainder as value. Block
+    scalars (`key: |`) are captured as present-but-multiline.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, 0
+    fm = {}
+    i = 1
+    while i < len(lines) and lines[i].strip() != "---":
+        m = re.match(r"^([A-Za-z0-9_]+):(.*)$", lines[i])
+        if m:
+            key, val = m.group(1), m.group(2).strip()
+            if val in ("|", ">", "|-", ">-"):
+                # Block scalar: non-empty iff at least one indented line follows.
+                has_content = (i + 1 < len(lines)
+                               and lines[i + 1].strip() != ""
+                               and lines[i + 1].startswith((" ", "\t")))
+                fm[key] = "<block>" if has_content else ""
+            else:
+                fm[key] = val
+        i += 1
+    return fm, i + 1
+
+
+def check_frontmatter(relpath, text, defects):
+    fm, _ = parse_frontmatter(text)
+    if fm is None:
+        defects.append(f"{relpath}:1 — missing frontmatter block")
+        return
+    for key in REQUIRED_COMMON:
+        if key not in fm:
+            defects.append(f"{relpath}:1 — frontmatter missing required field '{key}'")
+    t = fm.get("type", "")
+    if t and t not in VALID_TYPES:
+        defects.append(f"{relpath}:1 — frontmatter 'type: {t}' not in {sorted(VALID_TYPES)}")
+    dom = fm.get("domains", "")
+    if dom in ("", "[]", "[ ]"):
+        defects.append(f"{relpath}:1 — frontmatter 'domains' is empty")
+    l0 = fm.get("summary_l0", "")
+    if l0:
+        l0v = l0.strip().strip('"').strip("'")
+        if len(l0v) > 140:
+            defects.append(f"{relpath}:1 — frontmatter 'summary_l0' exceeds 140 chars ({len(l0v)})")
+    if fm.get("summary_l1", "") == "":
+        # present-but-empty block, or missing handled above
+        if "summary_l1" in fm:
+            defects.append(f"{relpath}:1 — frontmatter 'summary_l1' is empty")
+    if t == "decision":
+        status = fm.get("status", "")
+        if status not in ("pending", "accepted"):
+            defects.append(f"{relpath}:1 — decision frontmatter 'status' must be pending|accepted")
+
+
+def build_page_index(wiki_root):
+    """Return (relpaths set, bare-slug set) for every wiki/**/*.md."""
+    relpaths, bare = set(), set()
+    for p in wiki_root.rglob("*.md"):
+        rel = p.relative_to(wiki_root).with_suffix("")  # e.g. concepts/foo
+        relpaths.add(str(rel).replace("\\", "/"))
+        bare.add(p.stem)
+    return relpaths, bare
+
+
+def check_wikilinks(relpath, text, relpaths, bare, defects):
+    for n, line in enumerate(text.splitlines(), 1):
+        for m in WIKILINK_RE.finditer(line):
+            target = m.group(1).strip()
+            if target.startswith("raw/"):
+                continue
+            norm = target[len("wiki/"):] if target.startswith("wiki/") else target
+            norm = norm[:-3] if norm.endswith(".md") else norm
+            if norm in relpaths or norm.split("/")[-1] in bare:
+                continue
+            defects.append(f"{relpath}:{n} — broken wikilink [[{target}]]")
+
+
+def check_relative_links(relpath, abspath, text, wiki_root, repo_root, defects):
+    base = abspath.parent
+    for n, line in enumerate(text.splitlines(), 1):
+        for m in MDLINK_RE.finditer(line):
+            url = m.group(1).split()[0].strip()  # drop optional "title"
+            if EXTERNAL_RE.match(url) or url.startswith("#") or url.startswith("[["):
+                continue
+            path_part = url.split("#", 1)[0]
+            if not path_part:
+                continue
+            target = (base / path_part).resolve()
+            # Skip anything that resolves under raw/ (absent on the remote).
+            try:
+                rel_to_repo = target.relative_to(repo_root.resolve())
+                if str(rel_to_repo).startswith("raw/"):
+                    continue
+            except ValueError:
+                pass
+            if not target.exists():
+                defects.append(f"{relpath}:{n} — broken relative link ({url})")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=str(Path(__file__).resolve().parent.parent.parent),
+                    help="repo root (contains wiki/)")
+    args = ap.parse_args()
+    repo_root = Path(args.root)
+    wiki_root = repo_root / "wiki"
+    if not wiki_root.is_dir():
+        print(f"error: no wiki/ under {repo_root}", file=sys.stderr)
+        return 2
+
+    relpaths, bare = build_page_index(wiki_root)
+    defects = []
+    for p in sorted(wiki_root.rglob("*.md")):
+        rel = str(p.relative_to(repo_root)).replace("\\", "/")
+        text = p.read_text(encoding="utf-8", errors="replace")
+        check_frontmatter(rel, text, defects)
+        check_wikilinks(rel, text, relpaths, bare, defects)
+        check_relative_links(rel, p, text, wiki_root, repo_root, defects)
+
+    if defects:
+        print(f"✗ wiki integrity: {len(defects)} defect(s)\n")
+        for d in defects:
+            print(f"  {d}")
+        return 1
+    print("✓ wiki integrity: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Résumé

Recalibre la CI du template pour qu'elle serve de garde-fou de santé sur un **vault de contenu vivant**. Le `lint.yml` préexistant échouait à chaque push d'un vault réel (centaines de 404 externes inévitables + bruit markdownlint cosmétique sur du contenu généré).

Ce travail rejoint la **v1.1.0** non publiée (Part E de la migration), pas une version séparée.

## Changements

- **`lint.yml`** — 3 jobs bloquants au push/PR (`format-check` Prettier, `markdownlint` sémantique uniquement, `wiki-integrity`) + `link-check-report` hebdomadaire **non-bloquant** pour les liens web.
- **Prettier** comme formateur markdown (`.prettierrc` / `.prettierignore`) ; `.markdownlint.jsonc` ne garde que le sémantique (MD056, MD042, MD051, MD024) et désactive le cosmétique délégué à Prettier (dont MD060 par anticipation).
- **`scripts/wiki-maint/validate-wiki.py`** (+ 18 tests stdlib) — vérificateur déterministe : `[[wikilinks]]` cassés, liens internes, frontmatter par type. Omet `raw/` ; comprend l'alias échappé Obsidian `[[cible\|alias]]` ; vocabulaire ouvert (juger le vocabulaire = rôle de `/lint`).
- **`/format`** ; `/ingest`, `/save`, `/evolve-agent`, `/compress-bb` formatent leur sortie ; `/lint` vérifie aussi l'existence des sources `raw/`.
- **Migration v1.1.0 Part E** + entrées CHANGELOG + draft release mis à jour.

## Vérification

- Les 3 jobs CI passent en local sur le template.
- `validate-wiki.py` : 18 tests unitaires verts.
- Sur le vault de référence (bb-perso) : 213 vrais défauts identifiés après élimination de 127 faux positifs (calibrage du vérificateur sur le contenu réel). Leur nettoyage est l'étape de déploiement, suivie séparément.

## Principe directeur

Le vault distant est un artefact en lecture seule (`raw/` + LLM sont local-only) → la CI fait de la validation déterministe uniquement : elle bloque sur le réparable et pertinent, jamais sur le bruit inévitable.