### PR TITLE
docs(changelog): ouvrir v1.2.1 et documenter le rattrapage MCP 14 outils (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
+## [v1.2.1] — unreleased
+
+### Changed
+
+- **MCP documentation synced to the 14-tool surface**: `list_domains()` and `ingest()` (both shipped in v1.1.1, #62) were missing from the user-facing docs, which still described "12 tools". `README.md` and `docs/mcp-tiered-loading.md` now list all 14 tools and start the recommended tiered pattern with `list_domains` (domains evolve via `/domain`, so slugs are never guessed). `scripts/mcp/setup-mcp.sh` now injects a `list_domains`-first `CLAUDE.md` block and recognises the older 12-tool block (without `list_domains`) as outdated, replacing it in place. Documentation/setup only — no runtime tool change. (#91)
+
 ## [v1.2.0] — 2026-07-19
 
 ### Added


### PR DESCRIPTION
## Contexte

Le PR #91 (rattrapage doc MCP 12 → 14 outils) a été mergé sans entrée CHANGELOG. C'est le seul changement sur `develop` depuis v1.2.0 non documenté ici. Cette PR ouvre la section `v1.2.1 — unreleased` et l'y consigne.

## Changement

- Nouvelle section `## [v1.2.1] — unreleased` avec une entrée `### Changed` décrivant la synchronisation de la doc MCP sur les 14 outils (`list_domains` + `ingest`, déjà livrés en v1.1.1) et la régénération du bloc `CLAUDE.md` par `setup-mcp.sh`.

## Notes

- Patch (v1.2.1) : documentation/setup uniquement, aucune nouvelle capacité produit — les outils existaient déjà. Le numéro reste indicatif (« unreleased ») et pourra être bumpé à la release selon ce qui s'accumule.
- Aucune migration vault (le CHANGELOG n'affecte pas les vaults).