### PR TITLE
chore(release): préparer v1.1.1 (date CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
-## [v1.1.1] — unreleased
+## [v1.1.1] — 2026-07-03
 
 ### Added
 


### PR DESCRIPTION
## Résumé

Fige la date de release dans le CHANGELOG : `## [v1.1.1] — unreleased` → `## [v1.1.1] — 2026-07-03`. `.claude/template-version` est déjà à `1.1.1` (bump fait dans #58).

## Périmètre couvert par cette version

- CI bump Node 24 (#56)
- Mode CLI headless `wiki-cli.py` (#57)
- Fix Windows npx/UTF-8 dans `format-md.py` (#60)
- Fix Windows résolution python3/python dans `scan-raw.sh` (#61)
- Ingestion headless MCP (`ingest()`/`list_domains()`) + durcissement sécurité (#62)

## Test plan

- [x] CHANGELOG relu, aucune autre modification