### PR TITLE
fix(wiki-maint): interdit Prettier nu sur wiki/, wrapper seule porte (#89)

### DIFF
--- a/.claude/rules/pages-wiki.md
+++ b/.claude/rules/pages-wiki.md
@@ -17,6 +17,8 @@ paths:
 
 - All internal links as `[[wikilinks]]` Obsidian-style.
 - Alias format: `[[path/slug|Display text]]` when the slug is not self-explanatory.
+  - Inside a table, prefer an **escaped pipe** — `[[path/slug\|Display text]]` — it renders identically in Obsidian and survives any Markdown formatter.
+  - Never run Prettier **bare** on `wiki/` (`npx prettier --write`, or an editor "format on save"): it reflows GFM tables and destroys these alias/code-span pipes. Format only through the Obsidian-safe wrapper — `/format` or `scripts/wiki-maint/format-md.py` — which masks the pipes. `wiki/` is in `.prettierignore` to enforce this.
 - No relative `../` paths for wiki pages — always wikilinks.
 - External links via standard markdown syntax `[text](url)`.
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,9 @@
+# wiki/ is formatted ONLY through the Obsidian-safe wrapper
+# (scripts/wiki-maint/format-md.py), which opts out of this file via
+# `--ignore-path`. Never run Prettier bare on wiki/ (CLI or editor "format on
+# save"): it reflows GFM tables and destroys the pipes in `[[wikilink|alias]]`
+# and code spans. See .claude/rules/pages-wiki.md.
+wiki/
 # Raw sources are gitignored in vaults and never present on the remote.
 raw/
 # Generated / vendored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 - **MCP documentation synced to the 14-tool surface**: `list_domains()` and `ingest()` (both shipped in v1.1.1, #62) were missing from the user-facing docs, which still described "12 tools". `README.md` and `docs/mcp-tiered-loading.md` now list all 14 tools and start the recommended tiered pattern with `list_domains` (domains evolve via `/domain`, so slugs are never guessed). `scripts/mcp/setup-mcp.sh` now injects a `list_domains`-first `CLAUDE.md` block and recognises the older 12-tool block (without `list_domains`) as outdated, replacing it in place. Documentation/setup only — no runtime tool change. (#91)
 
+### Fixed
+
+- **`.prettierignore` + `scripts/wiki-maint/format-md.py`**: a bare Prettier run on `wiki/` (`npx prettier --write`, or an editor "format on save") reflowed GFM tables and silently destroyed the pipes inside `[[wikilink|alias]]` and code spans. The Obsidian-safe wrapper masks those pipes, but nothing forced callers through it. `wiki/` is now in `.prettierignore` so bare Prettier skips it; the wrapper opts out of that ignore via `--ignore-path` (an empty file) to keep formatting `wiki/` in both `--write` and `--check`, and `do_check` no longer copies `.prettierignore` into its temp tree — which would otherwise make `--check` skip the `wiki/` copies and report unformatted pages as clean (silent false negatives). `.claude/rules/pages-wiki.md` documents the hazard and the escaped-pipe (`\|`) alternative. (#89)
+
 ## [v1.2.0] — 2026-07-19
 
 ### Added

--- a/scripts/wiki-maint/format-md.py
+++ b/scripts/wiki-maint/format-md.py
@@ -84,12 +84,22 @@ def _npx():
 
 
 def run_prettier(files, cwd=None):
-    proc = subprocess.run(
-        [_npx(), "-y", "prettier", "--write", *files],
-        capture_output=True, text=True, cwd=cwd,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(f"prettier failed:\n{proc.stderr}")
+    # wiki/ is excluded in .prettierignore so a *bare* prettier refuses to touch
+    # it (that reflow corrupts table pipes). This wrapper already masks pipes and
+    # filters directories itself (mask() + EXCLUDE_DIRS), so it MUST format wiki/
+    # regardless — it opts out of .prettierignore/.gitignore by pointing
+    # --ignore-path at an empty file. mkstemp is portable (Windows included).
+    fd, empty_ignore = tempfile.mkstemp(prefix="prettier-noignore-")
+    os.close(fd)
+    try:
+        proc = subprocess.run(
+            [_npx(), "-y", "prettier", "--ignore-path", empty_ignore, "--write", *files],
+            capture_output=True, text=True, cwd=cwd,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"prettier failed:\n{proc.stderr}")
+    finally:
+        os.unlink(empty_ignore)
 
 
 MAX_WRITE_PASSES = 5
@@ -136,8 +146,12 @@ def do_check(files):
     repo_root = Path.cwd()
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
-        # Carry the Prettier config so formatting matches the real run.
-        for cfg in (".prettierrc", ".prettierignore", ".prettierrc.json", ".prettierrc.yaml"):
+        # Carry the Prettier *formatting* config so --check matches the real run.
+        # .prettierignore is deliberately NOT copied: run_prettier() opts out of
+        # it via --ignore-path (wiki/ is ignored for bare Prettier but MUST be
+        # checked here). Copying it would make Prettier skip the wiki/ copies →
+        # silent false negatives (unformatted wiki pages reported clean).
+        for cfg in (".prettierrc", ".prettierrc.json", ".prettierrc.yaml"):
             if (repo_root / cfg).is_file():
                 shutil.copy(repo_root / cfg, tmp / cfg)
         rel_copies = []

--- a/scripts/wiki-maint/test_format_md.py
+++ b/scripts/wiki-maint/test_format_md.py
@@ -165,5 +165,65 @@ class ExpandTest(unittest.TestCase):
         self.assertFalse(fmt._excluded("docs/guide.md"))
 
 
+class WikiIgnoreOptOutTest(unittest.TestCase):
+    """wiki/ est dans .prettierignore (Prettier nu le skippe) mais le wrapper
+    opt-out via --ignore-path et DOIT quand même le formatter et le vérifier."""
+
+    _UNFORMATTED_WIKI = (
+        "#  Bad   heading\n\n\n\n"
+        "| Col | Lien | Détail |\n| --- | --- | --- |\n"
+        "| a | [[entities/y|Alias]] | `skip|rewrite` |\n"
+    )
+
+    def _vault(self, tmp):
+        (tmp / ".prettierrc").write_text('{"proseWrap":"preserve"}', encoding="utf-8")
+        (tmp / ".prettierignore").write_text("wiki/\n", encoding="utf-8")
+        page = tmp / "wiki" / "domains" / "d.md"
+        page.parent.mkdir(parents=True)
+        page.write_text(self._UNFORMATTED_WIKI, encoding="utf-8")
+        return page
+
+    def test_write_formats_wiki_despite_prettierignore(self):
+        # Sans l'opt-out, Prettier skiperait wiki/ (ignoré) → fichier inchangé.
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            page = self._vault(tmp)
+            r = run(["--write", "wiki/domains/d.md"], cwd=str(tmp))
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            out = page.read_text(encoding="utf-8")
+            self.assertNotIn("#  Bad", out)            # heading normalisé → reformaté
+            self.assertNotIn("\n\n\n", out)            # runs de lignes vides collapsés
+            self.assertIn("[[entities/y|Alias]]", out)  # pipe d'alias préservé
+            self.assertIn("`skip|rewrite`", out)        # pipe de code-span préservé
+
+    def test_check_flags_unformatted_wiki_despite_prettierignore(self):
+        # Garde-fou anti-faux-négatif : --check doit voir le fichier mal formaté.
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._vault(tmp)
+            r = run(["--check", "wiki/domains/d.md"], cwd=str(tmp))
+            self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+
+    def test_bare_prettier_skips_wiki(self):
+        # Caractérisation (done-criterion #1) : Prettier nu respecte .prettierignore.
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            page = self._vault(tmp)
+            before = page.read_text(encoding="utf-8")
+            proc = subprocess.run(
+                [fmt._npx(), "-y", "prettier", "--write", "wiki/domains/d.md"],
+                capture_output=True, text=True, cwd=str(tmp),
+            )
+            self.assertEqual(page.read_text(encoding="utf-8"), before,
+                             proc.stdout + proc.stderr)
+
+
+class RepoPrettierIgnoreTest(unittest.TestCase):
+    def test_repo_prettierignore_excludes_wiki(self):
+        repo_root = HERE.parent.parent
+        ignore = (repo_root / ".prettierignore").read_text(encoding="utf-8")
+        self.assertRegex(ignore, r"(?m)^wiki/\s*$")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Contexte

`#89` — Prettier lancé **nu** (CLI `npx prettier --write`, ou un « format on save » d'éditeur) reflow les tables GFM et **détruit silencieusement** les pipes des `[[wikilink|alias]]` et des code-spans. Le wrapper Obsidian-safe `scripts/wiki-maint/format-md.py` masque ces pipes, mais rien n'obligeait à passer par lui.

## Ce que fait cette PR

Fait du wrapper la **seule porte** capable de formatter `wiki/` — `wiki/` reste intégralement prettifié, mais uniquement par l'outil qui ne casse pas les pipes :

- **`.prettierignore`** exclut `wiki/` → tout Prettier nu (CLI comme extension IDE, qui respecte `.prettierignore`) le skippe.
- **`run_prettier`** (point d'appel unique de Prettier) opt-out via `--ignore-path <fichier vide>` → le wrapper continue de formatter `wiki/` en `--write` **et** `--check`.
- **`do_check`** ne copie plus `.prettierignore` dans son tempdir — sinon `--check` skiperait les copies `wiki/` → **faux négatifs silencieux** (page mal formatée rapportée « clean »).
- **`.claude/rules/pages-wiki.md`** documente le hazard + la forme robuste `\|` (rend identiquement dans Obsidian, survit à tout formatter).
- **CHANGELOG** : nouvelle section `[v1.2.1] — unreleased`.

## Validation

- Suite `test_format_md` : **17 tests** (13 existants + 4 neufs), tous verts. Les 3 tests de régression échouent bien **avant** le fix — dont le faux négatif prouvé noir sur blanc : `✓ format: 1 file(s) clean` sur un fichier délibérément mal formaté.
- `format-md.py --check "**/*.md"` (le job CI `format-check`) : **36 fichiers clean**, exit 0.

## Notes

- **Comportement inchangé côté vaults** : le CI et les commandes (`/save`, `/ingest`, `/format`) appellent toujours le wrapper à l'identique ; seul Prettier nu est bloqué. → fix « autonome sans surprise vault », pas de Part de migration (comme #69).
- PR ciblant `develop` (branche non-défaut) → `Closes #89` ne fermera pas l'issue automatiquement, à fermer manuellement au merge.

Closes #89
