### PR TITLE
fix(wiki-maint): résoudre npx et l'encodage UTF-8 de format-md.py sur Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`scripts/mcp/mcp-wiki.py`**: refactored (550 → 153 lines) into a thin FastMCP wrapper that delegates to `wiki_core`. **No behaviour change** — the 12 tool descriptions and signatures are byte-identical (MCP schema unchanged) and every tool's markdown output is byte-identical to v1.1.0 (guaranteed by the parity tests and the `smoke_test.py` token gates). (#57)
 - **`.github/workflows/lint.yml`**: bumped the CI actions off the deprecated Node 20 runtime to Node 24 — `actions/checkout@v4 → @v6`, `actions/setup-python@v5 → @v6`, `DavidAnson/markdownlint-cli2-action@v16 → @v23` (bundles markdownlint-cli2 0.22.x; verified to introduce no new rule failures on this repo). Job logic unchanged. The workflow is template-tracked, so the fix reaches vaults via `/update-vault` file propagation — no migration needed. (#56)
 
+### Fixed
+
+- **`scripts/wiki-maint/format-md.py`**: fixed a crash on Windows where `subprocess.run(["npx", ...], shell=False)` failed to resolve `npx.cmd`/`.ps1` via `PATHEXT` (`FileNotFoundError: [WinError 2]`), and a follow-up `UnicodeEncodeError` on the Windows console (cp1252) once npx was reachable. `npx` is now resolved via `shutil.which()` (raises a clear error if missing); `stdout`/`stderr` are forced to UTF-8 at startup. (#60)
+
 ## [v1.1.0] — 2026-05-25
 
 ### Added

--- a/scripts/wiki-maint/format-md.py
+++ b/scripts/wiki-maint/format-md.py
@@ -79,7 +79,7 @@ def expand(paths):
 def _npx():
     exe = shutil.which("npx")
     if not exe:
-        raise RuntimeError("npx introuvable sur le PATH — installe Node.js (qui fournit npx).")
+        raise RuntimeError("npx not found on PATH — install Node.js (which provides npx).")
     return exe
 
 

--- a/scripts/wiki-maint/format-md.py
+++ b/scripts/wiki-maint/format-md.py
@@ -76,9 +76,16 @@ def expand(paths):
     return out
 
 
+def _npx():
+    exe = shutil.which("npx")
+    if not exe:
+        raise RuntimeError("npx introuvable sur le PATH — installe Node.js (qui fournit npx).")
+    return exe
+
+
 def run_prettier(files, cwd=None):
     proc = subprocess.run(
-        ["npx", "-y", "prettier", "--write", *files],
+        [_npx(), "-y", "prettier", "--write", *files],
         capture_output=True, text=True, cwd=cwd,
     )
     if proc.returncode != 0:
@@ -163,6 +170,11 @@ def do_check(files):
 
 
 def main():
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     ap = argparse.ArgumentParser(description="Obsidian-safe markdown formatter (wraps Prettier).")
     mode = ap.add_mutually_exclusive_group(required=True)
     mode.add_argument("--write", action="store_true", help="format files in place")

--- a/scripts/wiki-maint/test_format_md.py
+++ b/scripts/wiki-maint/test_format_md.py
@@ -5,12 +5,14 @@ Run: cd scripts/wiki-maint && python3 -m unittest test_format_md
 (Invokes Prettier via npx; first run may download it.)
 """
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest import mock
 
 HERE = Path(__file__).resolve().parent
 SCRIPT = HERE / "format-md.py"
@@ -20,11 +22,36 @@ fmt = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(fmt)
 
 
-def run(args, cwd):
+def run(args, cwd, env=None):
     return subprocess.run(
         [sys.executable, str(SCRIPT), *args],
-        capture_output=True, text=True, cwd=cwd,
+        capture_output=True, text=True, cwd=cwd, env=env,
     )
+
+
+class NpxResolutionTest(unittest.TestCase):
+    def test_npx_found_via_which(self):
+        with mock.patch.object(fmt.shutil, "which", return_value="/usr/bin/npx") as m:
+            self.assertEqual(fmt._npx(), "/usr/bin/npx")
+            m.assert_called_once_with("npx")
+
+    def test_npx_missing_raises_clear_error(self):
+        with mock.patch.object(fmt.shutil, "which", return_value=None):
+            with self.assertRaises(RuntimeError) as ctx:
+                fmt._npx()
+        self.assertIn("npx", str(ctx.exception).lower())
+        self.assertIn("PATH", str(ctx.exception))
+
+    def test_missing_npx_end_to_end_clear_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            f = tmp / "t.md"
+            f.write_text("# T\n", encoding="utf-8")
+            env = {"PATH": "/usr/bin:/bin"}  # strip node/npx dirs
+            r = run(["--write", "t.md"], cwd=str(tmp), env=env)
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("npx", r.stderr)
+            self.assertIn("PATH", r.stderr)
 
 
 class MaskUnmaskTest(unittest.TestCase):
@@ -112,6 +139,21 @@ class CheckTest(unittest.TestCase):
             (pkg / "README.md").write_text("#  Bad\n\n\n\nx\n", encoding="utf-8")
             r = run(["--check", "**/*.md"], cwd=str(tmp))
             self.assertEqual(r.returncode, 0, r.stdout + r.stderr)  # venv ignored → clean
+
+
+class Utf8OutputTest(unittest.TestCase):
+    def test_check_output_survives_ascii_console(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            (tmp / ".prettierrc").write_text('{"proseWrap":"preserve"}', encoding="utf-8")
+            f = tmp / "t.md"
+            f.write_text("| a | [[x|y]] | `p|q` |\n| --- | --- | --- |\n| 1 | 2 | 3 |\n",
+                         encoding="utf-8")
+            run(["--write", "t.md"], cwd=str(tmp))
+            env = {**os.environ, "PYTHONIOENCODING": "ascii"}
+            r = run(["--check", "t.md"], cwd=str(tmp), env=env)
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertNotIn("UnicodeEncodeError", r.stderr)
 
 
 class ExpandTest(unittest.TestCase):


### PR DESCRIPTION
## Résumé

Sur Windows, `scripts/wiki-maint/format-md.py --write|--check` plantait systématiquement (utilisé en fin de `/domain add` et `/ingest`). Deux bugs, même cause racine (helper externe invoqué par son nom nu, non résolu sur Windows), diagnostiqués et déjà validés en conditions réelles par l'auteur de l'issue (Windows 11, Node v22, Python 3.12, `--write`+`--check` sur 125 fichiers) :

1. `subprocess.run(["npx", ...], shell=False)` ne résout pas `npx.cmd`/`.ps1` via `PATHEXT` → `FileNotFoundError`. Fix : résolution via `shutil.which("npx")`, avec échec explicite si absent.
2. Une fois npx résolu, `print("✓ format: ...")` casse sur la console Windows (cp1252) → `UnicodeEncodeError`. Fix : `stdout`/`stderr` forcés en UTF-8 en tête de `main()`.

Plan détaillé et revue de code effectués avant merge (2 passes de revue — la première a relevé un message d'erreur en français, corrigé pour respecter la convention "fichiers propagés = anglais").

## Plan de test

- [x] `python3 -m unittest discover -s scripts/wiki-maint -p "test_format_md.py" -v` → 13/13 verts (9 existants + 4 nouveaux : résolution `_npx()`, échec bout-en-bout si npx absent, survie UTF-8 sous `PYTHONIOENCODING=ascii`)
- [x] Comportement Linux/macOS/CI inchangé (les 9 tests pré-existants passent sans adaptation)
- [ ] Validation Windows réelle non reproductible depuis cette machine (macOS) — l'auteur de l'issue a déjà validé en conditions réelles (voir commentaire de l'issue) ; les tests bout-en-bout ci-dessus simulent fidèlement les deux symptômes de façon portable (PATH tronqué, encodage forcé en ASCII)

Closes #60