### PR TITLE
feat: orientation domaine des agents experts via wiki-cli (tiered loading pour sous-agents)

### DIFF
--- a/.claude/agents/domain-expert.md.tpl
+++ b/.claude/agents/domain-expert.md.tpl
@@ -15,7 +15,7 @@ You are the wiki's **{{domain_label}}** expert. You ingest a source and create /
 
 When invoked, you receive:
 - The **path to a raw file** to ingest (note, transcript, article…).
-- The **current wiki context**: list of existing pages in the domain (`wiki/entities/`, `wiki/concepts/`, `wiki/cheatsheets/`, `wiki/syntheses/` depending on your deliverables) and the contents of `wiki/domains/{{domain_slug}}.md`.
+- The **current wiki context**: a fresh `scan-domain` snapshot of your domain (hub, counts by type, top pages by centrality) and the contents of `wiki/domains/{{domain_slug}}.md`. If the snapshot is absent, produce it yourself (see **Domain orientation** below).
 
 You execute the ingest **end-to-end**, writing directly into the wiki. The orchestrator does not filter — what comes out of your work is what enters the wiki.
 
@@ -32,6 +32,20 @@ Read `CLAUDE.md` at the root if in doubt. The essentials:
 - Threshold for creating a concept/entity page: **≥2 sources** OR **judged structural** by you (add `structural: true` to the frontmatter in that case).
 - Cite the **timestamp / line number** of the raw for every numerical value or specific claim you push. No hallucinations.
 - **`source_path:` always filled, never empty** — single file path. **`covered_paths:`** mandatory if the page covers multiple raw files (YAML list of contributing paths, directories with trailing `/`). Used by `scripts/scan-raw.sh` to avoid false-positive "NEW" entries on the next scan.
+
+## Domain orientation
+
+Your first reflex, before reading the source: orient yourself in your own domain. You have the wiki's tiered-loading CLI — use it instead of guessing.
+
+- If your spawn prompt includes a `scan-domain` snapshot, use it as your starting map.
+- Otherwise run it yourself: `bash scripts/mcp/wiki-cli.sh scan-domain {{domain_slug}}` (hub, counts by type, top pages by centrality — ~1k tokens).
+- Drill down only where the source demands it: `bash scripts/mcp/wiki-cli.sh scan-concepts {{domain_slug}} --query "<topic>"` (same for `scan-entities`, `scan-cheatsheets`, `scan-syntheses`, `scan-decisions`, `scan-diagrams`, `scan-sources`).
+- `bash scripts/mcp/wiki-cli.sh preview <page>` before deciding create-vs-enrich; `read <page>` only when you actually enrich it.
+- **Never guess whether a page exists** — check with a scan `--query` first. This applies to every `[[wikilink]]` you write: verify the target exists, otherwise create it (if the threshold is met) or log a Radar item.
+- Cross-domain anchors (co-ingest, cross-refs): `bash scripts/mcp/wiki-cli.sh search "<term>"`.
+- Idempotence step 0: resolve the candidate source page with `bash scripts/mcp/wiki-cli.sh scan-sources {{domain_slug}} --query "<slug>"` then `preview` it (frontmatter → `source_sha256`), instead of guessing its path.
+- If `wiki-cli` fails (missing interpreter, non-zero exit, or a denied command in headless mode), fall back to `Glob`/`Grep` and mention the degradation in your `## Ingest summary`.
+- These are all the commands you need; for occasional flags (`--top`, `--json`), run `bash scripts/mcp/wiki-cli.sh <command> --help`.
 
 ## What you produce
 

--- a/.claude/commands/ingest.md
+++ b/.claude/commands/ingest.md
@@ -70,10 +70,12 @@ For each validated agent, launch an `Agent` call with:
 - `subagent_type`: the chosen agent.
 - **Prompt** containing:
   - Path of the raw file to ingest.
-  - List of titles of existing pages in the domain (`wiki/entities/`, `wiki/concepts/`, `wiki/cheatsheets/`, etc. depending on the agent's deliverables).
+  - A fresh domain snapshot: run `bash scripts/mcp/wiki-cli.sh scan-domain <d>` and paste its output verbatim under a `## Domain snapshot` heading. Regenerate it for every spawn (never once per batch) so intra-batch pages created by earlier sources are visible. If the command fails (or is denied in `--headless` mode), omit the snapshot — the agent produces its own via its Domain orientation reflex.
   - Path of `wiki/domains/<d>.md`.
   - The full content of `.claude/agent-output-contract.md`.
   - Instruction: execute the ingest end-to-end, then return the three blocks (`## Ingest summary`, `## Radar items`, `## Evolution suggestions`) per the contract. The agent **does not write** to `wiki/log.md`, `wiki/radar.md`, or `.claude/agents/*.suggestions.md` — the main context handles propagation.
+
+The main context no longer builds a flat page-title list — the snapshot (counts + centrality + summaries) is both cheaper and richer, and the agent drills down on demand with the same CLI.
 
 Cross-domain → multiple agents in parallel (same multi-tool call).
 

--- a/.claude/template-version
+++ b/.claude/template-version
@@ -1,1 +1,1 @@
-template-version: 1.1.1
+template-version: 1.1.2

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -491,6 +491,8 @@ cp .claude/agents/domain-expert.md.tpl .claude/agents/{{domain_slug}}-expert.md
 
 Then substitute in the copy the **17 per-domain placeholders**: `{{domain_slug}}`, `{{domain_label}}`, `{{is_hub_pivot}}`, `{{hub_pivot_marker}}`, `{{summary_l0}}`, `{{summary_l1}}`, `{{domain_intro_paragraph}}`, `{{taxonomy_section}}`, `{{related_domains_section}}`, `{{deliverables}}`, `{{deliverables_signature_block}}`, `{{trigger_examples}}`, `{{frames_visual_formats}}`, `{{co_ingest_partners}}`, `{{co_ingest_section}}`, `{{authority_table_enabled}}`, `{{authority_table_section}}`, `{{confidentiality_block}}`, `{{confidentiality_section}}`, `{{domain_specific_observation_section}}`, `{{model}}`, `{{effort}}`, `{{maxTurns}}`.
 
+> After generating the agents, optionally add `Bash(bash scripts/mcp/wiki-cli.sh *)` to `.claude/settings.json` `permissions.allow` so the experts' Domain-orientation queries (the `## Domain orientation` section) run without a first-use permission prompt. Existing vaults get this automatically through the `v1.1.2-domain-orientation` migration.
+
 ### 5.3 Per-domain duplication — hubs
 
 For each `domain_slug`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
+## [v1.1.2] — 2026-07-17
+
+### Added
+
+- **`scripts/mcp/wiki-cli.sh`**: portable wrapper over `wiki-cli.py` (resolves `python3`/`python` like `scan-raw.sh`, Windows-safe against the Microsoft Store `python3` stub). The single invocation string `bash scripts/mcp/wiki-cli.sh <cmd>` is shared by the agent template, `/ingest`, the allowlist, and the headless guard.
+- **`.claude/agents/domain-expert.md.tpl`**: new **Domain orientation** section — each expert self-orients in its domain via the tiered-loading CLI (`scan-domain → drill-down → preview/read`) instead of depending on a main-injected page-title list, with a `Glob`/`Grep` fallback. Idempotence step 0, cross-refs, and `[[wikilink]]` checks now resolve through the CLI rather than guessing.
+- **`scripts/migrations/v1.1.2-domain-orientation.md`**: interactive, idempotent `/update-vault` migration that inserts the Domain orientation section into existing `<domain>-expert.md` agents and adds the `wiki-cli.sh` allowlist rule to the vault's `.claude/settings.json`.
+
+### Changed
+
+- **`.claude/commands/ingest.md`**: the spawn prompt injects a fresh `scan-domain` snapshot (counts + centrality + summaries) per spawn instead of a flat page-title list; the main context no longer builds that list.
+- **`scripts/mcp/ingest-headless-guard.sh`**: allowlists the charset-safe `wiki-cli.sh` subset (`scan-domain`, `scan-<type>` without `--query`, `list-domains`, `preview`, `read`) so headless ingest also gets the snapshot; `--query`/`search` stay denied (fall back to `Glob`/`Grep`). Guard tests extended (+10 allow/deny cases).
+
 ## [v1.1.1] — 2026-07-03
 
 ### Added

--- a/scripts/mcp/ingest-headless-guard.sh
+++ b/scripts/mcp/ingest-headless-guard.sh
@@ -91,6 +91,23 @@ except Exception:
       exit 0
     fi
 
+    # wiki-cli.sh — read-only tiered-loading queries for domain orientation.
+    # Only the charset-safe subcommands are allowlisted: scan-domain / scan-<type>
+    # take a domain slug, preview / read take a wiki page path (all within
+    # SAFE_ARG), list-domains takes nothing. --query and search carry arbitrary
+    # quoted text that can't be charset-anchored, so they are intentionally NOT
+    # allowlisted — the agent falls back to Glob/Grep for those in headless mode.
+    WIKI_CLI_SCAN='scan-domain|scan-concepts|scan-entities|scan-decisions|scan-syntheses|scan-cheatsheets|scan-diagrams|scan-sources'
+    if [[ "$command" =~ ^bash\ scripts/mcp/wiki-cli\.sh\ ($WIKI_CLI_SCAN)\ $SAFE_ARG$ ]]; then
+      exit 0
+    fi
+    if [[ "$command" =~ ^bash\ scripts/mcp/wiki-cli\.sh\ list-domains$ ]]; then
+      exit 0
+    fi
+    if [[ "$command" =~ ^bash\ scripts/mcp/wiki-cli\.sh\ (preview|read)\ $SAFE_ARG$ ]]; then
+      exit 0
+    fi
+
     # Vault-local extension: kept as prefix + metachar-denylist rather than
     # a charset-anchored regex, since the vault owner controls both the
     # prefix list and the trust boundary here (analogous to how they

--- a/scripts/mcp/test_wiki_core.py
+++ b/scripts/mcp/test_wiki_core.py
@@ -781,6 +781,59 @@ class TestIngestHeadlessGuard(unittest.TestCase):
             {"command": "bash scripts/wiki-maint/scan-raw.sh ../../etc"})
         self.assertEqual(result.returncode, 2)
 
+    # wiki-cli.sh read-only orientation queries: only the charset-safe subset
+    # is allowlisted. --query / search (arbitrary quoted text) stay denied.
+    def test_allows_wiki_cli_scan_domain(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh scan-domain ia"})
+        self.assertEqual(result.returncode, 0)
+
+    def test_allows_wiki_cli_list_domains(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh list-domains"})
+        self.assertEqual(result.returncode, 0)
+
+    def test_allows_wiki_cli_scan_concepts(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh scan-concepts ia"})
+        self.assertEqual(result.returncode, 0)
+
+    def test_allows_wiki_cli_preview(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh preview wiki/concepts/foo.md"})
+        self.assertEqual(result.returncode, 0)
+
+    def test_allows_wiki_cli_read(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh read wiki/sources/x.md"})
+        self.assertEqual(result.returncode, 0)
+
+    def test_denies_wiki_cli_scan_with_query_flag(self):
+        result = self._run_hook(
+            "Bash",
+            {"command": 'bash scripts/mcp/wiki-cli.sh scan-concepts ia --query "model context protocol"'})
+        self.assertEqual(result.returncode, 2)
+
+    def test_denies_wiki_cli_search(self):
+        result = self._run_hook(
+            "Bash", {"command": 'bash scripts/mcp/wiki-cli.sh search "anything"'})
+        self.assertEqual(result.returncode, 2)
+
+    def test_denies_wiki_cli_scan_domain_with_chained_command(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh scan-domain ia; rm -rf /"})
+        self.assertEqual(result.returncode, 2)
+
+    def test_denies_wiki_cli_scan_domain_with_command_substitution(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh scan-domain $(whoami)"})
+        self.assertEqual(result.returncode, 2)
+
+    def test_denies_wiki_cli_preview_path_traversal(self):
+        result = self._run_hook(
+            "Bash", {"command": "bash scripts/mcp/wiki-cli.sh preview wiki/../etc/passwd"})
+        self.assertEqual(result.returncode, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/mcp/wiki-cli.sh
+++ b/scripts/mcp/wiki-cli.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# wiki-cli.sh — portable wrapper over wiki-cli.py.
+# Resolves a functional Python interpreter the same way scan-raw.sh does
+# (Windows ships only python.exe, and bare "python3" may resolve to the
+# non-functional Microsoft Store stub), then execs the CLI with all args.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [ -z "$PYTHON_BIN" ]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  fi
+fi
+if [ -z "$PYTHON_BIN" ] || ! "$PYTHON_BIN" -c "import sys" >/dev/null 2>&1; then
+  echo "ERROR: no functional Python interpreter found (python3/python missing or unusable — Windows Store stub?)." >&2
+  echo "       wiki-cli.sh needs it to run wiki-cli.py. Install Python 3, or set \$PYTHON_BIN." >&2
+  exit 1
+fi
+
+exec "$PYTHON_BIN" "$SCRIPT_DIR/wiki-cli.py" "$@"

--- a/scripts/migrations/v1.1.2-domain-orientation.md
+++ b/scripts/migrations/v1.1.2-domain-orientation.md
@@ -17,6 +17,8 @@ Two things ship with this migration:
 1. The `## Domain orientation` section, inserted into each detected domain-expert agent (with `{{domain_slug}}` resolved to the agent's real slug).
 2. A `Bash(bash scripts/mcp/wiki-cli.sh *)` rule in `.claude/settings.json` `permissions.allow`, so the experts' orientation queries run without a first-use permission prompt in interactive sessions. (The `.claude/settings.json` of a vault is a local accumulation of approvals — it is not propagated by the template, so this migration is its only delivery channel.)
 
+**Vault language.** Existing per-domain agents are fully localized to the vault language (an FR vault's agent has `## Ta mission`, `## Ce que tu produis`, … not the EN template headings). Like `v1.0.3-vault-language.md`, this migration **renders the section prose in the agent's own language** — only the `bash scripts/mcp/wiki-cli.sh …` commands, paths, flags, and `[[wikilink]]` examples stay verbatim. Placement anchors are detected by role, not by an exact English heading, so the migration works whatever the vault language.
+
 ## Workflow
 
 ### 1. Add the `wiki-cli.sh` allowlist rule to `settings.json`
@@ -106,7 +108,12 @@ For each detected domain-expert agent, with its captured `<slug>`:
 
 **Idempotence check first.** If the file already contains a line `## Domain orientation` → skip it (already migrated, or manually added). Report it as "already present".
 
-Otherwise, insert the following section. **Substitute `<slug>` with the agent's real slug** everywhere it appears (the template placeholder `{{domain_slug}}` is already resolved to a concrete slug in an existing agent file, so render the concrete slug here too):
+Otherwise, insert the section below. Two substitutions apply:
+
+- **`<slug>` → the agent's real slug** everywhere it appears (the template's `{{domain_slug}}` is already a concrete slug in an existing agent file).
+- **Prose → the agent's language.** Detect the agent's language from its existing headings/body (e.g. `## Ta mission` ⇒ French). Translate every prose sentence and bullet into that language. Keep **verbatim**, untranslated: every `bash scripts/mcp/wiki-cli.sh …` command, every path, every flag (`--query`, `--top`, `--json`), the `[[wikilink]]` token, `scan-domain`/`scan-<type>`/`preview`/`read`/`search` subcommand names, and the `## Ingest summary` reference. If the agent is in English, use the text as-is. Keep the heading itself as `## Domain orientation` (a stable, language-independent anchor the idempotence check relies on).
+
+Canonical (English) source text:
 
 ```markdown
 ## Domain orientation
@@ -124,15 +131,15 @@ Your first reflex, before reading the source: orient yourself in your own domain
 - These are all the commands you need; for occasional flags (`--top`, `--json`), run `bash scripts/mcp/wiki-cli.sh <command> --help`.
 ```
 
-**Placement**: insert it as a new top-level section. Preferred anchor — immediately **before** the `## What you produce` section (this mirrors the template). If that heading is absent (agent was restructured), fall back to inserting it immediately **after** the frontmatter block (the closing `---`), and note the non-standard placement in the report. Never split an existing section.
+**Placement (language-agnostic).** Insert it as a new top-level section immediately **before the deliverables section** — the section that enumerates the wiki pages the agent produces (`## What you produce` in the template, or its localized equivalent such as `## Ce que tu produis` / `## Lo que produces` / `## Was du produzierst`; identify it by role — the heading whose body lists `wiki/sources`, `wiki/concepts`, `wiki/entities` deliverables — not by an exact English string). If you cannot confidently identify that section (heavily restructured agent), fall back to inserting immediately **after** the frontmatter block (the closing `---`) and note the non-standard placement in the report. Never split an existing section.
 
-**Optional mission-bullet rewrite.** If the agent's `## Your mission` section still contains the old wording `list of existing pages in the domain`, propose replacing that bullet with:
+**Optional mission-bullet rewrite.** If the agent's mission section (`## Your mission` / localized equivalent such as `## Ta mission`) still describes the old title-list context — a bullet listing the existing pages of the domain, in whatever language — propose replacing that bullet with this one, rendered in the agent's language (commands/paths verbatim):
 
 ```markdown
 - The **current wiki context**: a fresh `scan-domain` snapshot of your domain (hub, counts by type, top pages by centrality) and the contents of `wiki/domains/<slug>.md`. If the snapshot is absent, produce it yourself (see **Domain orientation** below).
 ```
 
-(Same slug substitution.) If the mission bullet was customized away from the template wording, leave it as-is — the Domain orientation section is self-contained.
+(Same slug substitution.) If the mission bullet was customized away or you cannot confidently locate the old wording, leave it as-is — the Domain orientation section is self-contained.
 
 **Review one by one**: for each file, show the insertion diff (the new section + its anchor context) and ask Apply / Edit manually / Skip.
 
@@ -147,7 +154,8 @@ Append to `wiki/log.md`:
 
 - settings.json: wiki-cli allowlist rule added / already present / skipped.
 - Agents migrated: N inserted / M already present / K edited manually / L skipped (out of <total> domain-expert agents detected).
-- Non-standard placement (section inserted after frontmatter, `## What you produce` not found): <list of agents if any>.
+- Non-standard placement (section inserted after frontmatter, deliverables section not confidently identified): <list of agents if any>.
+- Language rendered per agent: <vault language(s) detected, e.g. Français>.
 - Custom agents skipped (non-domain-expert): <list of names if any>.
 ```
 
@@ -177,7 +185,7 @@ The migration is idempotent at the file level:
 
 ## Preserving user customizations
 
-`.claude/agents/<domain>-expert.md` may contain user customizations (extra sections, refined rules, `/evolve-agent` output). This migration only **inserts one new section** (and optionally rewrites the single stale mission bullet). It never deletes, reorders, or rewrites any other content. If the `## What you produce` anchor cannot be found, it falls back to a safe post-frontmatter insertion and reports it, rather than guessing a location inside existing prose.
+`.claude/agents/<domain>-expert.md` may contain user customizations (extra sections, refined rules, `/evolve-agent` output). This migration only **inserts one new section** (and optionally rewrites the single stale mission bullet), rendered in the agent's own language. It never deletes, reorders, or rewrites any other content. If the deliverables section cannot be confidently identified (in any language), it falls back to a safe post-frontmatter insertion and reports it, rather than guessing a location inside existing prose.
 
 ## Notes
 

--- a/scripts/migrations/v1.1.2-domain-orientation.md
+++ b/scripts/migrations/v1.1.2-domain-orientation.md
@@ -1,0 +1,186 @@
+---
+description: Migration v1.1.2 — insert the Domain orientation section into existing <domain>-expert.md agents and allowlist wiki-cli.sh in settings.json
+---
+
+# Migration `v1.1.2-domain-orientation`
+
+This slash-command is invoked automatically by `/update-vault` when the vault is in version < 1.1.2. It retrofits the **user-owned** domain-expert agents (`.claude/agents/<domain>-expert.md`) with the **Domain orientation** section introduced in v1.1.2, and adds the `wiki-cli.sh` allowlist rule to the vault's `.claude/settings.json`.
+
+## Context
+
+v1.1.2 gives each domain-expert subagent first-class, self-service knowledge of its domain through the already-shipped tiered-loading CLI (`scripts/mcp/wiki-cli.py`, wrapped by the new portable `scripts/mcp/wiki-cli.sh`). Instead of depending on a flat page-title list injected by the main context at every spawn, the agent runs `scan-domain → scan-<type> → preview/read` itself, with a `Glob`/`Grep` fallback.
+
+For new vaults, `domain-expert.md.tpl` already carries the section, so bootstrap handles it. For **existing** vaults, the per-domain `<domain>-expert.md` files are **user-owned** (customized at bootstrap, potentially enriched by `/evolve-agent` afterwards). This migration inserts the section **additively** — it never regenerates or reorders an agent's prompt — and every change goes through `AskUserQuestion`.
+
+Two things ship with this migration:
+
+1. The `## Domain orientation` section, inserted into each detected domain-expert agent (with `{{domain_slug}}` resolved to the agent's real slug).
+2. A `Bash(bash scripts/mcp/wiki-cli.sh *)` rule in `.claude/settings.json` `permissions.allow`, so the experts' orientation queries run without a first-use permission prompt in interactive sessions. (The `.claude/settings.json` of a vault is a local accumulation of approvals — it is not propagated by the template, so this migration is its only delivery channel.)
+
+## Workflow
+
+### 1. Add the `wiki-cli.sh` allowlist rule to `settings.json`
+
+Read `.claude/settings.json`. If it does not exist, treat the current allow list as empty. The rule to ensure present, verbatim:
+
+```
+Bash(bash scripts/mcp/wiki-cli.sh *)
+```
+
+**Idempotence**: if `permissions.allow` already contains this exact string, do nothing (report "already present"). Otherwise append it to `permissions.allow`, preserving every existing entry and the rest of the file (`env`, `additionalDirectories`, other keys) untouched. If the file is absent, create it with the minimal shape:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(bash scripts/mcp/wiki-cli.sh *)"]
+  }
+}
+```
+
+Ask via `AskUserQuestion`:
+
+```json
+{
+  "questions": [
+    {
+      "question": "Add the wiki-cli allowlist rule to .claude/settings.json? (lets the domain experts run their Domain-orientation queries without a per-use permission prompt)",
+      "header": "settings.json",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Apply",
+          "description": "Appends Bash(bash scripts/mcp/wiki-cli.sh *) to permissions.allow. The rest of settings.json is untouched."
+        },
+        {
+          "label": "⏭️ Skip",
+          "description": "Don't touch settings.json. The first wiki-cli call in an interactive ingest will prompt once (then be remembered by Claude Code)."
+        }
+      ]
+    }
+  ]
+}
+```
+
+Apply only if the user picks **Apply**.
+
+### 2. Detect the domain-expert agents
+
+List `.claude/agents/*.md`. For each file, apply the same heuristic as `v1.0.3-vault-language.md`:
+
+- Frontmatter contains `name: <slug>-expert` AND `description: ...expert...` → it's a domain-expert agent. Capture `<slug>` from the `name:` field.
+- Otherwise (e.g. `compress-bb.md`, `extract-range-grid.md`, or any custom slash-command-style agent, and any `*.suggestions.md` / `*.suggestions.archive.md` / `*-reference.md` sidecar) → **skip**.
+
+### 3. Choose a batch strategy
+
+Ask via `AskUserQuestion` how to handle the detected agents:
+
+```json
+{
+  "questions": [
+    {
+      "question": "How do you want to migrate the per-domain agents (N files detected)?",
+      "header": "Agent migration",
+      "multiSelect": false,
+      "options": [
+        {
+          "label": "✅ Apply to all",
+          "description": "Insert the Domain orientation section into every <domain>-expert.md that lacks it, without per-file confirmation. Recommended if you haven't heavily restructured the agents."
+        },
+        {
+          "label": "🔍 Review one by one",
+          "description": "Show the insertion diff and ask for each file. Recommended if some agents have a non-standard section layout."
+        },
+        {
+          "label": "⏭️ Skip all",
+          "description": "Don't touch any agent. Migration will be re-proposed at the next /update-vault."
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 4. Insert the section into each agent
+
+For each detected domain-expert agent, with its captured `<slug>`:
+
+**Idempotence check first.** If the file already contains a line `## Domain orientation` → skip it (already migrated, or manually added). Report it as "already present".
+
+Otherwise, insert the following section. **Substitute `<slug>` with the agent's real slug** everywhere it appears (the template placeholder `{{domain_slug}}` is already resolved to a concrete slug in an existing agent file, so render the concrete slug here too):
+
+```markdown
+## Domain orientation
+
+Your first reflex, before reading the source: orient yourself in your own domain. You have the wiki's tiered-loading CLI — use it instead of guessing.
+
+- If your spawn prompt includes a `scan-domain` snapshot, use it as your starting map.
+- Otherwise run it yourself: `bash scripts/mcp/wiki-cli.sh scan-domain <slug>` (hub, counts by type, top pages by centrality — ~1k tokens).
+- Drill down only where the source demands it: `bash scripts/mcp/wiki-cli.sh scan-concepts <slug> --query "<topic>"` (same for `scan-entities`, `scan-cheatsheets`, `scan-syntheses`, `scan-decisions`, `scan-diagrams`, `scan-sources`).
+- `bash scripts/mcp/wiki-cli.sh preview <page>` before deciding create-vs-enrich; `read <page>` only when you actually enrich it.
+- **Never guess whether a page exists** — check with a scan `--query` first. This applies to every `[[wikilink]]` you write: verify the target exists, otherwise create it (if the threshold is met) or log a Radar item.
+- Cross-domain anchors (co-ingest, cross-refs): `bash scripts/mcp/wiki-cli.sh search "<term>"`.
+- Idempotence step 0: resolve the candidate source page with `bash scripts/mcp/wiki-cli.sh scan-sources <slug> --query "<slug-of-source>"` then `preview` it (frontmatter → `source_sha256`), instead of guessing its path.
+- If `wiki-cli` fails (missing interpreter, non-zero exit, or a denied command in headless mode), fall back to `Glob`/`Grep` and mention the degradation in your `## Ingest summary`.
+- These are all the commands you need; for occasional flags (`--top`, `--json`), run `bash scripts/mcp/wiki-cli.sh <command> --help`.
+```
+
+**Placement**: insert it as a new top-level section. Preferred anchor — immediately **before** the `## What you produce` section (this mirrors the template). If that heading is absent (agent was restructured), fall back to inserting it immediately **after** the frontmatter block (the closing `---`), and note the non-standard placement in the report. Never split an existing section.
+
+**Optional mission-bullet rewrite.** If the agent's `## Your mission` section still contains the old wording `list of existing pages in the domain`, propose replacing that bullet with:
+
+```markdown
+- The **current wiki context**: a fresh `scan-domain` snapshot of your domain (hub, counts by type, top pages by centrality) and the contents of `wiki/domains/<slug>.md`. If the snapshot is absent, produce it yourself (see **Domain orientation** below).
+```
+
+(Same slug substitution.) If the mission bullet was customized away from the template wording, leave it as-is — the Domain orientation section is self-contained.
+
+**Review one by one**: for each file, show the insertion diff (the new section + its anchor context) and ask Apply / Edit manually / Skip.
+
+**Apply to all**: insert into every detected agent that lacks the section, log the count.
+
+### 5. Logging
+
+Append to `wiki/log.md`:
+
+```markdown
+## [YYYY-MM-DD] migrate | v1.1.2-domain-orientation
+
+- settings.json: wiki-cli allowlist rule added / already present / skipped.
+- Agents migrated: N inserted / M already present / K edited manually / L skipped (out of <total> domain-expert agents detected).
+- Non-standard placement (section inserted after frontmatter, `## What you produce` not found): <list of agents if any>.
+- Custom agents skipped (non-domain-expert): <list of names if any>.
+```
+
+### 6. Commit
+
+If at least one file was modified by this migration:
+
+```bash
+git add .claude/agents/*.md .claude/settings.json wiki/log.md
+git commit -m "chore: migrate agents to v1.1.2 domain-orientation (section + wiki-cli allowlist)"
+```
+
+If nothing was modified (everything already present or skipped), do not commit.
+
+### 7. Verdict for `/update-vault`
+
+If **all** proposed changes were Applied (settings.json rule present + every detected agent has the section) → migration is **complete** → `/update-vault` may bump `.claude/template-version` to 1.1.2.
+
+If **any** change was skipped or edited manually → migration is **partial** → `/update-vault` must NOT bump `.claude/template-version`. The migration is re-proposed at the next `/update-vault` and skips what is already present (see _Idempotence_).
+
+## Idempotence
+
+The migration is idempotent at the file level:
+
+- **settings.json**: skip if `permissions.allow` already contains `Bash(bash scripts/mcp/wiki-cli.sh *)` (exact-string match).
+- **Agents**: skip any agent whose file already contains a `## Domain orientation` heading. A partial migration can therefore be safely re-run by the next `/update-vault` without double-inserting.
+
+## Preserving user customizations
+
+`.claude/agents/<domain>-expert.md` may contain user customizations (extra sections, refined rules, `/evolve-agent` output). This migration only **inserts one new section** (and optionally rewrites the single stale mission bullet). It never deletes, reorders, or rewrites any other content. If the `## What you produce` anchor cannot be found, it falls back to a safe post-frontmatter insertion and reports it, rather than guessing a location inside existing prose.
+
+## Notes
+
+- This follows the stable `scripts/migrations/v<X>-*.md` pattern (after `v1.0.2-claude-md-slim.md`, `v1.0.3-vault-language.md`, `v1.1.0.md`): one slash-command per breaking version, invoked by `/update-vault`, always interactive.
+- The section text is kept in lockstep with `.claude/agents/domain-expert.md.tpl`. If the template's Domain orientation wording changes in a later version, ship a new migration rather than editing this one (unless it carries `force-rerun: true`).
+- Vaults that predate `scripts/mcp/wiki-cli.py` / `wiki-cli.sh` receive those files through the normal `/update-vault` file propagation step (they are template-tracked) before this migration runs, so the invocation string the section references is present.


### PR DESCRIPTION
Referme #71.

Donne à chaque agent domain-expert une **orientation domaine self-service** via le tiered loading déjà livré (`wiki-cli`), et remplace la liste de titres injectée au spawn par un **snapshot `scan-domain`**. Cible autant l'ingestion que l'usage général de l'agent.

## Contenu (6 commits, un par tâche, squash-mergés)

| Commit | Livrable |
| --- | --- |
| `wiki-cli.sh` | Wrapper portable (résolution `python3`/`python` comme `scan-raw.sh`), string d'invocation unique partagée par le template, `/ingest`, l'allowlist et le guard. |
| Template agent | Section **Domain orientation** dans `domain-expert.md.tpl` : `scan-domain → drill-down ciblé → preview/read`, wikilinks vérifiés, idempotence step 0 via `scan-sources`, fallback `Glob`/`Grep`. |
| `/ingest` | Snapshot `scan-domain` injecté par spawn (fraîcheur intra-batch), fin de la construction de la liste de titres côté main. |
| Guard headless | Allowlist du sous-ensemble **charset-safe** (`scan-domain`, `scan-<type>` sans `--query`, `list-domains`, `preview`, `read`) ; `--query`/`search` restent refusés (fallback). +10 tests. |
| Migration | `v1.1.2-domain-orientation` : insère la section dans les `<domain>-expert.md` existants + ajoute l'allowlist au `settings.json` du vault (interactif, idempotent). |
| Release | `template-version` 1.1.2 + CHANGELOG + note BOOTSTRAP. |

## Validation réelle

- Suite mcp sur la branche : **109 tests OK (skipped=25)** (inclut +10 tests du guard).
- Guard : `--query`, `search`, `; rm -rf /`, `$(whoami)`, `..` tous refusés par construction ; sous-ensemble sûr accepté.
- Smoke orientation réel via la string livrée (`bash scripts/mcp/wiki-cli.sh scan-domain ia`) : snapshot ~1k tokens + drill-down ciblé conformes.

## Notes

- Contenu propagé aux vaults en **anglais** ; corps de PR en français (convention).
- La PR cible `develop` (non-défaut) : `Referme #71` ne fermera **pas** l'issue automatiquement — fermeture manuelle au merge.
- Spec + plan en local (`docs/superpowers/`, gitignoré).
