### PR TITLE
docs(mcp): documenter list_domains et ingest (12 → 14 outils)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 debug-*.png
 debug_*.png
 .claude/settings.json
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *.pyc
 debug-*.png
 debug_*.png
+.claude/settings.json

--- a/README.md
+++ b/README.md
@@ -190,18 +190,18 @@ Run `bash scripts/mcp/setup-mcp.sh` once after bootstrap to register the `boilin
 
 **14 tools** are exposed, organised as a tiered-loading hierarchy (orient → drill → read). Full reference: [docs/mcp-tiered-loading.md](docs/mcp-tiered-loading.md).
 
-| Tool                                                                                     | Purpose                                                                                                                             |
-| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Tool                                                                                     | Purpose                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `list_domains()`                                                                         | **Orient**: valid domain slugs + short description + whether a domain-expert agent exists. Use FIRST — domains evolve via `/domain`. |
-| `scan_domain(domain)`                                                                    | **Orient**: hub `summary_l1` + counts per type + top 10 pages by centrality (backlinks). ~860 tokens.                               |
-| `scan_concepts(domain, query="", top=20)`                                                | **Drill**: concepts in a domain, ranked by centrality. Optional query (case + separator insensitive).                               |
-| `scan_entities`, `scan_decisions`, `scan_syntheses`, `scan_cheatsheets`, `scan_diagrams` | Same semantics, per type.                                                                                                           |
-| `scan_sources(domain, query, top=20)`                                                    | Same shape but query is **required** (sources too numerous without a target).                                                       |
-| `preview_page(page_path)`                                                                | L1: frontmatter (whitelisted fields) + `summary_l1`.                                                                                |
-| `read_page(page_path)`                                                                   | L2: full body.                                                                                                                      |
-| `search_wiki(query, limit=10)`                                                           | Cross-type, cross-domain. Format enriched: path, type, summary_l0, outgoing wikilinks.                                              |
-| `drop_to_raw(subfolder, filename, content)`                                              | Sanctioned write into `raw/` (server-side, bypasses the `protect-raw.sh` hook by design). Auto-signals via `cache/.pending-ingest`. |
-| `ingest(path, domain_hint="")`                                                           | Trigger headless ingestion of a file already in `raw/` (see tool description for the permission-mode opt-in).                       |
+| `scan_domain(domain)`                                                                    | **Orient**: hub `summary_l1` + counts per type + top 10 pages by centrality (backlinks). ~860 tokens.                                |
+| `scan_concepts(domain, query="", top=20)`                                                | **Drill**: concepts in a domain, ranked by centrality. Optional query (case + separator insensitive).                                |
+| `scan_entities`, `scan_decisions`, `scan_syntheses`, `scan_cheatsheets`, `scan_diagrams` | Same semantics, per type.                                                                                                            |
+| `scan_sources(domain, query, top=20)`                                                    | Same shape but query is **required** (sources too numerous without a target).                                                        |
+| `preview_page(page_path)`                                                                | L1: frontmatter (whitelisted fields) + `summary_l1`.                                                                                 |
+| `read_page(page_path)`                                                                   | L2: full body.                                                                                                                       |
+| `search_wiki(query, limit=10)`                                                           | Cross-type, cross-domain. Format enriched: path, type, summary_l0, outgoing wikilinks.                                               |
+| `drop_to_raw(subfolder, filename, content)`                                              | Sanctioned write into `raw/` (server-side, bypasses the `protect-raw.sh` hook by design). Auto-signals via `cache/.pending-ingest`.  |
+| `ingest(path, domain_hint="")`                                                           | Trigger headless ingestion of a file already in `raw/` (see tool description for the permission-mode opt-in).                        |
 
 **Recommended pattern**: `list_domains` → `scan_domain` → `scan_<type>(query=...)` → `preview_page` → `read_page`. Measured: ~96% token reduction vs a flat dump on a 388-page domain.
 

--- a/README.md
+++ b/README.md
@@ -188,11 +188,12 @@ Run `/format` to normalise a pre-formatter vault; generation commands (`/ingest`
 
 Run `bash scripts/mcp/setup-mcp.sh` once after bootstrap to register the `boiling-brain-wiki` MCP server (user-scope). Once active, Claude Code can query your wiki from **any project** — not just inside the vault directory.
 
-**12 tools** are exposed, organised as a tiered-loading hierarchy (orient → drill → read). Full reference: [docs/mcp-tiered-loading.md](docs/mcp-tiered-loading.md).
+**14 tools** are exposed, organised as a tiered-loading hierarchy (orient → drill → read). Full reference: [docs/mcp-tiered-loading.md](docs/mcp-tiered-loading.md).
 
 | Tool                                                                                     | Purpose                                                                                                                             |
 | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `scan_domain(domain)`                                                                    | **Orient**: hub `summary_l1` + counts per type + top 10 pages by centrality (backlinks). ~860 tokens. Use FIRST.                    |
+| `list_domains()`                                                                         | **Orient**: valid domain slugs + short description + whether a domain-expert agent exists. Use FIRST — domains evolve via `/domain`. |
+| `scan_domain(domain)`                                                                    | **Orient**: hub `summary_l1` + counts per type + top 10 pages by centrality (backlinks). ~860 tokens.                               |
 | `scan_concepts(domain, query="", top=20)`                                                | **Drill**: concepts in a domain, ranked by centrality. Optional query (case + separator insensitive).                               |
 | `scan_entities`, `scan_decisions`, `scan_syntheses`, `scan_cheatsheets`, `scan_diagrams` | Same semantics, per type.                                                                                                           |
 | `scan_sources(domain, query, top=20)`                                                    | Same shape but query is **required** (sources too numerous without a target).                                                       |
@@ -200,8 +201,9 @@ Run `bash scripts/mcp/setup-mcp.sh` once after bootstrap to register the `boilin
 | `read_page(page_path)`                                                                   | L2: full body.                                                                                                                      |
 | `search_wiki(query, limit=10)`                                                           | Cross-type, cross-domain. Format enriched: path, type, summary_l0, outgoing wikilinks.                                              |
 | `drop_to_raw(subfolder, filename, content)`                                              | Sanctioned write into `raw/` (server-side, bypasses the `protect-raw.sh` hook by design). Auto-signals via `cache/.pending-ingest`. |
+| `ingest(path, domain_hint="")`                                                           | Trigger headless ingestion of a file already in `raw/` (see tool description for the permission-mode opt-in).                       |
 
-**Recommended pattern**: `scan_domain` → `scan_<type>(query=...)` → `preview_page` → `read_page`. Measured: ~96% token reduction vs a flat dump on a 388-page domain.
+**Recommended pattern**: `list_domains` → `scan_domain` → `scan_<type>(query=...)` → `preview_page` → `read_page`. Measured: ~96% token reduction vs a flat dump on a 388-page domain.
 
 A standalone smoke test (`scripts/mcp/smoke_test.py`) asserts per-tool token budgets against any vault — run it after any non-trivial change to `mcp-wiki.py`.
 

--- a/docs/mcp-tiered-loading.md
+++ b/docs/mcp-tiered-loading.md
@@ -1,15 +1,18 @@
 # MCP tiered-loading layer
 
-> **TL;DR:** reference for the `boiling-brain-wiki` MCP server's 12 tools and the tiered-loading pattern they implement (orient → drill → preview → read). Added in v1.1.0 (refactor #41). Measured ~96% token reduction vs the pre-v1.1.0 flat dump on a 388-page domain.
+> **TL;DR:** reference for the `boiling-brain-wiki` MCP server's 14 tools and the tiered-loading pattern they implement (orient → drill → preview → read). Added in v1.1.0 (refactor #41). Measured ~96% token reduction vs the pre-v1.1.0 flat dump on a 388-page domain.
 
 ## Why tiered loading
 
 A flat `scan_domain("ia")` on a 388-page domain returns ~23k tokens — too much for context-constrained backends (e.g. a Realtime voice agent against a 40k TPM org limit, or smaller models with tight context budgets). The MCP server now exposes a **hierarchical descent**: orient first, then drill into the right type, then read the matching pages. Measured reduction on the same query path: **~96%** (23k → ~900 tokens for the orientation step).
 
-## The 12 tools
+## The 14 tools
 
 ```
 ┌─ Orientation ──────────────────────────────────────────────────────┐
+│  list_domains()                                                    │
+│    → valid domain slugs + short description + expert-agent flag    │
+│    → call FIRST: domains evolve via /domain, never guess slugs     │
 │  scan_domain(domain)                                               │
 │    → hub summary_l1 + counts per type + top 10 by centrality       │
 │    → ~860 tokens, replaces the old "dump all pages" behaviour      │
@@ -49,6 +52,9 @@ A flat `scan_domain("ia")` on a 388-page domain returns ~23k tokens — too much
 │  drop_to_raw(subfolder, filename, content)                         │
 │    Sanctioned write into raw/ (bypasses protect-raw.sh PreToolUse  │
 │    hook by writing server-side). Auto-updates cache/.pending-ingest│
+│  ingest(path, domain_hint="")                                      │
+│    Headless ingestion of a file already in raw/ via a domain-expert│
+│    agent run. See the tool description for the permission opt-in.  │
 └────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -56,10 +62,11 @@ A flat `scan_domain("ia")` on a 388-page domain returns ~23k tokens — too much
 
 For a natural-language query (typical voice or chat usage):
 
-1. **Orient** with `scan_domain(domain)` — get the hub summary, see what types exist, pick the most relevant `scan_<type>` for the next step. ~860 tokens.
-2. **Drill** with `scan_<type>(domain, query="<topic>")` — get the top 20 pages of that type matching the query, ranked by centrality. ~500-800 tokens.
-3. **Preview** with `preview_page(<path>)` on the 1-3 most promising pages — read the L1 summary. ~300 tokens each.
-4. **Read** with `read_page(<path>)` only when the L1 confirms relevance — full body. Variable, often 2-10k tokens.
+1. **List** with `list_domains()` — learn which domain slugs exist before anything else; domains are added/renamed dynamically via `/domain`, so never guess.
+2. **Orient** with `scan_domain(domain)` — get the hub summary, see what types exist, pick the most relevant `scan_<type>` for the next step. ~860 tokens.
+3. **Drill** with `scan_<type>(domain, query="<topic>")` — get the top 20 pages of that type matching the query, ranked by centrality. ~500-800 tokens.
+4. **Preview** with `preview_page(<path>)` on the 1-3 most promising pages — read the L1 summary. ~300 tokens each.
+5. **Read** with `read_page(<path>)` only when the L1 confirms relevance — full body. Variable, often 2-10k tokens.
 
 Total typical session: **2-3k tokens**, sometimes 5k if the L2 read is mandatory. Compare to the pre-refactor ~23k just for the orientation step alone.
 

--- a/scripts/mcp/setup-mcp.sh
+++ b/scripts/mcp/setup-mcp.sh
@@ -154,36 +154,29 @@ MARKER="<!-- boiling-brain-wiki-mcp -->"
 CLAUDE_MD_BLOCK="$MARKER
 ## Wiki personnel (boiling-brain-wiki MCP)
 
-Tu as accès à un serveur MCP \`boiling-brain-wiki\` qui expose le wiki personnel de l'utilisateur.
+Le MCP \`boiling-brain-wiki\` expose le wiki de connaissances personnel de l'utilisateur (concepts, décisions, synthèses, cheatsheets, sources… organisés par domaines).
 
-**Règle d'invocation :** avant de répondre à toute question portant sur les domaines de connaissance de l'utilisateur, suis le pattern de tiered loading :
+**Déclencheur** : dès qu'une question peut toucher aux connaissances, projets ou décisions personnels de l'utilisateur (et pas seulement au code du repo courant), consulte le wiki AVANT de répondre de mémoire. Premier appel obligatoire : \`list_domains()\` — c'est lui qui te dit quels domaines existent, ne les devine pas.
 
-1. **\`scan_domain(domain)\`** — overview hiérarchique du domaine (hub + counts par type + top 10 centralité). ~1k tokens. À appeler EN PREMIER pour s'orienter.
-2. **\`scan_<type>(domain, query=\"\", top=20)\`** — drill-down par type une fois le domaine identifié. Sans query : top N par centralité. Avec query : filtrage tokenisé (case + séparateur insensible). 7 outils granulaires :
-   - \`scan_concepts\` — concepts / idées / principes
-   - \`scan_entities\` — acteurs, outils, lieux, organisations
-   - \`scan_decisions\` — ADRs, tradeoffs retenus
-   - \`scan_syntheses\` — résumés cross-cutting
-   - \`scan_cheatsheets\` — référence rapide / how-to
-   - \`scan_diagrams\` — artefacts visuels
-   - \`scan_sources\` — sources brutes (REQUIERT une query, sources trop nombreuses sans cible)
-3. **\`preview_page(page_path)\`** — frontmatter + summary_l1 d'une page (L1, ~300 tokens).
-4. **\`read_page(page_path)\`** — corps complet d'une page (L2, taille variable).
+**Pattern tiered — toujours dans cet ordre, jamais de dump de domaine :**
+1. \`list_domains()\` → domaines existants.
+2. \`scan_domain(domain)\` → overview hiérarchique (~1k tokens).
+3. \`scan_<type>(domain, query=\"\", top=20)\` → drill-down par type : \`scan_concepts\`, \`scan_entities\`, \`scan_decisions\`, \`scan_syntheses\`, \`scan_cheatsheets\`, \`scan_diagrams\`, \`scan_sources\` (ce dernier REQUIERT une query). Sans query : top N par centralité.
+4. \`preview_page(page_path)\` (résumé, ~300 tokens) avant \`read_page(page_path)\` (corps complet).
 
-**Cross-coupe** : \`search_wiki(query, limit=10)\` — recherche full-text tokenisée cross-type, cross-domain, format enrichi (path, type, summary_l0, wikilinks). Complémentaire aux scan_<type> qui sont intra-domaine.
+**Cross-domaine** : \`search_wiki(query, limit=10)\` — full-text cross-type/cross-domain, quand tu ne sais pas dans quel domaine chercher.
 
 **Écriture** : \`drop_to_raw(subfolder, filename, content)\` — dépose un fichier dans raw/ pour ingest (bypass propre du hook protect-raw.sh).
-
-Le pattern tiered (scan_domain → scan_<type> → preview → read) économise drastiquement les tokens vs un dump de domaine (mesuré : ~96% de réduction sur un domaine de 388 pages).
 $MARKER"
 
 if [[ -f "$CLAUDE_MD" ]] && grep -qF "$MARKER" "$CLAUDE_MD"; then
-  # Marker present — check if the existing block is the current (12-tool) version
-  # by looking for a distinctive string of the new content.
-  if grep -qF "scan_concepts" "$CLAUDE_MD"; then
+  # Marker present — check if the existing block is the current (list_domains-first)
+  # version by looking for a distinctive string of the new content.
+  if grep -qF "list_domains" "$CLAUDE_MD"; then
     echo "✅ $CLAUDE_MD déjà configuré (marqueur présent, contenu à jour)."
   else
-    # Outdated block (pre-#47, only 5 tools listed). Replace in place.
+    # Outdated block (pre-#47 5-tool version, or 12-tool version without
+    # list_domains-first). Replace in place.
     CLAUDE_MD="$CLAUDE_MD" python3 - <<PYEOF
 import os, re, pathlib
 p = pathlib.Path(os.environ["CLAUDE_MD"])
@@ -197,7 +190,7 @@ if n == 0:
     # Shouldn't happen (grep above confirmed marker presence) but fallback safely.
     new_content = content.rstrip() + "\n\n" + new_block + "\n"
 p.write_text(new_content, encoding="utf-8")
-print(f"✅ {p} mis à jour (bloc obsolète remplacé par la version 12 outils + tiered loading).")
+print(f"✅ {p} mis à jour (bloc obsolète remplacé par la version list_domains-first + tiered loading).")
 PYEOF
   fi
 else


### PR DESCRIPTION
## Contexte

Les outils MCP `list_domains()` et `ingest()` existent dans le code depuis **v1.1.1** (#62), mais la documentation était restée à « 12 outils ». Cette PR est un **rattrapage documentaire pur** — aucun changement de comportement produit.

## Changements

| Fichier | Changement |
| --- | --- |
| `README.md` | 12 → 14 outils ; ajout des lignes `list_domains()` (orient, à appeler en premier — les domaines évoluent via `/domain`) et `ingest(path, domain_hint)` ; le pattern recommandé commence par `list_domains`. |
| `docs/mcp-tiered-loading.md` | 12 → 14 outils dans le TL;DR, l'arbre ASCII et le walkthrough numéroté (étape 1 = `list_domains`). |
| `scripts/mcp/setup-mcp.sh` | Le bloc `CLAUDE.md` auto-injecté est réécrit en version « list_domains-first » ; la détection d'obsolescence reconnaît les blocs 12 outils (sans `list_domains`) comme à remplacer. |
| `.gitignore` | Ignore `.claude/settings.json` (settings locaux). |

## Notes

- **CHANGELOG** : pas de section « Unreleased » ouverte (v1.2.0 publiée). Une ligne pourra être ajoutée à la prochaine version.
- **Migration vault** : aucune requise. `setup-mcp.sh` est auto-idempotent (il détecte et régénère le bloc obsolète au prochain run) ; README/docs arrivent par simple propagation de fichier.
- Rebasé sur `origin/develop` : coexiste proprement avec le fix UTF-8 #75 (lignes distinctes).