### PR TITLE
chore(release): préparer v1.2.0 (date CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
-## [v1.2.0] — unreleased
+## [v1.2.0] — 2026-07-19
 
 ### Added
 


### PR DESCRIPTION
Pose la date de release `2026-07-19` sur `## [v1.2.0]` du CHANGELOG (retire `— unreleased`), avant le merge `develop → main` + tag `v1.2.0`.