### PR TITLE
fix(mcp): setup-mcp.sh force UTF-8 stdout (Windows cp1252) — #69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 ### Fixed
 
 - **`scripts/wiki-maint/scan-raw.sh` → `scan-raw.py`**: rewrote the state-detection engine in Python (single process) — the old bash spawned one `python3` per indexed path plus a `grep|sed` pipeline per frontmatter line, so on a mature vault (several hundred source pages, several thousand raw files) even a single-file scan blew past the 120s timeout and `/ingest` step 1 was unusable. `scan-raw.sh` is now a thin wrapper that keeps the portable `PYTHON_BIN` resolution (#61) and execs `scan-raw.py`. Default stdout is byte-for-byte identical (golden-tested against the pre-rewrite bash); stderr messages moved to English (template EN policy). One deliberate default-verdict change: `source_path`/`covered_paths` motifs are now recognised only inside the leading `---` frontmatter block, killing phantom `SKIP`s from body text. Existing vaults upgrade via `scripts/migrations/v1.1.2-scan-raw-python.md`. (#70)
+- **`scripts/mcp/setup-mcp.sh`**: forced UTF-8 on the script's Python subprocess stdio (`export PYTHONIOENCODING=utf-8`), fixing a hard `UnicodeEncodeError` crash on Windows consoles (cp1252, `PYTHONUTF8` unset) when the `python -c` / heredoc blocks print status emoji (`✅`, U+2705). Same root cause as #60 (`format-md.py`), extended here to `setup-mcp.sh`. The crash aborted the force-rerun `v1.1.0` migration invoked by `/update-vault` on Windows vaults; macOS/Linux are unaffected (emoji still render). (#69)
 
 ## [v1.1.1] — 2026-07-03
 

--- a/scripts/mcp/setup-mcp.sh
+++ b/scripts/mcp/setup-mcp.sh
@@ -17,6 +17,13 @@
 
 set -euo pipefail
 
+# Force UTF-8 on this script's Python subprocesses' stdio: several `python -c` / heredoc
+# blocks below print status emoji (✅). On a Windows console (cp1252) with PYTHONUTF8
+# unset, Python would encode stdout with the locale code page and crash with
+# UnicodeEncodeError. Setting PYTHONIOENCODING here is inherited by every python child and
+# overrides the console code page. Same root cause as #60 (format-md.py). (#69)
+export PYTHONIOENCODING=utf-8
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Post-#42 layout : ce script vit dans scripts/mcp/. La racine du vault est
 # donc 2 niveaux au-dessus (../..), pas 1 seul comme avant #42.


### PR DESCRIPTION
## Contexte

Sur Windows (console cp1252, \`PYTHONUTF8\` non défini), \`bash scripts/mcp/setup-mcp.sh\` plante avec un \`UnicodeEncodeError\`. Plusieurs blocs \`python -c\` / heredoc du script impriment des emoji de statut (\`✅\`, U+2705) sur stdout ; sans forçage UTF-8, Python encode stdout avec la code page locale (cp1252), qui ne représente pas \`✅\` → crash dur (exit 1). Le crash aborte la migration force-rerun \`v1.1.0\` invoquée par \`/update-vault\` sur un vault Windows.

Même cause racine que #60 (corrigé pour \`format-md.py\`), non couverte alors pour \`setup-mcp.sh\`.

## Correctif

Une ligne, en tête de script (après \`set -euo pipefail\`) :

\`\`\`bash
export PYTHONIOENCODING=utf-8
\`\`\`

Ciblé (streams stdio uniquement), hérité par **tous** les sous-process Python du script, et prime sur la code page console. Sans effet sur les lectures/écritures fichier (déjà en \`encoding="utf-8"\` explicite). Les \`echo\` bash à emoji n'étaient pas concernés (bash écrit des octets UTF-8 bruts).

**Pas de fichier de migration** : \`setup-mcp.sh\` est template-tracké → délivré aux vaults par la propagation de fichiers de \`/update-vault\` (étape 5), avant la ré-exécution de la migration \`v1.1.0\` (étape 6). Comme #60/#61 en v1.1.1.

## Validation

- Repro du crash (macOS, encodage forcé cp1252) : \`PYTHONIOENCODING=cp1252 python3 -c "print('✅')"\` → \`UnicodeEncodeError\`, exit 1.
- Preuve du fix : \`export PYTHONIOENCODING=utf-8\` local prime sur un cp1252 hérité → \`✅ OK\`, exit 0.
- \`bash -n scripts/mcp/setup-mcp.sh\` OK ; export ligne 25 < 1re invocation Python ligne 68.
- Non-régression emoji en locale UTF-8 : rendu OK.
- Le vrai test console Windows cp1252 passera par le beta-test sur vault perso.

Closes #69 (⚠️ PR vers \`develop\`, branche non-défaut : l'issue ne se fermera pas automatiquement, fermeture manuelle au merge).