### PR TITLE
fix(wiki-maint): résoudre python3/python de façon portable dans scan-raw.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 - **`scripts/mcp/mcp-wiki.py`**: refactored (550 → 153 lines) into a thin FastMCP wrapper that delegates to `wiki_core`. **No behaviour change** — the 12 tool descriptions and signatures are byte-identical (MCP schema unchanged) and every tool's markdown output is byte-identical to v1.1.0 (guaranteed by the parity tests and the `smoke_test.py` token gates). (#57)
 - **`.github/workflows/lint.yml`**: bumped the CI actions off the deprecated Node 20 runtime to Node 24 — `actions/checkout@v4 → @v6`, `actions/setup-python@v5 → @v6`, `DavidAnson/markdownlint-cli2-action@v16 → @v23` (bundles markdownlint-cli2 0.22.x; verified to introduce no new rule failures on this repo). Job logic unchanged. The workflow is template-tracked, so the fix reaches vaults via `/update-vault` file propagation — no migration needed. (#56)
 
+### Fixed
+
+- **`scripts/wiki-maint/scan-raw.sh`**: fixed silently degraded ingest-state detection on Windows, where the bare `python3` invocation in `_normalize_path()` could resolve to the non-functional Windows Store stub — and, since it's nested inside a command substitution, its failure was swallowed by `set -e`, producing false `covered-by` verdicts. The Python interpreter is now resolved once at startup (`PYTHON_BIN` env override, then `python3`, then `python`) and functionally self-tested; if none works, the script now fails loudly before scanning instead of degrading silently. (#61)
+
 ## [v1.1.0] — 2026-05-25
 
 ### Added

--- a/scripts/wiki-maint/scan-raw.sh
+++ b/scripts/wiki-maint/scan-raw.sh
@@ -19,6 +19,29 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VAULT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 WIKI_SOURCES="$VAULT_ROOT/wiki/sources"
 
+# --- Résolution portable de l'interpréteur Python ---
+# Sur Windows, l'installeur officiel ne fournit que python.exe (pas
+# python3.exe), et le nom nu "python3" peut résoudre vers le stub Microsoft
+# Store (présent sur le PATH, mais non fonctionnel). command -v seul ne
+# détecte pas ce cas — un auto-test fonctionnel est nécessaire. Ceci doit
+# s'exécuter avant toute boucle : un échec de python3 dans _normalize_path()
+# est invisible à `set -e` une fois imbriqué dans une substitution de
+# commande (path_to_slug["$(_safe_key "$(_normalize_path ...)")"]=...), donc
+# c'est le seul point où un abort explicite est fiable.
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [ -z "$PYTHON_BIN" ]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  fi
+fi
+if [ -z "$PYTHON_BIN" ] || ! "$PYTHON_BIN" -c "import unicodedata" >/dev/null 2>&1; then
+  echo "ERROR: no functional Python interpreter found (python3/python missing or unusable — Windows Store stub?)." >&2
+  echo "       scan-raw.sh depends on it for NFC path normalization. Install Python 3, or set \$PYTHON_BIN." >&2
+  exit 1
+fi
+
 # --- Collecte des fichiers à analyser ---
 
 args=("$@")
@@ -69,7 +92,7 @@ _safe_key() {
 # typographiques (U+2019 RIGHT SINGLE QUOTATION MARK → U+0027 APOSTROPHE).
 # Les autres caractères typographiques sont volontairement hors scope en v1.1.0.
 _normalize_path() {
-  python3 - <<'PY' "$1"
+  "$PYTHON_BIN" - <<'PY' "$1"
 import sys, unicodedata
 p = sys.argv[1]
 p = unicodedata.normalize("NFC", p)

--- a/scripts/wiki-maint/test_scan_raw.py
+++ b/scripts/wiki-maint/test_scan_raw.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""unittest suite for scan-raw.sh — verifies Python interpreter resolution.
+
+Run: cd scripts/wiki-maint && python3 -m unittest test_scan_raw
+Builds a hermetic PATH per test (symlinks to only the coreutils the script
+needs) so each scenario (missing python3, python-only, broken interpreter)
+is deterministic regardless of what's installed on the host running the
+suite.
+"""
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "scan-raw.sh"
+BASH = shutil.which("bash")
+REAL_PYTHON = sys.executable
+
+REQUIRED_TOOLS = ["find", "grep", "sed", "sort", "sha256sum", "dirname", "basename", "wc", "tr", "cut"]
+
+
+def _hermetic_bin(tmp):
+    """A bin/ dir with symlinks to only the coreutils scan-raw.sh needs.
+    No python3/python here — callers add those explicitly per scenario."""
+    bindir = tmp / "bin"
+    bindir.mkdir(exist_ok=True)
+    for tool in REQUIRED_TOOLS:
+        src = shutil.which(tool)
+        assert src, f"{tool} not found on the test host's PATH"
+        (bindir / tool).symlink_to(src)
+    return bindir
+
+
+def _write_broken_python(path):
+    """Simulates a PATH entry that resolves but isn't a working interpreter
+    (e.g. the Windows Store python3 stub): any invocation fails."""
+    path.write_text('#!/bin/sh\necho "not a real interpreter" >&2\nexit 9\n', encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _write_marker_python(path, marker_file):
+    path.write_text(
+        f'#!/bin/sh\necho called >> "{marker_file}"\nexec "{REAL_PYTHON}" "$@"\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _make_vault(tmp, raw_files, sources):
+    """raw_files: {rel_path_under_raw: content}. sources: {slug: {source_path, source_sha256?}}."""
+    dest_script_dir = tmp / "scripts" / "wiki-maint"
+    dest_script_dir.mkdir(parents=True)
+    dest_script = dest_script_dir / "scan-raw.sh"
+    dest_script.write_text(SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+    dest_script.chmod(0o755)
+
+    for rel, content in raw_files.items():
+        p = tmp / "raw" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+    sources_dir = tmp / "wiki" / "sources"
+    sources_dir.mkdir(parents=True, exist_ok=True)
+    for slug, fm in sources.items():
+        lines = ["---"]
+        lines.append(f"source_path: {fm['source_path']}")
+        if "source_sha256" in fm:
+            lines.append(f"source_sha256: {fm['source_sha256']}")
+        lines.append("---")
+        (sources_dir / f"{slug}.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    return dest_script
+
+
+def run_scan(script, env, cwd):
+    return subprocess.run([BASH, str(script)], capture_output=True, text=True, env=env, cwd=cwd)
+
+
+class PythonResolutionTest(unittest.TestCase):
+    def test_baseline_python3_present_unchanged(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            bindir = _hermetic_bin(tmp)
+            (bindir / "python3").symlink_to(REAL_PYTHON)
+            script = _make_vault(
+                tmp,
+                {"foo.md": "hello\n"},
+                {"foo": {"source_path": "raw/foo.md"}},
+            )
+            r = run_scan(script, env={"PATH": str(bindir)}, cwd=str(tmp))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("SKIP     raw/foo.md  (covered-by: foo)", r.stdout)
+
+    def test_python_only_no_python3_resolves(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            bindir = _hermetic_bin(tmp)
+            (bindir / "python").symlink_to(REAL_PYTHON)  # no python3 entry
+            script = _make_vault(
+                tmp,
+                {"foo.md": "hello\n"},
+                {"foo": {"source_path": "raw/foo.md"}},
+            )
+            r = run_scan(script, env={"PATH": str(bindir)}, cwd=str(tmp))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("SKIP     raw/foo.md  (covered-by: foo)", r.stdout)
+
+    def test_no_interpreter_fails_loudly_no_false_verdict(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            bindir = _hermetic_bin(tmp)  # neither python nor python3
+            script = _make_vault(
+                tmp,
+                {"foo.md": "hello\n"},
+                {"foo": {"source_path": "raw/foo.md"}},
+            )
+            r = run_scan(script, env={"PATH": str(bindir)}, cwd=str(tmp))
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("python", r.stderr.lower())
+            self.assertNotIn("covered-by", r.stdout)
+            self.assertNotIn("NEW", r.stdout)
+
+    def test_non_functional_interpreter_fails_loudly(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            bindir = _hermetic_bin(tmp)
+            _write_broken_python(bindir / "python3")  # resolves, but unusable (Store-stub-like)
+            script = _make_vault(
+                tmp,
+                {"foo.md": "hello\n"},
+                {"foo": {"source_path": "raw/foo.md"}},
+            )
+            r = run_scan(script, env={"PATH": str(bindir)}, cwd=str(tmp))
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("python", r.stderr.lower())
+            self.assertNotIn("covered-by", r.stdout)
+
+    def test_python_bin_override_respected(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            bindir = _hermetic_bin(tmp)
+            (bindir / "python3").symlink_to(REAL_PYTHON)  # present but must NOT be used
+            marker_file = tmp / "marker.txt"
+            marker_python = tmp / "marker_python.sh"
+            _write_marker_python(marker_python, marker_file)
+            script = _make_vault(
+                tmp,
+                {"foo.md": "hello\n"},
+                {"foo": {"source_path": "raw/foo.md"}},
+            )
+            env = {"PATH": str(bindir), "PYTHON_BIN": str(marker_python)}
+            r = run_scan(script, env=env, cwd=str(tmp))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            self.assertIn("SKIP     raw/foo.md  (covered-by: foo)", r.stdout)
+            self.assertTrue(marker_file.exists(), "PYTHON_BIN override was not invoked")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Résumé

Sur Windows, `scripts/wiki-maint/scan-raw.sh` appelait `python3` en dur dans `_normalize_path()` pour la normalisation NFC des chemins comparés lors de la détection d'état d'`/ingest`. `python3` peut résoudre vers le stub Microsoft Store (présent sur le PATH, non fonctionnel) — et un échec dans `_normalize_path()` était **silencieusement avalé par `set -e`** (chaque appel est imbriqué dans une double substitution de commande, `errexit` n'évalue que le statut de la commande englobante). Résultat : un fichier réellement `NEW` pouvait être rapporté `MODIFIED ... (covered-by: <slug-erroné>)`, compromettant l'idempotence hash-based du workflow `/ingest`.

Fix : résolution de `PYTHON_BIN` une fois au démarrage (override env → `python3` → `python`), suivie d'un **auto-test fonctionnel** (`import unicodedata`, pas seulement `command -v`, pour attraper le cas du stub qui répond présent sans être exploitable) exécuté **avant toute boucle** — seul point où l'abort est fiable vu le piège de substitution imbriquée. Aucun interpréteur utilisable → échec bruyant explicite plutôt qu'un faux `covered-by` silencieux.

**Hors scope** (décidé avec l'utilisateur avant implémentation) : la lenteur mesurée par l'auteur de l'issue (3min42/fichier, un spawn Python par chemin indexé) et le batching NFC suggéré en commentaire — refactor plus large sur une logique de matching qui a déjà fait l'objet de 3 bugfixes antérieurs, à traiter en suivi séparé.

Plan détaillé et revue de code effectués avant merge (revue : root cause indépendamment reproduite en bash par le reviewer, aucun issue critique/important, `Ready to merge: Yes`).

## Plan de test

- [x] `python3 -m unittest discover -s scripts/wiki-maint -p "test_scan_raw.py" -v` → 5/5 verts (nouveau fichier, aucun test n'existait avant pour ce script) : baseline inchangée, python-only (pas de python3), aucun interpréteur, interpréteur présent mais non fonctionnel (simule le stub Store), override `PYTHON_BIN` respecté
- [x] Non-régression : `python3 -m unittest discover -s scripts/wiki-maint -p "test_*.py" -v` → 34/34 verts (9 `test_format_md` + 5 `test_scan_raw` + 20 `test_validate_wiki`)
- [x] Exécution manuelle de `scan-raw.sh` sur le repo réel — comportement inchangé
- [ ] Validation Windows réelle non reproductible depuis cette machine (macOS) — les tests ci-dessus simulent le comportement via un `PATH` hermétique (coreutils symlinkés individuellement, aucun `/usr/bin` inclus) plutôt que de dépendre de l'environnement Windows ; à confirmer par l'auteur de l'issue sur sa machine avant fermeture définitive

Closes #61