### PR TITLE
fix(docs): affirmations obsolètes sur le force-rerun de v1.1.0 (suite de #90)

### DIFF
--- a/docs/mcp-tiered-loading.md
+++ b/docs/mcp-tiered-loading.md
@@ -139,7 +139,7 @@ The hub page lookup uses `wiki/domains/<domain>.md` and reads its `summary_l1`. 
 - `scripts/mcp/wiki_core.py` — shared query layer used by both entry points.
 - `scripts/mcp/setup-mcp.sh` — installer + self-healing maintainer of `~/.claude/CLAUDE.md` block.
 - `scripts/mcp/smoke_test.py` — token-budget harness.
-- `scripts/migrations/v1.1.0.md` — migration that installs/refreshes the stack. Marked `force-rerun: true` to re-evaluate at every `/update-vault`.
+- `scripts/migrations/v1.1.0.md` — migration that installs the stack on a vault that never enabled it (runs once, like every other migration). Refreshing an already-installed stack is handled by `/update-vault` **step 7**, which detects propagated `scripts/mcp/**` changes and offers `setup-mcp.sh` only then, plus a reload signal when the server code changed (#90).
 
 ## CLI mode (no MCP client)
 

--- a/scripts/migrations/v1.1.0.md
+++ b/scripts/migrations/v1.1.0.md
@@ -428,7 +428,7 @@ Part D performs an idempotent in-place rewrite of these references in user-owned
 
 - A negative lookbehind on the script path regex prevents double-substitution: once a path is rewritten to `scripts/video/scan-raw.sh`, scanning again for the bare `scripts/scan-raw.sh` substring would falsely match the tail of the rewritten path; the lookbehind blocks that. Re-running Part D on an already-patched vault is a clean no-op.
 - The wikilink substitution rewrites both `[[slug]]` and `[[slug|alias]]` forms. Already-rewritten markdown links (`[alias](https://...)`) are not matched.
-- Covered by `force-rerun: true` on this migration: even if a user adds a new agent file `.claude/agents/<new>-expert.md.tpl` with stale references after a partial migration, the next `/update-vault` will re-evaluate and patch.
+- **Not auto-covered anymore**: this migration dropped `force-rerun` (#90), so a vault that already applied it no longer re-evaluates Part D. If an agent file `.claude/agents/<new>-expert.md` is added _after_ the migration with stale `scripts/` paths or old wikilinks, patch it manually — or remove the `v1.1.0` line from `applied-migrations` in `.claude/template-version` to force a full re-run at the next `/update-vault`.
 
 ## Part E — CI revamp for living vaults (v1.1.0 finalize)
 


### PR DESCRIPTION
Suite directe de #96 (#90) : le retrait du `force-rerun` a laissé **deux textes qui affirmaient encore qu'il était actif**. Raté lors de la passe #90 — le plan ne visait que la note d'en-tête du frontmatter, sans balayer les autres mentions du fichier ni la doc.

| Fichier | Affirmation devenue fausse | Correction |
| --- | --- | --- |
| `scripts/migrations/v1.1.0.md` (Part D) | « Covered by `force-rerun: true` … the next `/update-vault` will re-evaluate and patch » — décrivait un filet de sécurité **qui n'existe plus** | Indique que Part D n'est plus ré-évaluée, avec la procédure manuelle (patch direct, ou retrait de la ligne `v1.1.0` d'`applied-migrations` pour forcer un re-run) |
| `docs/mcp-tiered-loading.md` | « migration … **Marked `force-rerun: true`** to re-evaluate at every `/update-vault` » | La migration installe la stack (une fois) ; le refresh est piloté par l'**étape 7** de `/update-vault` |

Non touchés volontairement : les mentions de `CHANGELOG.md` (**historiques**, elles documentent une version passée) et celles d'`update-vault.md` (le **mécanisme générique** `force-rerun`, toujours valide pour de futures migrations).

## Validation

- `grep -rn force-rerun` sur `scripts/`, `docs/`, `.claude/` : plus aucune affirmation obsolète ; ne restent que la note « No `force-rerun` » de v1.1.0, le « **not** `force-rerun` » de v1.2.0 (déjà correct) et la description du mécanisme dans `update-vault.md`.
- `format-md.py --check "**/*.md"` → 36 fichiers clean.

Documentation seule, aucun changement de comportement.