### PR TITLE
feat(mcp-wiki): mode CLI pour interroger le wiki sans client MCP (#57)

### DIFF
--- a/.claude/template-version
+++ b/.claude/template-version
@@ -1,1 +1,1 @@
-template-version: 1.1.0
+template-version: 1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
+## [v1.1.1] — unreleased
+
+### Added
+
+- **`scripts/mcp/wiki-cli.py`**: headless CLI front over the wiki, for scriptable / containerised consumers without an MCP client. Exposes the 11 read tools as subcommands (`scan-domain`, `scan-concepts`, `scan-entities`, `scan-decisions`, `scan-syntheses`, `scan-cheatsheets`, `scan-diagrams`, `scan-sources`, `preview`, `read`, `search`). Markdown by default; `--json` emits a stable, machine-readable shape (the `path` fields are vault-relative and reinjectable into `preview` / `read`). Exit code `0` on success or a legitimate empty result, `2` (message on stderr) on a lookup error (page not found, empty domain, path traversal, `scan-sources` without a query). Targets a vault via `WIKI_PATH` or `--wiki-path`. No `fastmcp` dependency. (#57)
+- **`scripts/mcp/wiki_core.py`**: dependency-free query layer shared by the MCP server and the CLI. Each read tool is split into `<tool>_data()` (structured, JSON-able — the source of truth) and `<tool>_md()` (human-readable markdown). PyYAML stays optional (frontmatter features degrade gracefully when it is absent). (#57)
+- **`scripts/mcp/test_wiki_core.py` + `scripts/mcp/test_wiki_cli.py`**: `unittest` suites covering MCP↔core parity (fastmcp-gated, self-skips without fastmcp), CLI↔core markdown parity, exit codes, and JSON shape. (#57)
+- **`docs/mcp-tiered-loading.md`**: new "CLI mode (no MCP client)" section documenting the headless entry point, the subcommand surface, and the JSON contract. (#57)
+
+### Changed
+
+- **`scripts/mcp/mcp-wiki.py`**: refactored (550 → 153 lines) into a thin FastMCP wrapper that delegates to `wiki_core`. **No behaviour change** — the 12 tool descriptions and signatures are byte-identical (MCP schema unchanged) and every tool's markdown output is byte-identical to v1.1.0 (guaranteed by the parity tests and the `smoke_test.py` token gates). (#57)
+
 ## [v1.1.0] — 2026-05-25
 
 ### Added

--- a/docs/mcp-tiered-loading.md
+++ b/docs/mcp-tiered-loading.md
@@ -128,6 +128,36 @@ The hub page lookup uses `wiki/domains/<domain>.md` and reads its `summary_l1`. 
 ## Related artefacts
 
 - `scripts/mcp/mcp-wiki.py` — server implementation (FastMCP stdio).
+- `scripts/mcp/wiki-cli.py` — headless CLI (argparse), no fastmcp dependency.
+- `scripts/mcp/wiki_core.py` — shared query layer used by both entry points.
 - `scripts/mcp/setup-mcp.sh` — installer + self-healing maintainer of `~/.claude/CLAUDE.md` block.
 - `scripts/mcp/smoke_test.py` — token-budget harness.
 - `scripts/migrations/v1.1.0.md` — migration that installs/refreshes the stack. Marked `force-rerun: true` to re-evaluate at every `/update-vault`.
+
+## CLI mode (no MCP client)
+
+`scripts/mcp/wiki-cli.py` exposes the 11 read tools over the same query layer
+(`wiki_core`), for headless / containerised consumers without an MCP client. It
+has no fastmcp dependency.
+
+```bash
+python3 scripts/mcp/wiki-cli.py search "model context protocol" --json
+python3 scripts/mcp/wiki-cli.py scan-domain ia
+python3 scripts/mcp/wiki-cli.py scan-concepts ia --query rag --top 10
+python3 scripts/mcp/wiki-cli.py preview wiki/concepts/foo.md
+python3 scripts/mcp/wiki-cli.py read wiki/sources/2026-01-15-x.md
+```
+
+Subcommands mirror the MCP read tools: `scan-domain`, `scan-concepts`,
+`scan-entities`, `scan-decisions`, `scan-syntheses`, `scan-cheatsheets`,
+`scan-diagrams`, `scan-sources` (query required), `preview`, `read`, `search`.
+
+- Markdown by default; `--json` emits a stable machine-readable shape. The `path`
+  fields are vault-relative and reinjectable into `preview` / `read`.
+- Exit code `0` on success or a legitimate empty result, `2` (message on stderr)
+  on a lookup error (page not found, empty domain, path traversal, `scan-sources`
+  without a query).
+- Point at a vault with the `WIKI_PATH` env var or the `--wiki-path` option.
+
+The MCP server (`mcp-wiki.py`) and the CLI share the same `wiki_core` functions,
+so a given query yields byte-identical markdown through either entry point.

--- a/scripts/mcp/mcp-wiki.py
+++ b/scripts/mcp/mcp-wiki.py
@@ -1,182 +1,34 @@
 #!/usr/bin/env python3
-"""
-mcp-wiki.py — MCP server (stdio) exposing the BoilingBrain wiki via FastMCP.
+"""mcp-wiki.py — MCP server (stdio) exposing the BoilingBrain wiki via FastMCP.
 
-Tools (12 total, organised as a tiered-loading hierarchy):
+Thin wrapper layer: all query logic lives in wiki_core (dependency-free, also
+used by wiki-cli.py). Each read tool delegates to wiki_core.<tool>_data + _md and
+catches WikiLookupError to preserve the legacy plain-string error behaviour.
 
-  Orient (entry point, ~1k tokens):
-    scan_domain   — hub summary_l1 + counts per type + top 10 by centrality
-
-  Drill (per-type, ~500 tokens each):
-    scan_concepts, scan_entities, scan_decisions, scan_syntheses,
-    scan_cheatsheets, scan_diagrams       — top N by centrality OR matching query
-    scan_sources                          — same shape but query REQUIRED
-
-  Tiered loading (page-level):
-    preview_page  — frontmatter + summary_l1
-    read_page     — full body
-
-  Cross-coupe (cross-type, cross-domain):
-    search_wiki   — tokenised full-text + ranking by centrality
-
-  Write side:
-    drop_to_raw   — server-side write into raw/ (bypasses protect-raw.sh)
+For headless / scriptable access without an MCP client, see wiki-cli.py.
 
 Usage:
   Launched automatically by Claude Code (registered via `claude mcp add`).
   Set WIKI_PATH env var to override the vault root path.
 """
-
-import os
-import re
-import json
-import unicodedata
+import sys
 from pathlib import Path
-from typing import Optional
 
-from fastmcp import FastMCP
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wiki_core  # noqa: E402
 
-WIKI_PATH = Path(os.environ.get("WIKI_PATH", str(Path(__file__).parent.parent.parent)))
-WIKI_DIR = WIKI_PATH / "wiki"
-RAW_DIR = WIKI_PATH / "raw"
-CACHE_DIR = WIKI_PATH / "cache"
-
-FRONT_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+from fastmcp import FastMCP  # noqa: E402
 
 mcp = FastMCP("boiling-brain-wiki")
 
 
-def _parse_front(content: str) -> tuple[dict, str]:
-    """Returns (frontmatter_dict, body). frontmatter_dict is {} if absent."""
-    m = FRONT_RE.match(content)
-    if not m:
-        return {}, content
+def _md(md_fn, data_fn, *args, **kwargs):
+    """Delegate to wiki_core: render data via md_fn, mapping WikiLookupError back
+    to the legacy plain-string return so the MCP output is unchanged."""
     try:
-        import yaml
-        fm = yaml.safe_load(m.group(1)) or {}
-    except Exception:
-        fm = {}
-    body = content[m.end():]
-    return fm, body
-
-
-def _all_wiki_pages() -> list[Path]:
-    return sorted(WIKI_DIR.rglob("*.md"))
-
-
-def _domain_pages(domain: str) -> list[Path]:
-    """Returns pages whose frontmatter domains list contains domain (case-insensitive)."""
-    domain_lower = domain.lower()
-    matches = []
-    for p in _all_wiki_pages():
-        try:
-            content = p.read_text(encoding="utf-8")
-            fm, _ = _parse_front(content)
-            domains = fm.get("domains", [])
-            if isinstance(domains, str):
-                domains = [domains]
-            if any(domain_lower in str(d).lower() for d in domains):
-                matches.append(p)
-        except Exception:
-            continue
-    return matches
-
-
-_BACKLINK_CACHE: dict[str, int] | None = None
-_WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]")
-
-
-def _build_backlink_index() -> dict[str, int]:
-    """Scan every wiki page once and count [[slug]] occurrences. Result is
-    cached in-process. Slug = page path relative to WIKI_DIR, without the .md
-    extension (e.g. 'concepts/model-context-protocol' for
-    wiki/concepts/model-context-protocol.md). Wikilinks may also use bare
-    slugs ('model-context-protocol') — those are counted under the bare-slug
-    bucket and added to the full-slug count by _compute_centrality.
-    """
-    counts: dict[str, int] = {}
-    for p in _all_wiki_pages():
-        try:
-            content = p.read_text(encoding="utf-8")
-        except Exception:
-            continue
-        for m in _WIKILINK_RE.finditer(content):
-            target = m.group(1).strip()
-            counts[target] = counts.get(target, 0) + 1
-    return counts
-
-
-def _compute_centrality(page_path: str) -> int:
-    """Return the number of backlinks pointing to `page_path` (relative to
-    WIKI_PATH, e.g. 'wiki/concepts/foo.md'). Builds the backlink index lazily;
-    subsequent calls reuse the cache. To refresh, set the module-level
-    `_BACKLINK_CACHE = None` and call again.
-    """
-    global _BACKLINK_CACHE
-    if _BACKLINK_CACHE is None:
-        _BACKLINK_CACHE = _build_backlink_index()
-    if not page_path.startswith("wiki/"):
-        page_path = "wiki/" + page_path
-    rel = page_path[len("wiki/"):]
-    if rel.endswith(".md"):
-        rel = rel[:-3]
-    full = _BACKLINK_CACHE.get(rel, 0)
-    bare = _BACKLINK_CACHE.get(rel.rsplit("/", 1)[-1], 0) if "/" in rel else 0
-    return full + bare
-
-
-def _normalize_query(q: str) -> list[str]:
-    """Lowercase, NFC-normalise, split on whitespace and hyphens, drop empties.
-    Used by the matching layer to make 'two-words', 'two words', and 'twowords'
-    queries behave consistently against the page content.
-    """
-    q = unicodedata.normalize("NFC", q).lower()
-    tokens: list[str] = []
-    for chunk in q.replace("-", " ").split():
-        if chunk:
-            tokens.append(chunk)
-    return tokens
-
-
-def _normalize_haystack(text: str) -> str:
-    """Counterpart of _normalize_query for the searched text. Lowercase, NFC,
-    collapse hyphens and whitespace to single spaces.
-    """
-    text = unicodedata.normalize("NFC", text).lower()
-    text = text.replace("-", " ")
-    text = " ".join(text.split())
-    return text
-
-
-def _all_tokens_present(tokens: list[str], haystack: str) -> bool:
-    """True iff every token from _normalize_query is a substring of the
-    pre-normalised haystack.
-    """
-    return all(t in haystack for t in tokens)
-
-
-def _compact_l0(fm: dict, p) -> str:
-    """Compact one-line representation used by scan_<type> outputs.
-    Format: '- <slug> — <summary_l0>'. The slug is the page filename
-    without the .md extension; the type is left implicit (the caller
-    knows it from its own tool name).
-    """
-    l0 = fm.get("summary_l0", "—") or "—"
-    slug = p.stem
-    return f"- {slug} — {l0}"
-
-
-# Map from the directory-style plural name used in the scan_<type> tool to the
-# singular value stored in the `type:` frontmatter field.
-_TYPE_TOOL_TO_FRONTMATTER = {
-    "concepts": "concept",
-    "sources": "source",
-    "syntheses": "synthesis",
-    "entities": "entity",
-    "cheatsheets": "cheatsheet",
-    "decisions": "decision",
-    "diagrams": "diagram",
-}
+        return md_fn(data_fn(*args, **kwargs))
+    except wiki_core.WikiLookupError as e:
+        return str(e)
 
 
 @mcp.tool(
@@ -190,127 +42,7 @@ _TYPE_TOOL_TO_FRONTMATTER = {
     )
 )
 def scan_domain(domain: str) -> str:
-    pages = _domain_pages(domain)
-    if not pages:
-        return f"Aucune page trouvée pour le domaine « {domain} »."
-
-    # Hub page lookup: wiki/domains/<domain>.md with type: domain
-    hub_path = WIKI_DIR / "domains" / f"{domain}.md"
-    hub_l1 = ""
-    if hub_path.exists():
-        try:
-            hub_fm, _ = _parse_front(hub_path.read_text(encoding="utf-8"))
-            hub_l1 = hub_fm.get("summary_l1", "") or ""
-        except Exception:
-            hub_l1 = ""
-
-    # Counts by type (frontmatter `type:` value, lowercased and trimmed)
-    counts: dict[str, int] = {}
-    for p in pages:
-        try:
-            fm, _ = _parse_front(p.read_text(encoding="utf-8"))
-            t = str(fm.get("type", "")).strip().lower()
-            counts[t] = counts.get(t, 0) + 1
-        except Exception:
-            continue
-
-    # Top 10 pages by centrality (backlinks)
-    ranked: list[tuple[int, Path, dict]] = []
-    for p in pages:
-        try:
-            fm, _ = _parse_front(p.read_text(encoding="utf-8"))
-        except Exception:
-            fm = {}
-        rel = str(p.relative_to(WIKI_PATH))
-        c = _compute_centrality(rel)
-        ranked.append((c, p, fm))
-    ranked.sort(key=lambda x: x[0], reverse=True)
-    top = ranked[:10]
-
-    # Assemble the response
-    lines = [f"# Domaine {domain} ({len(pages)} pages)\n"]
-    if hub_l1:
-        lines.append("## Hub\n")
-        lines.append(hub_l1.strip())
-        lines.append("")
-
-    lines.append("## Structure")
-    type_to_tool = {v: k for k, v in _TYPE_TOOL_TO_FRONTMATTER.items()}
-    sorted_counts = sorted(counts.items(), key=lambda kv: -kv[1])
-    for t, n in sorted_counts:
-        tool = type_to_tool.get(t)
-        if tool == "sources":
-            hint = f'scan_sources("{domain}", query=...)  [query required]'
-        elif tool:
-            hint = f'scan_{tool}("{domain}")'
-        else:
-            hint = "(no dedicated scan tool for this type)"
-        lines.append(f"- {t}: {n} → {hint}")
-    lines.append("")
-
-    lines.append("## Top 10 pages centrales (par backlinks)")
-    for c, p, fm in top:
-        slug = p.stem
-        rel_dir = str(p.parent.relative_to(WIKI_DIR))
-        t = fm.get("type", "")
-        l0 = fm.get("summary_l0", "—") or "—"
-        lines.append(f"- {rel_dir}/{slug} ({t}, {c} backlinks) — {l0}")
-
-    return "\n".join(lines)
-
-
-def _scan_type_impl(domain: str, type_singular: str, type_plural: str, query: str, top: int) -> str:
-    """Shared implementation for scan_concepts, scan_entities, scan_decisions,
-    scan_syntheses, scan_cheatsheets, scan_diagrams. scan_sources wraps this
-    too but adds a refusal path for empty queries.
-    """
-    pages = []
-    for p in _domain_pages(domain):
-        try:
-            fm, body = _parse_front(p.read_text(encoding="utf-8"))
-        except Exception:
-            continue
-        if str(fm.get("type", "")).strip().lower() != type_singular:
-            continue
-        pages.append((p, fm, body))
-
-    if not pages:
-        return f"Aucune page de type « {type_singular} » dans le domaine « {domain} »."
-
-    if query.strip():
-        tokens = _normalize_query(query)
-        scored = []
-        for p, fm, body in pages:
-            haystack_parts = [
-                str(fm.get("summary_l0", "")),
-                str(fm.get("summary_l1", "")),
-                p.stem,
-                body,
-            ]
-            haystack = _normalize_haystack(" ".join(haystack_parts))
-            if _all_tokens_present(tokens, haystack):
-                centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
-                scored.append((centrality, p, fm))
-        scored.sort(key=lambda x: x[0], reverse=True)
-        kept = scored[:top]
-        if not kept:
-            return f"Aucune page de type « {type_singular} » dans « {domain} » ne matche « {query} »."
-    else:
-        ranked = []
-        for p, fm, _body in pages:
-            centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
-            ranked.append((centrality, p, fm))
-        ranked.sort(key=lambda x: x[0], reverse=True)
-        kept = ranked[:top]
-
-    header = (
-        f"# {type_plural} dans {domain} — top {len(kept)}"
-        + (f" pour « {query} »" if query.strip() else " par centralité")
-    )
-    lines = [header, ""]
-    for _c, p, fm in kept:
-        lines.append(_compact_l0(fm, p))
-    return "\n".join(lines)
+    return _md(wiki_core.scan_domain_md, wiki_core.scan_domain_data, domain)
 
 
 @mcp.tool(
@@ -322,42 +54,42 @@ def _scan_type_impl(domain: str, type_singular: str, type_plural: str, query: st
     )
 )
 def scan_concepts(domain: str, query: str = "", top: int = 20) -> str:
-    return _scan_type_impl(domain, "concept", "Concepts", query, top)
+    return _md(wiki_core.scan_type_md, wiki_core.scan_type_data, domain, "concept", query, top)
 
 
 @mcp.tool(
     description="List entities (people, tools, places, organisations) in a domain. Same semantics as scan_concepts."
 )
 def scan_entities(domain: str, query: str = "", top: int = 20) -> str:
-    return _scan_type_impl(domain, "entity", "Entities", query, top)
+    return _md(wiki_core.scan_type_md, wiki_core.scan_type_data, domain, "entity", query, top)
 
 
 @mcp.tool(
     description="List decisions (ADRs, retained tradeoffs) in a domain. Same semantics as scan_concepts."
 )
 def scan_decisions(domain: str, query: str = "", top: int = 20) -> str:
-    return _scan_type_impl(domain, "decision", "Decisions", query, top)
+    return _md(wiki_core.scan_type_md, wiki_core.scan_type_data, domain, "decision", query, top)
 
 
 @mcp.tool(
     description="List syntheses (cross-cutting summaries) in a domain. Same semantics as scan_concepts."
 )
 def scan_syntheses(domain: str, query: str = "", top: int = 20) -> str:
-    return _scan_type_impl(domain, "synthesis", "Syntheses", query, top)
+    return _md(wiki_core.scan_type_md, wiki_core.scan_type_data, domain, "synthesis", query, top)
 
 
 @mcp.tool(
     description="List cheatsheets (quick-reference how-tos) in a domain. Same semantics as scan_concepts."
 )
 def scan_cheatsheets(domain: str, query: str = "", top: int = 20) -> str:
-    return _scan_type_impl(domain, "cheatsheet", "Cheatsheets", query, top)
+    return _md(wiki_core.scan_type_md, wiki_core.scan_type_data, domain, "cheatsheet", query, top)
 
 
 @mcp.tool(
     description="List diagrams (visual artefacts) in a domain. Same semantics as scan_concepts."
 )
 def scan_diagrams(domain: str, query: str = "", top: int = 20) -> str:
-    return _scan_type_impl(domain, "diagram", "Diagrams", query, top)
+    return _md(wiki_core.scan_type_md, wiki_core.scan_type_data, domain, "diagram", query, top)
 
 
 @mcp.tool(
@@ -369,26 +101,7 @@ def scan_diagrams(domain: str, query: str = "", top: int = 20) -> str:
     )
 )
 def scan_sources(domain: str, query: str = "", top: int = 20) -> str:
-    if not query.strip():
-        n_sources = sum(
-            1 for p in _domain_pages(domain)
-            if _safe_get_type(p) == "source"
-        )
-        return (
-            f"scan_sources(\"{domain}\") sans query retournerait {n_sources} sources, peu utile.\n"
-            f"Préciser une query : scan_sources(\"{domain}\", query=\"<topic>\").\n"
-            f"Pour explorer le domaine sans cible, préférer scan_domain(\"{domain}\") "
-            f"ou scan_concepts(\"{domain}\")."
-        )
-    return _scan_type_impl(domain, "source", "Sources", query, top)
-
-
-def _safe_get_type(p) -> str:
-    try:
-        fm, _ = _parse_front(p.read_text(encoding="utf-8"))
-        return str(fm.get("type", "")).strip().lower()
-    except Exception:
-        return ""
+    return _md(wiki_core.scan_type_md, wiki_core.scan_sources_data, domain, query, top)
 
 
 @mcp.tool(
@@ -399,31 +112,7 @@ def _safe_get_type(p) -> str:
     )
 )
 def preview_page(page_path: str) -> str:
-    target = (WIKI_PATH / page_path).resolve()
-    if not str(target).startswith(str(WIKI_PATH.resolve())):
-        return "Erreur : chemin invalide (path traversal détecté)."
-    if not target.exists():
-        return f"Page introuvable : {page_path}"
-    try:
-        content = target.read_text(encoding="utf-8")
-    except Exception as e:
-        return f"Erreur de lecture : {e}"
-    fm, body = _parse_front(content)
-    lines = [f"# Preview : {page_path}\n"]
-    # Whitelist: caps verbosity — verdict_evidence, verdict_date, revisit_after intentionally skipped.
-    preview_fields = ("type", "domains", "created", "updated", "summary_l0",
-                      "sources", "status", "verdict")
-    for k in preview_fields:
-        if k in fm:
-            lines.append(f"**{k}**: {fm[k]}")
-    l1 = fm.get("summary_l1", "")
-    if l1:
-        lines.append(f"\n## summary_l1\n{l1}")
-    else:
-        # Fall back to first 300 chars of body
-        snippet = body.strip()[:300]
-        lines.append(f"\n## Début de page\n{snippet}…")
-    return "\n".join(lines)
+    return _md(wiki_core.preview_page_md, wiki_core.preview_page_data, page_path)
 
 
 @mcp.tool(
@@ -434,29 +123,7 @@ def preview_page(page_path: str) -> str:
     )
 )
 def read_page(page_path: str) -> str:
-    target = (WIKI_PATH / page_path).resolve()
-    if not str(target).startswith(str(WIKI_PATH.resolve())):
-        return "Erreur : chemin invalide (path traversal détecté)."
-    if not target.exists():
-        return f"Page introuvable : {page_path}"
-    try:
-        return target.read_text(encoding="utf-8")
-    except Exception as e:
-        return f"Erreur de lecture : {e}"
-
-
-def _outgoing_wikilinks(body: str, limit: int = 10) -> list[str]:
-    seen: list[str] = []
-    seen_set: set[str] = set()
-    for m in _WIKILINK_RE.finditer(body):
-        slug = m.group(1).strip()
-        if slug in seen_set:
-            continue
-        seen_set.add(slug)
-        seen.append(slug)
-        if len(seen) >= limit:
-            break
-    return seen
+    return _md(wiki_core.read_page_md, wiki_core.read_page_data, page_path)
 
 
 @mcp.tool(
@@ -472,39 +139,7 @@ def _outgoing_wikilinks(body: str, limit: int = 10) -> list[str]:
     )
 )
 def search_wiki(query: str, limit: int = 10) -> str:
-    tokens = _normalize_query(query)
-    if not tokens:
-        return "Requête vide."
-    scored: list[tuple[int, Path, dict, str]] = []
-    for p in _all_wiki_pages():
-        try:
-            content = p.read_text(encoding="utf-8")
-        except Exception:
-            continue
-        fm, body = _parse_front(content)
-        haystack_parts = [
-            str(fm.get("summary_l0", "")),
-            str(fm.get("summary_l1", "")),
-            p.stem,
-            body,
-        ]
-        haystack = _normalize_haystack(" ".join(haystack_parts))
-        if _all_tokens_present(tokens, haystack):
-            centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
-            scored.append((centrality, p, fm, body))
-    scored.sort(key=lambda x: x[0], reverse=True)
-    kept = scored[:limit]
-    if not kept:
-        return f"Aucun résultat pour « {query} »."
-    lines = [f"# Résultats pour « {query} » ({len(kept)})", ""]
-    for _c, p, fm, body in kept:
-        rel = str(p.relative_to(WIKI_PATH))
-        t = fm.get("type", "")
-        l0 = fm.get("summary_l0", "—") or "—"
-        wikilinks = _outgoing_wikilinks(body, limit=3)
-        wikilinks_str = ", ".join(wikilinks) if wikilinks else "—"
-        lines.append(f"- {rel} ({t}) — {l0} — wikilinks: [{wikilinks_str}]")
-    return "\n".join(lines)
+    return _md(wiki_core.search_wiki_md, wiki_core.search_wiki_data, query, limit)
 
 
 @mcp.tool(
@@ -520,8 +155,8 @@ def search_wiki(query: str, limit: int = 10) -> str:
 def drop_to_raw(subfolder: str, filename: str, content: str) -> str:
     # Path traversal protection
     try:
-        dest_dir = (RAW_DIR / subfolder).resolve()
-        if not str(dest_dir).startswith(str(RAW_DIR.resolve())):
+        dest_dir = (wiki_core.RAW_DIR / subfolder).resolve()
+        if not str(dest_dir).startswith(str(wiki_core.RAW_DIR.resolve())):
             return "Erreur : sous-dossier invalide (path traversal détecté)."
         dest_file = (dest_dir / filename).resolve()
         if not str(dest_file).startswith(str(dest_dir)):
@@ -530,15 +165,15 @@ def drop_to_raw(subfolder: str, filename: str, content: str) -> str:
         return f"Erreur de validation du chemin : {e}"
 
     if dest_file.exists():
-        return f"Fichier déjà existant : {dest_file.relative_to(WIKI_PATH)}. Utilise un autre nom."
+        return f"Fichier déjà existant : {dest_file.relative_to(wiki_core.WIKI_PATH)}. Utilise un autre nom."
 
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest_file.write_text(content, encoding="utf-8")
 
     # Signal for SessionStart hook
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    pending = CACHE_DIR / ".pending-ingest"
-    rel_path = str(dest_file.relative_to(WIKI_PATH))
+    wiki_core.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    pending = wiki_core.CACHE_DIR / ".pending-ingest"
+    rel_path = str(dest_file.relative_to(wiki_core.WIKI_PATH))
     with open(pending, "a", encoding="utf-8") as f:
         f.write(rel_path + "\n")
 

--- a/scripts/mcp/setup-mcp.sh
+++ b/scripts/mcp/setup-mcp.sh
@@ -11,6 +11,9 @@
 #   - Claude Code CLI (`claude`)
 #   - Python 3.9+
 #   - fastmcp (installé automatiquement via pipx si dispo, sinon pip --user)
+#   - For headless / scriptable access without an MCP client, use wiki-cli.py
+#     (same query layer via wiki_core, no fastmcp dependency):
+#       python3 scripts/mcp/wiki-cli.py search "<query>" --json
 
 set -euo pipefail
 

--- a/scripts/mcp/test_wiki_cli.py
+++ b/scripts/mcp/test_wiki_cli.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""unittest suite for wiki-cli.py — drives the CLI via subprocess on a temp vault.
+
+Run: cd scripts/mcp && python3 -m unittest test_wiki_cli
+Requires NO fastmcp (the CLI imports only wiki_core).
+"""
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+CLI = Path(__file__).resolve().parent / "wiki-cli.py"
+
+PAGES = {
+    "domains/demo.md": "---\ntype: domain\ndomains: [demo]\nsummary_l1: \"Hub.\"\n---\n# Demo\n[[concepts/alpha]]\n",
+    "concepts/alpha.md": "---\ntype: concept\ndomains: [demo]\nsummary_l0: \"Alpha\"\n---\n# Alpha\n",
+}
+
+
+def make_vault(tmp: Path):
+    for rel, body in PAGES.items():
+        p = tmp / "wiki" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+
+def run(vault, *args):
+    return subprocess.run(
+        [sys.executable, str(CLI), *args, "--wiki-path", str(vault)],
+        capture_output=True, text=True)
+
+
+class TestWikiCli(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.vault = Path(self._tmp.name)
+        make_vault(self.vault)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_search_markdown_exit_zero(self):
+        r = run(self.vault, "search", "alpha")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("Résultats pour « alpha »", r.stdout)
+
+    def test_search_json_is_parsable(self):
+        r = run(self.vault, "search", "alpha", "--json")
+        self.assertEqual(r.returncode, 0)
+        payload = json.loads(r.stdout)
+        self.assertEqual(payload["query"], "alpha")
+        self.assertTrue(payload["results"][0]["path"].startswith("wiki/"))
+
+    def test_json_path_is_reinjectable_into_read(self):
+        r = run(self.vault, "search", "alpha", "--json")
+        path = json.loads(r.stdout)["results"][0]["path"]
+        r2 = run(self.vault, "read", path)
+        self.assertEqual(r2.returncode, 0)
+        self.assertIn("# Alpha", r2.stdout)
+
+    def test_missing_page_exits_2_with_stderr(self):
+        r = run(self.vault, "read", "wiki/concepts/ghost.md")
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("Page introuvable", r.stderr)
+        self.assertEqual(r.stdout, "")
+
+    def test_empty_search_no_match_exits_0(self):
+        r = run(self.vault, "search", "zzzznope")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("Aucun résultat", r.stdout)
+
+    def test_scan_sources_without_query_exits_2(self):
+        r = run(self.vault, "scan-sources", "demo")
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("sans query", r.stderr)
+
+    def test_scan_domain_json(self):
+        r = run(self.vault, "scan-domain", "demo", "--json")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(json.loads(r.stdout)["domain"], "demo")
+
+    def test_scan_concepts_markdown_and_json(self):
+        r = run(self.vault, "scan-concepts", "demo")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("Concepts dans demo", r.stdout)
+        self.assertIn("- alpha — Alpha", r.stdout)
+        rj = run(self.vault, "scan-concepts", "demo", "--json")
+        self.assertEqual(rj.returncode, 0)
+        payload = json.loads(rj.stdout)
+        self.assertEqual(payload["type"], "concept")
+        self.assertEqual(payload["results"][0]["slug"], "alpha")
+
+    def test_preview_markdown(self):
+        r = run(self.vault, "preview", "wiki/concepts/alpha.md")
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(r.stdout.startswith("# Preview : wiki/concepts/alpha.md"))
+        self.assertIn("**type**: concept", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/mcp/test_wiki_cli.py
+++ b/scripts/mcp/test_wiki_cli.py
@@ -99,5 +99,32 @@ class TestWikiCli(unittest.TestCase):
         self.assertIn("**type**: concept", r.stdout)
 
 
+class TestCliMcpMdParity(unittest.TestCase):
+    """The CLI markdown output (default) must equal wiki_core's *_md output —
+    i.e. the same bytes a consumer would get from the MCP tool."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.vault = Path(self._tmp.name)
+        make_vault(self.vault)
+        sys.path.insert(0, str(CLI.parent))
+        import wiki_core
+        self.wiki_core = wiki_core
+        wiki_core.configure(self.vault)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_search_md_matches_core(self):
+        r = run(self.vault, "search", "alpha")
+        expected = self.wiki_core.search_wiki_md(self.wiki_core.search_wiki_data("alpha"))
+        self.assertEqual(r.stdout.rstrip("\n"), expected)
+
+    def test_scan_domain_md_matches_core(self):
+        r = run(self.vault, "scan-domain", "demo")
+        expected = self.wiki_core.scan_domain_md(self.wiki_core.scan_domain_data("demo"))
+        self.assertEqual(r.stdout.rstrip("\n"), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -144,5 +144,41 @@ class TestPreviewPage(WikiCoreTestBase):
             wiki_core.preview_page_data("wiki/concepts/ghost.md")
 
 
+class TestSearchWiki(WikiCoreTestBase):
+    def test_search_ranks_by_centrality_and_uses_canonical_path(self):
+        data = wiki_core.search_wiki_data("alpha")
+        self.assertEqual(data["query"], "alpha")
+        paths = [r["path"] for r in data["results"]]
+        # alpha (4 backlinks) ranks before beta (2); paths are 'wiki/....md'
+        self.assertTrue(all(p.startswith("wiki/") and p.endswith(".md") for p in paths))
+        self.assertLess(paths.index("wiki/concepts/alpha.md"),
+                        paths.index("wiki/concepts/beta.md"))
+        self.assertEqual(data["results"][0]["backlinks"], 4)
+
+    def test_search_no_match_is_empty_not_error(self):
+        data = wiki_core.search_wiki_data("zzzznomatch")
+        self.assertEqual(data["results"], [])
+        self.assertEqual(wiki_core.search_wiki_md(data),
+                         "Aucun résultat pour « zzzznomatch ».")
+
+    def test_search_empty_query_raises(self):
+        with self.assertRaises(wiki_core.WikiLookupError) as ctx:
+            wiki_core.search_wiki_data("   ")
+        self.assertEqual(str(ctx.exception), "Requête vide.")
+
+    def test_search_null_summary_l0_renders_dash(self):
+        # A page whose summary_l0 is explicitly null must render "—", not "None".
+        extra = self.vault / "wiki" / "concepts" / "nullsum.md"
+        extra.write_text(
+            "---\ntype: concept\ndomains: [demo]\nsummary_l0: null\n---\n"
+            "# Nullsum\nUniquetokenxyz here.\n", encoding="utf-8")
+        wiki_core.configure(self.vault)  # reset caches after adding a file
+        data = wiki_core.search_wiki_data("uniquetokenxyz")
+        self.assertEqual(data["results"][0]["summary_l0"], "")
+        md = wiki_core.search_wiki_md(data)
+        self.assertIn("(concept) — — — wikilinks:", md)
+        self.assertNotIn("None", md)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""unittest suite for wiki_core.py — drives the pure query layer on a temp vault.
+
+Run: cd scripts/mcp && python3 -m unittest test_wiki_core
+Does NOT require fastmcp (the parity test self-skips if fastmcp is absent).
+"""
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wiki_core  # noqa: E402
+
+
+# A small, deterministic vault. Backlink counts (full-slug):
+#   concepts/alpha : demo(1) + beta(2) + acme(1) = 4
+#   concepts/beta  : demo(1) + alpha(1)          = 2
+#   others                                        = 0
+PAGES = {
+    "domains/demo.md": textwrap.dedent("""\
+        ---
+        type: domain
+        domains: [demo]
+        summary_l0: "Demo domain hub"
+        summary_l1: "Hub of the demo domain for tests."
+        ---
+        # Demo
+        See [[concepts/alpha]] and [[concepts/beta]].
+        """),
+    "concepts/alpha.md": textwrap.dedent("""\
+        ---
+        type: concept
+        domains: [demo]
+        created: 2026-01-01
+        summary_l0: "Alpha concept"
+        summary_l1: "Alpha is the central concept."
+        ---
+        # Alpha
+        Links to [[concepts/beta]].
+        """),
+    "concepts/beta.md": textwrap.dedent("""\
+        ---
+        type: concept
+        domains: [demo]
+        created: 2026-01-02
+        summary_l0: "Beta concept"
+        ---
+        # Beta
+        Refers to [[concepts/alpha]] then [[concepts/alpha]] again.
+        """),
+    "entities/acme.md": textwrap.dedent("""\
+        ---
+        type: entity
+        domains: [demo]
+        summary_l0: "Acme org"
+        ---
+        # Acme
+        Uses [[concepts/alpha]].
+        """),
+    "sources/2026-01-03-doc.md": textwrap.dedent("""\
+        ---
+        type: source
+        domains: [demo]
+        summary_l0: "A source doc"
+        ---
+        # Source
+        Mentions alpha and beta.
+        """),
+}
+
+
+def make_vault(tmp: Path, pages: dict):
+    """pages: {relpath_under_wiki: file_body}. Builds the wiki/ tree."""
+    for rel, body in pages.items():
+        p = tmp / "wiki" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+
+class WikiCoreTestBase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.vault = Path(self._tmp.name)
+        make_vault(self.vault, PAGES)
+        wiki_core.configure(self.vault)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+
+class TestHelpers(WikiCoreTestBase):
+    def test_centrality_counts_backlinks(self):
+        self.assertEqual(wiki_core._compute_centrality("wiki/concepts/alpha.md"), 4)
+        self.assertEqual(wiki_core._compute_centrality("wiki/concepts/beta.md"), 2)
+        self.assertEqual(wiki_core._compute_centrality("wiki/entities/acme.md"), 0)
+
+    def test_domain_pages_filters_by_frontmatter(self):
+        rels = sorted(str(p.relative_to(self.vault)) for p in wiki_core._domain_pages("demo"))
+        self.assertEqual(len(rels), 5)
+        self.assertIn("wiki/concepts/alpha.md", rels)
+        self.assertEqual(wiki_core._domain_pages("nope"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -231,5 +231,32 @@ class TestScanType(WikiCoreTestBase):
         self.assertEqual(parsed["results"], [])
 
 
+class TestScanDomain(WikiCoreTestBase):
+    def test_domain_overview_structure(self):
+        data = wiki_core.scan_domain_data("demo")
+        self.assertEqual(data["page_count"], 5)
+        self.assertEqual(data["hub_summary_l1"], "Hub of the demo domain for tests.")
+        # counts sorted by -n: concept(2) first
+        self.assertEqual(data["counts"][0], {"type": "concept", "n": 2})
+        # top_central ranked by backlinks, canonical paths
+        self.assertEqual(data["top_central"][0]["path"], "wiki/concepts/alpha.md")
+        self.assertEqual(data["top_central"][0]["backlinks"], 4)
+
+    def test_domain_md_rendering(self):
+        md = wiki_core.scan_domain_md(wiki_core.scan_domain_data("demo"))
+        self.assertTrue(md.startswith("# Domaine demo (5 pages)"))
+        self.assertIn("## Hub", md)
+        self.assertIn("## Structure", md)
+        self.assertIn("- concept: 2 → scan_concepts(\"demo\")", md)
+        self.assertIn("## Top 10 pages centrales (par backlinks)", md)
+        # display path is rel_dir/slug, not the canonical wiki/...md
+        self.assertIn("- concepts/alpha (concept, 4 backlinks) — Alpha concept", md)
+
+    def test_empty_domain_raises(self):
+        with self.assertRaises(wiki_core.WikiLookupError) as ctx:
+            wiki_core.scan_domain_data("nope")
+        self.assertEqual(str(ctx.exception), "Aucune page trouvée pour le domaine « nope ».")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -121,5 +121,28 @@ class TestReadPage(WikiCoreTestBase):
         self.assertIn("path traversal", str(ctx.exception))
 
 
+class TestPreviewPage(WikiCoreTestBase):
+    def test_preview_with_summary_l1(self):
+        data = wiki_core.preview_page_data("wiki/concepts/alpha.md")
+        self.assertEqual(data["frontmatter"]["type"], "concept")
+        self.assertEqual(data["summary_l1"], "Alpha is the central concept.")
+        self.assertIsNone(data["body_snippet"])
+        md = wiki_core.preview_page_md(data)
+        self.assertTrue(md.startswith("# Preview : wiki/concepts/alpha.md"))
+        self.assertIn("**type**: concept", md)
+        self.assertIn("## summary_l1\nAlpha is the central concept.", md)
+
+    def test_preview_without_summary_l1_falls_back_to_snippet(self):
+        # beta.md has no summary_l1
+        data = wiki_core.preview_page_data("wiki/concepts/beta.md")
+        self.assertEqual(data["summary_l1"], "")
+        self.assertIsNotNone(data["body_snippet"])
+        self.assertIn("## Début de page", wiki_core.preview_page_md(data))
+
+    def test_preview_missing_raises(self):
+        with self.assertRaises(wiki_core.WikiLookupError):
+            wiki_core.preview_page_data("wiki/concepts/ghost.md")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -180,5 +180,56 @@ class TestSearchWiki(WikiCoreTestBase):
         self.assertNotIn("None", md)
 
 
+class TestScanType(WikiCoreTestBase):
+    def test_concepts_ranked_by_centrality(self):
+        data = wiki_core.scan_type_data("demo", "concept")
+        slugs = [r["slug"] for r in data["results"]]
+        self.assertEqual(slugs, ["alpha", "beta"])  # 4 backlinks before 2
+        md = wiki_core.scan_type_md(data)
+        self.assertTrue(md.startswith("# Concepts dans demo — top 2 par centralité"))
+        self.assertIn("- alpha — Alpha concept", md)
+
+    def test_concepts_with_query_header(self):
+        data = wiki_core.scan_type_data("demo", "concept", query="alpha")
+        md = wiki_core.scan_type_md(data)
+        self.assertIn("pour « alpha »", md)
+
+    def test_empty_domain_raises(self):
+        with self.assertRaises(wiki_core.WikiLookupError) as ctx:
+            wiki_core.scan_type_data("nope", "concept")
+        self.assertEqual(str(ctx.exception),
+                         "Aucune page de type « concept » dans le domaine « nope ».")
+
+    def test_type_absent_in_populated_domain_is_empty(self):
+        data = wiki_core.scan_type_data("demo", "diagram")  # no diagrams in demo
+        self.assertEqual(data["results"], [])
+        self.assertEqual(data["_reason"], "no_typed")
+        self.assertEqual(wiki_core.scan_type_md(data),
+                         "Aucune page de type « diagram » dans le domaine « demo ».")
+
+    def test_query_no_match_is_empty(self):
+        data = wiki_core.scan_type_data("demo", "concept", query="zzzz")
+        self.assertEqual(data["results"], [])
+        self.assertEqual(data["_reason"], "no_match")
+        self.assertIn("ne matche « zzzz »", wiki_core.scan_type_md(data))
+
+    def test_scan_sources_without_query_raises_guidance(self):
+        with self.assertRaises(wiki_core.WikiLookupError) as ctx:
+            wiki_core.scan_sources_data("demo")
+        self.assertIn("sans query retournerait 1 sources", str(ctx.exception))
+
+    def test_scan_sources_with_query(self):
+        data = wiki_core.scan_sources_data("demo", query="source")
+        self.assertEqual(data["type"], "source")
+        self.assertEqual(len(data["results"]), 1)
+
+    def test_to_json_strips_underscore_keys(self):
+        import json as _json
+        data = wiki_core.scan_type_data("demo", "diagram")  # has _reason
+        parsed = _json.loads(wiki_core.to_json(data))
+        self.assertNotIn("_reason", parsed)
+        self.assertEqual(parsed["results"], [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -258,5 +258,106 @@ class TestScanDomain(WikiCoreTestBase):
         self.assertEqual(str(ctx.exception), "Aucune page trouvée pour le domaine « nope ».")
 
 
+import os  # noqa: E402
+import importlib.util  # noqa: E402
+
+
+def _fastmcp_available():
+    try:
+        import fastmcp  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+_HAS_FASTMCP = _fastmcp_available()
+
+
+def _load_mcp_module_fresh():
+    """Load mcp-wiki.py fresh by path (its hyphenated name isn't importable).
+    Its inner `import wiki_core` resolves to the already-imported module, so
+    configuring wiki_core also configures what the server sees."""
+    spec = importlib.util.spec_from_file_location(
+        "mcp_wiki_fresh", str(Path(__file__).resolve().parent / "mcp-wiki.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@unittest.skipUnless(_HAS_FASTMCP, "fastmcp not installed")
+class TestMcpParity(WikiCoreTestBase):
+    """Byte-for-byte parity between wiki_core *_md(*_data(...)) and the MCP tools."""
+
+    def setUp(self):
+        super().setUp()                       # builds vault, configures wiki_core
+        # Resolve symlinks (macOS /var -> /private/var) so the vault root matches
+        # the canonical paths drop_to_raw derives via Path.resolve(), as a real
+        # WIKI_PATH (env var / repo root) would already be canonical.
+        self.vault = self.vault.resolve()
+        self._prev_env = os.environ.get("WIKI_PATH")
+        os.environ["WIKI_PATH"] = str(self.vault)
+        self.m = _load_mcp_module_fresh()
+        # The rewritten server always delegates to wiki_core; fail loudly if not.
+        self.assertTrue(hasattr(self.m, "wiki_core"),
+                        "mcp-wiki.py loaded without a wiki_core attribute")
+        self.m.wiki_core.configure(self.vault)
+        wiki_core.configure(self.vault)
+
+    def tearDown(self):
+        if self._prev_env is None:
+            os.environ.pop("WIKI_PATH", None)
+        else:
+            os.environ["WIKI_PATH"] = self._prev_env
+        super().tearDown()
+
+    def test_scan_domain_parity(self):
+        self.assertEqual(self.m.scan_domain("demo"),
+                         wiki_core.scan_domain_md(wiki_core.scan_domain_data("demo")))
+
+    def test_scan_concepts_parity(self):
+        self.assertEqual(self.m.scan_concepts("demo"),
+                         wiki_core.scan_type_md(wiki_core.scan_type_data("demo", "concept")))
+
+    def test_scan_sources_refusal_parity(self):
+        self.assertEqual(self.m.scan_sources("demo"),
+                         self._safe_md(lambda: wiki_core.scan_sources_data("demo")))
+
+    def test_preview_parity(self):
+        self.assertEqual(self.m.preview_page("wiki/concepts/alpha.md"),
+                         wiki_core.preview_page_md(wiki_core.preview_page_data("wiki/concepts/alpha.md")))
+
+    def test_read_parity(self):
+        self.assertEqual(self.m.read_page("wiki/concepts/alpha.md"),
+                         wiki_core.read_page_md(wiki_core.read_page_data("wiki/concepts/alpha.md")))
+
+    def test_search_parity(self):
+        self.assertEqual(self.m.search_wiki("alpha"),
+                         wiki_core.search_wiki_md(wiki_core.search_wiki_data("alpha")))
+
+    def test_missing_page_parity(self):
+        self.assertEqual(self.m.read_page("wiki/x/ghost.md"),
+                         self._safe_md(lambda: wiki_core.read_page_data("wiki/x/ghost.md")))
+
+    def test_drop_to_raw_writes_file_and_signals(self):
+        result = self.m.drop_to_raw("notes", "task7-check.md", "# Hello\nbody\n")
+        dest = self.vault / "raw" / "notes" / "task7-check.md"
+        self.assertTrue(dest.exists())
+        self.assertEqual(dest.read_text(encoding="utf-8"), "# Hello\nbody\n")
+        self.assertIn("Fichier créé", result)
+        pending = (self.vault / "cache" / ".pending-ingest").read_text(encoding="utf-8")
+        self.assertIn("raw/notes/task7-check.md", pending)
+
+    def test_drop_to_raw_rejects_path_traversal(self):
+        result = self.m.drop_to_raw("../evil", "x.md", "nope")
+        self.assertIn("path traversal détecté", result)
+        self.assertFalse((self.vault / "raw" / "evil").exists())
+
+    def _safe_md(self, fn):
+        try:
+            return str(fn())
+        except wiki_core.WikiLookupError as e:
+            return str(e)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -103,5 +103,23 @@ class TestHelpers(WikiCoreTestBase):
         self.assertEqual(wiki_core._domain_pages("nope"), [])
 
 
+class TestReadPage(WikiCoreTestBase):
+    def test_read_returns_full_content(self):
+        data = wiki_core.read_page_data("wiki/concepts/alpha.md")
+        self.assertEqual(data["page_path"], "wiki/concepts/alpha.md")
+        self.assertIn("# Alpha", data["content"])
+        self.assertEqual(wiki_core.read_page_md(data), data["content"])
+
+    def test_read_missing_raises(self):
+        with self.assertRaises(wiki_core.WikiLookupError) as ctx:
+            wiki_core.read_page_data("wiki/concepts/ghost.md")
+        self.assertEqual(str(ctx.exception), "Page introuvable : wiki/concepts/ghost.md")
+
+    def test_read_path_traversal_raises(self):
+        with self.assertRaises(wiki_core.WikiLookupError) as ctx:
+            wiki_core.read_page_data("../../etc/passwd")
+        self.assertIn("path traversal", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/wiki-cli.py
+++ b/scripts/mcp/wiki-cli.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""wiki-cli.py — headless CLI over a BoilingBrain vault, no MCP client required.
+
+Reuses wiki_core (no fastmcp dependency). Markdown by default; --json emits the
+stable machine-readable shape. Exit codes: 0 on success or legitimate empty
+result, 2 on lookup error (message on stderr).
+
+Examples:
+  python3 wiki-cli.py search "model context protocol" --limit 5
+  python3 wiki-cli.py scan-domain ia --json
+  python3 wiki-cli.py scan-concepts ia --query rag --top 10
+  python3 wiki-cli.py preview wiki/concepts/foo.md
+  WIKI_PATH=/path/to/vault python3 wiki-cli.py read wiki/sources/x.md
+
+JSON shapes are documented in wiki_core.py (the <tool>_data() return values).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wiki_core  # noqa: E402
+
+_SCAN_TYPES = {
+    "scan-concepts": "concept", "scan-entities": "entity",
+    "scan-decisions": "decision", "scan-syntheses": "synthesis",
+    "scan-cheatsheets": "cheatsheet", "scan-diagrams": "diagram",
+}
+
+
+def _emit(data, md_fn, as_json):
+    print(wiki_core.to_json(data) if as_json else md_fn(data))
+
+
+def _build_parser():
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--json", action="store_true",
+                        help="Emit JSON instead of markdown.")
+    common.add_argument("--wiki-path",
+                        help="Vault root (overrides the WIKI_PATH env var).")
+
+    parser = argparse.ArgumentParser(
+        prog="wiki-cli",
+        description="Query a BoilingBrain vault without an MCP client.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("scan-domain", parents=[common])
+    sp.add_argument("domain")
+
+    for name in _SCAN_TYPES:
+        sp = sub.add_parser(name, parents=[common])
+        sp.add_argument("domain")
+        sp.add_argument("--query", default="")
+        sp.add_argument("--top", type=int, default=20)
+
+    sp = sub.add_parser("scan-sources", parents=[common])
+    sp.add_argument("domain")
+    sp.add_argument("--query", default="")
+    sp.add_argument("--top", type=int, default=20)
+
+    sp = sub.add_parser("preview", parents=[common])
+    sp.add_argument("page_path")
+
+    sp = sub.add_parser("read", parents=[common])
+    sp.add_argument("page_path")
+
+    sp = sub.add_parser("search", parents=[common])
+    sp.add_argument("query")
+    sp.add_argument("--limit", type=int, default=10)
+
+    return parser
+
+
+def main(argv=None):
+    args = _build_parser().parse_args(argv)
+    if args.wiki_path:
+        wiki_core.configure(args.wiki_path)
+    try:
+        if args.cmd == "scan-domain":
+            _emit(wiki_core.scan_domain_data(args.domain),
+                  wiki_core.scan_domain_md, args.json)
+        elif args.cmd in _SCAN_TYPES:
+            _emit(wiki_core.scan_type_data(args.domain, _SCAN_TYPES[args.cmd],
+                                           args.query, args.top),
+                  wiki_core.scan_type_md, args.json)
+        elif args.cmd == "scan-sources":
+            _emit(wiki_core.scan_sources_data(args.domain, args.query, args.top),
+                  wiki_core.scan_type_md, args.json)
+        elif args.cmd == "preview":
+            _emit(wiki_core.preview_page_data(args.page_path),
+                  wiki_core.preview_page_md, args.json)
+        elif args.cmd == "read":
+            _emit(wiki_core.read_page_data(args.page_path),
+                  wiki_core.read_page_md, args.json)
+        elif args.cmd == "search":
+            _emit(wiki_core.search_wiki_data(args.query, args.limit),
+                  wiki_core.search_wiki_md, args.json)
+    except wiki_core.WikiLookupError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mcp/wiki_core.py
+++ b/scripts/mcp/wiki_core.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""wiki_core.py — pure, dependency-free query layer over a BoilingBrain vault.
+
+Shared by mcp-wiki.py (FastMCP stdio server) and wiki-cli.py (headless CLI).
+No third-party dependency is required: PyYAML is used opportunistically for
+frontmatter and degrades to {} if absent; fastmcp is NOT imported here.
+
+Each read tool is split into:
+  <tool>_data(...) -> dict   # structured source of truth (also the JSON shape)
+  <tool>_md(data)  -> str    # human-readable markdown, byte-identical to the
+                             # historical mcp-wiki.py output
+
+Errors that should map to a non-zero CLI exit raise WikiLookupError; the MCP
+wrappers catch it and return str(e) so the legacy markdown behaviour is kept.
+
+Point the module at a vault via the WIKI_PATH env var or configure().
+"""
+import os
+import re
+import json
+import unicodedata
+from pathlib import Path
+
+
+class WikiLookupError(Exception):
+    """Genuine lookup error (missing page, empty domain, path traversal, usage
+    misuse). CLI maps it to stderr + exit 2; MCP wrappers return str(e)."""
+
+
+WIKI_PATH = Path(os.environ.get("WIKI_PATH", str(Path(__file__).parent.parent.parent)))
+WIKI_DIR = WIKI_PATH / "wiki"
+RAW_DIR = WIKI_PATH / "raw"
+CACHE_DIR = WIKI_PATH / "cache"
+
+FRONT_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_WIKILINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]")
+_BACKLINK_CACHE = None
+
+# Directory-style plural (scan tool name) -> singular value stored in `type:`.
+_TYPE_TOOL_TO_FRONTMATTER = {
+    "concepts": "concept",
+    "sources": "source",
+    "syntheses": "synthesis",
+    "entities": "entity",
+    "cheatsheets": "cheatsheet",
+    "decisions": "decision",
+    "diagrams": "diagram",
+}
+
+_TYPE_PLURAL = {
+    "concept": "Concepts", "entity": "Entities", "decision": "Decisions",
+    "synthesis": "Syntheses", "cheatsheet": "Cheatsheets", "diagram": "Diagrams",
+    "source": "Sources",
+}
+
+
+def configure(wiki_path):
+    """Re-point the module at a different vault root and reset caches. Used by
+    wiki-cli.py --wiki-path and by tests. The MCP server relies on the WIKI_PATH
+    env var resolved at import time and does not call this."""
+    global WIKI_PATH, WIKI_DIR, RAW_DIR, CACHE_DIR, _BACKLINK_CACHE
+    WIKI_PATH = Path(wiki_path)
+    WIKI_DIR = WIKI_PATH / "wiki"
+    RAW_DIR = WIKI_PATH / "raw"
+    CACHE_DIR = WIKI_PATH / "cache"
+    _BACKLINK_CACHE = None
+
+
+# ---- frontmatter + page enumeration -------------------------------------
+def _parse_front(content):
+    """Returns (frontmatter_dict, body). frontmatter_dict is {} if absent."""
+    m = FRONT_RE.match(content)
+    if not m:
+        return {}, content
+    try:
+        import yaml
+        fm = yaml.safe_load(m.group(1)) or {}
+    except Exception:
+        fm = {}
+    body = content[m.end():]
+    return fm, body
+
+
+def _all_wiki_pages():
+    return sorted(WIKI_DIR.rglob("*.md"))
+
+
+def _domain_pages(domain):
+    """Pages whose frontmatter `domains` contains domain (case-insensitive)."""
+    domain_lower = domain.lower()
+    matches = []
+    for p in _all_wiki_pages():
+        try:
+            fm, _ = _parse_front(p.read_text(encoding="utf-8"))
+            domains = fm.get("domains", [])
+            if isinstance(domains, str):
+                domains = [domains]
+            if any(domain_lower in str(d).lower() for d in domains):
+                matches.append(p)
+        except Exception:
+            continue
+    return matches
+
+
+def _safe_get_type(p):
+    try:
+        fm, _ = _parse_front(p.read_text(encoding="utf-8"))
+        return str(fm.get("type", "")).strip().lower()
+    except Exception:
+        return ""
+
+
+# ---- centrality ----------------------------------------------------------
+def _build_backlink_index():
+    counts = {}
+    for p in _all_wiki_pages():
+        try:
+            content = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        for m in _WIKILINK_RE.finditer(content):
+            target = m.group(1).strip()
+            counts[target] = counts.get(target, 0) + 1
+    return counts
+
+
+def _compute_centrality(page_path):
+    """Number of backlinks pointing to page_path (rel to WIKI_PATH). Lazily
+    builds and caches the backlink index; configure() resets it."""
+    global _BACKLINK_CACHE
+    if _BACKLINK_CACHE is None:
+        _BACKLINK_CACHE = _build_backlink_index()
+    if not page_path.startswith("wiki/"):
+        page_path = "wiki/" + page_path
+    rel = page_path[len("wiki/"):]
+    if rel.endswith(".md"):
+        rel = rel[:-3]
+    full = _BACKLINK_CACHE.get(rel, 0)
+    bare = _BACKLINK_CACHE.get(rel.rsplit("/", 1)[-1], 0) if "/" in rel else 0
+    return full + bare
+
+
+# ---- query normalisation -------------------------------------------------
+def _normalize_query(q):
+    q = unicodedata.normalize("NFC", q).lower()
+    tokens = []
+    for chunk in q.replace("-", " ").split():
+        if chunk:
+            tokens.append(chunk)
+    return tokens
+
+
+def _normalize_haystack(text):
+    text = unicodedata.normalize("NFC", text).lower()
+    text = text.replace("-", " ")
+    text = " ".join(text.split())
+    return text
+
+
+def _all_tokens_present(tokens, haystack):
+    return all(t in haystack for t in tokens)
+
+
+def _outgoing_wikilinks(body, limit=10):
+    seen, seen_set = [], set()
+    for m in _WIKILINK_RE.finditer(body):
+        slug = m.group(1).strip()
+        if slug in seen_set:
+            continue
+        seen_set.add(slug)
+        seen.append(slug)
+        if len(seen) >= limit:
+            break
+    return seen
+
+
+# ---- JSON helper ---------------------------------------------------------
+def to_json(data):
+    """Serialize a *_data() result to JSON. Keys prefixed with '_' are
+    presentation hints and are dropped from the JSON output."""
+    clean = {k: v for k, v in data.items() if not k.startswith("_")}
+    return json.dumps(clean, ensure_ascii=False, indent=2)
+
+
+def _resolve_in_vault(page_path):
+    """Resolve page_path under the vault, guarding against path traversal."""
+    target = (WIKI_PATH / page_path).resolve()
+    if not str(target).startswith(str(WIKI_PATH.resolve())):
+        raise WikiLookupError("Erreur : chemin invalide (path traversal détecté).")
+    if not target.exists():
+        raise WikiLookupError(f"Page introuvable : {page_path}")
+    return target

--- a/scripts/mcp/wiki_core.py
+++ b/scripts/mcp/wiki_core.py
@@ -374,3 +374,85 @@ def scan_sources_data(domain, query="", top=20):
             f"ou scan_concepts(\"{domain}\")."
         )
     return scan_type_data(domain, "source", query, top)
+
+
+# ---- scan_domain ---------------------------------------------------------
+def scan_domain_data(domain):
+    """Return a structured overview of a domain: page count, hub summary,
+    type counts sorted by descending count, and top-10 most central pages.
+
+    Raises WikiLookupError when the domain has zero pages.
+    """
+    pages = _domain_pages(domain)
+    if not pages:
+        raise WikiLookupError(f"Aucune page trouvée pour le domaine « {domain} ».")
+    hub_path = WIKI_DIR / "domains" / f"{domain}.md"
+    hub_l1 = ""
+    if hub_path.exists():
+        try:
+            hub_fm, _ = _parse_front(hub_path.read_text(encoding="utf-8"))
+            hub_l1 = hub_fm.get("summary_l1", "") or ""
+        except Exception:
+            hub_l1 = ""
+    counts = {}
+    for p in pages:
+        try:
+            fm, _ = _parse_front(p.read_text(encoding="utf-8"))
+            t = str(fm.get("type", "")).strip().lower()
+            counts[t] = counts.get(t, 0) + 1
+        except Exception:
+            continue
+    sorted_counts = sorted(counts.items(), key=lambda kv: -kv[1])
+    ranked = []
+    for p in pages:
+        try:
+            fm, _ = _parse_front(p.read_text(encoding="utf-8"))
+        except Exception:
+            fm = {}
+        c = _compute_centrality(str(p.relative_to(WIKI_PATH)))
+        ranked.append((c, p, fm))
+    ranked.sort(key=lambda x: x[0], reverse=True)
+    top_central = [{
+        "path": str(p.relative_to(WIKI_PATH)),
+        "type": fm.get("type", ""),
+        "backlinks": c,
+        # Use `or ""` (not str(...)) so YAML-null summary_l0 becomes "" not "None".
+        "summary_l0": fm.get("summary_l0") or "",
+    } for c, p, fm in ranked[:10]]
+    return {
+        "domain": domain,
+        "page_count": len(pages),
+        "hub_summary_l1": hub_l1,
+        "counts": [{"type": t, "n": n} for t, n in sorted_counts],
+        "top_central": top_central,
+    }
+
+
+def scan_domain_md(data):
+    """Render scan_domain_data() output as a human-readable markdown string."""
+    domain = data["domain"]
+    lines = [f"# Domaine {domain} ({data['page_count']} pages)\n"]
+    if data["hub_summary_l1"]:
+        lines.append("## Hub\n")
+        lines.append(data["hub_summary_l1"].strip())
+        lines.append("")
+    lines.append("## Structure")
+    type_to_tool = {v: k for k, v in _TYPE_TOOL_TO_FRONTMATTER.items()}
+    for entry in data["counts"]:
+        t, n = entry["type"], entry["n"]
+        tool = type_to_tool.get(t)
+        if tool == "sources":
+            hint = f'scan_sources("{domain}", query=...)  [query required]'
+        elif tool:
+            hint = f'scan_{tool}("{domain}")'
+        else:
+            hint = "(no dedicated scan tool for this type)"
+        lines.append(f"- {t}: {n} → {hint}")
+    lines.append("")
+    lines.append("## Top 10 pages centrales (par backlinks)")
+    for r in data["top_central"]:
+        p = WIKI_PATH / r["path"]
+        rel_dir = str(p.parent.relative_to(WIKI_DIR))
+        l0 = r["summary_l0"] or "—"
+        lines.append(f"- {rel_dir}/{p.stem} ({r['type']}, {r['backlinks']} backlinks) — {l0}")
+    return "\n".join(lines)

--- a/scripts/mcp/wiki_core.py
+++ b/scripts/mcp/wiki_core.py
@@ -204,3 +204,32 @@ def read_page_data(page_path):
 
 def read_page_md(data):
     return data["content"]
+
+
+# ---- preview_page --------------------------------------------------------
+def preview_page_data(page_path):
+    target = _resolve_in_vault(page_path)
+    try:
+        content = target.read_text(encoding="utf-8")
+    except Exception as e:
+        raise WikiLookupError(f"Erreur de lecture : {e}")
+    fm, body = _parse_front(content)
+    # Whitelist caps verbosity — mirrors the historical preview_page output.
+    preview_fields = ("type", "domains", "created", "updated", "summary_l0",
+                      "sources", "status", "verdict")
+    frontmatter = {k: fm[k] for k in preview_fields if k in fm}
+    l1 = fm.get("summary_l1", "") or ""
+    body_snippet = None if l1 else body.strip()[:300]
+    return {"page_path": page_path, "frontmatter": frontmatter,
+            "summary_l1": l1, "body_snippet": body_snippet}
+
+
+def preview_page_md(data):
+    lines = [f"# Preview : {data['page_path']}\n"]
+    for k, v in data["frontmatter"].items():
+        lines.append(f"**{k}**: {v}")
+    if data["summary_l1"]:
+        lines.append(f"\n## summary_l1\n{data['summary_l1']}")
+    else:
+        lines.append(f"\n## Début de page\n{data['body_snippet']}…")
+    return "\n".join(lines)

--- a/scripts/mcp/wiki_core.py
+++ b/scripts/mcp/wiki_core.py
@@ -190,3 +190,17 @@ def _resolve_in_vault(page_path):
     if not target.exists():
         raise WikiLookupError(f"Page introuvable : {page_path}")
     return target
+
+
+# ---- read_page -----------------------------------------------------------
+def read_page_data(page_path):
+    target = _resolve_in_vault(page_path)
+    try:
+        content = target.read_text(encoding="utf-8")
+    except Exception as e:
+        raise WikiLookupError(f"Erreur de lecture : {e}")
+    return {"page_path": page_path, "content": content}
+
+
+def read_page_md(data):
+    return data["content"]

--- a/scripts/mcp/wiki_core.py
+++ b/scripts/mcp/wiki_core.py
@@ -233,3 +233,48 @@ def preview_page_md(data):
     else:
         lines.append(f"\n## Début de page\n{data['body_snippet']}…")
     return "\n".join(lines)
+
+
+# ---- search_wiki ---------------------------------------------------------
+def search_wiki_data(query, limit=10):
+    tokens = _normalize_query(query)
+    if not tokens:
+        raise WikiLookupError("Requête vide.")
+    scored = []
+    for p in _all_wiki_pages():
+        try:
+            content = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        fm, body = _parse_front(content)
+        haystack = _normalize_haystack(" ".join([
+            str(fm.get("summary_l0", "")),
+            str(fm.get("summary_l1", "")),
+            p.stem,
+            body,
+        ]))
+        if _all_tokens_present(tokens, haystack):
+            centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
+            scored.append((centrality, p, fm, body))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    kept = scored[:limit]
+    results = [{
+        "path": str(p.relative_to(WIKI_PATH)),
+        "type": fm.get("type", ""),
+        "summary_l0": fm.get("summary_l0") or "",
+        "backlinks": c,
+        "wikilinks": _outgoing_wikilinks(body, limit=3),
+    } for c, p, fm, body in kept]
+    return {"query": query, "limit": limit, "results": results}
+
+
+def search_wiki_md(data):
+    results = data["results"]
+    if not results:
+        return f"Aucun résultat pour « {data['query']} »."
+    lines = [f"# Résultats pour « {data['query']} » ({len(results)})", ""]
+    for r in results:
+        l0 = r["summary_l0"] or "—"
+        wl = ", ".join(r["wikilinks"]) if r["wikilinks"] else "—"
+        lines.append(f"- {r['path']} ({r['type']}) — {l0} — wikilinks: [{wl}]")
+    return "\n".join(lines)

--- a/scripts/mcp/wiki_core.py
+++ b/scripts/mcp/wiki_core.py
@@ -278,3 +278,99 @@ def search_wiki_md(data):
         wl = ", ".join(r["wikilinks"]) if r["wikilinks"] else "—"
         lines.append(f"- {r['path']} ({r['type']}) — {l0} — wikilinks: [{wl}]")
     return "\n".join(lines)
+
+
+# ---- scan_<type> ---------------------------------------------------------
+def scan_type_data(domain, type_singular, query="", top=20):
+    """Return structured scan results for a given type within a domain.
+
+    Raises WikiLookupError when the domain has zero pages (empty domain).
+    Returns an empty results list with a _reason key when the domain exists
+    but has no pages of the requested type, or when the query yields no match.
+    The _reason key is a presentation hint stripped from to_json() output.
+    """
+    domain_pages = _domain_pages(domain)
+    if not domain_pages:
+        raise WikiLookupError(
+            f"Aucune page de type « {type_singular} » dans le domaine « {domain} ».")
+    typed = []
+    for p in domain_pages:
+        try:
+            fm, body = _parse_front(p.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if str(fm.get("type", "")).strip().lower() != type_singular:
+            continue
+        typed.append((p, fm, body))
+    base = {"domain": domain, "type": type_singular, "query": query, "top": top}
+    if not typed:
+        return {**base, "results": [], "_reason": "no_typed"}
+    if query.strip():
+        tokens = _normalize_query(query)
+        scored = []
+        for p, fm, body in typed:
+            haystack = _normalize_haystack(" ".join([
+                str(fm.get("summary_l0", "")),
+                str(fm.get("summary_l1", "")),
+                p.stem,
+                body,
+            ]))
+            if _all_tokens_present(tokens, haystack):
+                centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
+                scored.append((centrality, p, fm))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        kept = scored[:top]
+        if not kept:
+            return {**base, "results": [], "_reason": "no_match"}
+    else:
+        ranked = []
+        for p, fm, _b in typed:
+            centrality = _compute_centrality(str(p.relative_to(WIKI_PATH)))
+            ranked.append((centrality, p, fm))
+        ranked.sort(key=lambda x: x[0], reverse=True)
+        kept = ranked[:top]
+    results = [{
+        "path": str(p.relative_to(WIKI_PATH)),
+        "slug": p.stem,
+        "type": type_singular,
+        # Use `or ""` (not str(...)) so YAML-null summary_l0 becomes "" not "None".
+        "summary_l0": fm.get("summary_l0") or "",
+        "backlinks": c,
+    } for c, p, fm in kept]
+    return {**base, "results": results}
+
+
+def scan_type_md(data):
+    """Render scan_type_data() output as a human-readable markdown string."""
+    type_singular = data["type"]
+    type_plural = _TYPE_PLURAL.get(type_singular, type_singular.capitalize())
+    domain, query = data["domain"], data["query"]
+    if not data["results"]:
+        if data.get("_reason") == "no_match":
+            return (f"Aucune page de type « {type_singular} » dans « {domain} » "
+                    f"ne matche « {query} ».")
+        return f"Aucune page de type « {type_singular} » dans le domaine « {domain} »."
+    header = (f"# {type_plural} dans {domain} — top {len(data['results'])}"
+              + (f" pour « {query} »" if query.strip() else " par centralité"))
+    lines = [header, ""]
+    for r in data["results"]:
+        l0 = r["summary_l0"] or "—"
+        lines.append(f"- {r['slug']} — {l0}")
+    return "\n".join(lines)
+
+
+def scan_sources_data(domain, query="", top=20):
+    """scan_type_data wrapper for sources that requires a non-empty query.
+
+    Raises WikiLookupError with guidance when query is empty, matching the
+    legacy scan_sources behaviour (too many sources to be useful without a target).
+    """
+    if not query.strip():
+        n_sources = sum(1 for p in _domain_pages(domain) if _safe_get_type(p) == "source")
+        raise WikiLookupError(
+            f"scan_sources(\"{domain}\") sans query retournerait {n_sources} sources, peu utile.\n"
+            f"Préciser une query : scan_sources(\"{domain}\", query=\"<topic>\").\n"
+            f"Pour explorer le domaine sans cible, préférer scan_domain(\"{domain}\") "
+            f"ou scan_concepts(\"{domain}\")."
+        )
+    return scan_type_data(domain, "source", query, top)


### PR DESCRIPTION
## Contexte

Implémente #57. `scripts/mcp/mcp-wiki.py` n'exposait le wiki que via **FastMCP en stdio** (consommable uniquement par un client MCP). Cette PR ajoute un **mode CLI headless**, sans dépendance fastmcp, pour les consommateurs automatisés / conteneurisés.

Cible : **v1.1.1** (évolution mineure, rétro-compatible).

## Ce qui change

- **`scripts/mcp/wiki_core.py`** (nouveau) — couche de requête **pure et sans dépendance dure** (PyYAML optionnel, pas de fastmcp). Chaque outil de lecture est scindé en `<tool>_data()` (structure = forme JSON) + `<tool>_md()` (markdown **byte-identique** à l'ancien rendu MCP). Erreurs typées via `WikiLookupError` ; `to_json()` ; `configure()` pour cibler un vault.
- **`scripts/mcp/mcp-wiki.py`** (réécrit) — fine couche de wrappers `@mcp.tool` qui **délèguent** à `wiki_core` (550 → 153 lignes). Descriptions et signatures des 12 outils **inchangées au byte près** (schéma MCP préservé).
- **`scripts/mcp/wiki-cli.py`** (nouveau) — front CLI (argparse) exposant les **11 outils de lecture**. Markdown par défaut, `--json` pour une sortie stable et parsable (`path` vault-relatif, réinjectable dans `preview`/`read`). Exit `0` (succès / vide légitime) vs `2` + stderr (erreur de lookup). Cible un vault via `WIKI_PATH` ou `--wiki-path`. **N'importe pas fastmcp.**
- **Tests** — `test_wiki_core.py` (parité MCP↔core, gated fastmcp) + `test_wiki_cli.py` (subprocess : exit codes, JSON parsable, parité CLI↔core). Convention `unittest` du repo.
- **Doc** — section « CLI mode » dans `docs/mcp-tiered-loading.md` + note dans `setup-mcp.sh` (EN).

## Garanties de non-régression

- Le serveur MCP et le CLI partagent `wiki_core` → un même appel rend un markdown **byte-identique** par les deux entrées (vérifié par les tests de parité + comparaison empirique sur 17 cas limites).
- Schéma MCP (noms, descriptions, signatures des 12 outils) **identique** à `1093d5e` (vérifié par AST).
- `smoke_test.py` (gates de tokens) : **All gates passed** sur le vault réel.

## Test Plan

- [x] `python3 -m unittest test_wiki_core test_wiki_cli` → 43 OK (parité MCP self-skip sans fastmcp)
- [x] `<pipx>/python -m unittest test_wiki_core` → 32 OK (11 tests de parité MCP actifs)
- [x] `WIKI_PATH=<vault> <pipx>/python smoke_test.py ia` → All gates passed
- [x] CLI réel : `scan-domain ia`, `search … --json | read <path>` (round-trip), `read <absente>` → exit 2

## Hors périmètre

`drop_to_raw` (écriture) n'est pas exposé en CLI ; aucun changement de pagination/ranking.

---

## Post-merge — release v1.1.1 (mainteneur)

Cette PR embarque la préparation de release (bump `.claude/template-version` → `1.1.1` + entrée CHANGELOG `[v1.1.1] — unreleased`). **Release propagation-only** : pas de `scripts/migrations/v1.1.1.md` (tous les fichiers sont template-tracked → propagés par l'étape 5 de `/update-vault` ; aucun fichier user-owned/global ne change, schéma MCP identique).

Étapes pour finaliser après merge :

1. Merger cette PR dans `develop`, puis `develop → main`.
2. **Figer la date** du CHANGELOG : `## [v1.1.1] — unreleased` → date du tag (cf. le commit « figer la date » de v1.1.0).
3. **Tag `v1.1.1`** sur `main` :
   ```bash
   git checkout main && git pull
   git tag v1.1.1 && git push origin v1.1.1
   ```
   C'est ce tag qui rend la version consommable : `/update-vault` lit `.claude/template-version` sur la branche cible et calcule la chaîne de migrations (aucune ici).
4. Vérifier l'upgrade depuis un vault : `/update-vault` doit propager `wiki_core.py` + `wiki-cli.py` + `mcp-wiki.py` réécrit (nouveaux fichiers pré-cochés), sans proposer de migration.
5. **Clôturer #57** manuellement (cette PR cible `develop`, pas la branche par défaut → pas d'auto-close).
