### PR TITLE
ci(lint): bumper les actions dépréciées Node 20 → Node 24 (#56)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,8 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       # Obsidian-safe formatter check (wraps Prettier; preserves pipes in
@@ -32,8 +32,8 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v16
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           globs: |
             **/*.md
@@ -49,8 +49,8 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - run: python3 scripts/wiki-maint/validate-wiki.py
@@ -60,7 +60,7 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Lychee external link report
         uses: lycheeverse/lychee-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 ### Changed
 
 - **`scripts/mcp/mcp-wiki.py`**: refactored (550 → 153 lines) into a thin FastMCP wrapper that delegates to `wiki_core`. **No behaviour change** — the 12 tool descriptions and signatures are byte-identical (MCP schema unchanged) and every tool's markdown output is byte-identical to v1.1.0 (guaranteed by the parity tests and the `smoke_test.py` token gates). (#57)
+- **`.github/workflows/lint.yml`**: bumped the CI actions off the deprecated Node 20 runtime to Node 24 — `actions/checkout@v4 → @v6`, `actions/setup-python@v5 → @v6`, `DavidAnson/markdownlint-cli2-action@v16 → @v23` (bundles markdownlint-cli2 0.22.x; verified to introduce no new rule failures on this repo). Job logic unchanged. The workflow is template-tracked, so the fix reaches vaults via `/update-vault` file propagation — no migration needed. (#56)
 
 ## [v1.1.0] — 2026-05-25
 


### PR DESCRIPTION
Résout #56.

## Problème

Les actions de `.github/workflows/lint.yml` tournaient sur **Node.js 20** (déprécié) : GitHub force Node 24 par défaut au 16/06/2026 et retire Node 20 du runner au 16/09/2026.

## Changement

Bump des actions vers leur version Node 24 (tags major-flottants, style du workflow) :

| Action | Avant | Après | Occurrences |
|--------|-------|-------|-------------|
| `actions/checkout` | `@v4` | `@v6` | 4× (dont `link-check-report`) |
| `actions/setup-python` | `@v5` | `@v6` | 2× |
| `DavidAnson/markdownlint-cli2-action` | `@v16` | `@v23` | 1× |

- `markdownlint-cli2-action@v23` est la **première version Node 24** (v22 = node20). Elle embarque markdownlint-cli2 `0.13.0` → `0.22.1` (markdownlint `v0.40.0`).
- `checkout` bumpé aussi dans `link-check-report` (run hebdo) pour éliminer l'avertissement node20 partout.
- `lycheeverse/lychee-action@v2` laissé tel quel (action conteneurisée, non concernée par la dépréciation node20). Logique des jobs **inchangée** (out-of-scope respecté).

## Vérification

- Pré-test local : `markdownlint-cli2 v0.22.1` sur les 35 `.md` committés avec le `.markdownlint.jsonc` existant → **0 erreur** (le saut 0.13 → 0.22 n'introduit aucune nouvelle règle bloquante).
- La CI de cette PR tourne déjà sur les **nouvelles** actions → vérifie en direct les done-criteria : 3 jobs verts + aucun avertissement node20.

## Done criteria (#56)

- [ ] Plus aucun avertissement de dépréciation Node 20 dans les logs
- [ ] Les 3 jobs (`format-check`, `wiki-integrity`, `markdownlint`) restent verts