### PR TITLE
chore(release): préparer v1.2.1 (bump template-version + date CHANGELOG)

### DIFF
--- a/.claude/template-version
+++ b/.claude/template-version
@@ -1,1 +1,1 @@
-template-version: 1.2.0
+template-version: 1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
-## [v1.2.1] — unreleased
+## [v1.2.1] — 2026-07-26
 
 ### Changed
 


### PR DESCRIPTION
## Prep de release v1.2.1

Finalisation de la version `[v1.2.1]` (contenu déjà mergé sur `develop` depuis v1.2.0).

- **`.claude/template-version` : `1.2.0` → `1.2.1`** — sans ce bump, les vaults se croient à jour et `/update-vault` répond « up to date ».
- **CHANGELOG : `[v1.2.1] — unreleased` → `[v1.2.1] — 2026-07-26`**.

### Pas de fichier de migration

Décision assumée, cohérente avec le précédent **v1.1.1** (sortie sans migration) :
- Chaîne de migrations vide → l'étape 8 de `/update-vault` bumpe quand même la version ; les fichiers se propagent seuls.
- Le seul effet vault-side (refresh du bloc `CLAUDE.md` MCP en anglais + signal de reload, #95/#91) est pris en charge par l'**étape 7** de `/update-vault` (MCP-aware, #90), déclenchée par la propagation de `scripts/mcp/*`.
- #89, #88, #97 : aucune action vault.

### Contenu de la v1.2.1 (rappel)

6 groupes de PR depuis v1.2.0 : #91 (docs MCP 14 outils), #89 (prettier/wiki), #88 (scan-raw couverture par contenu), #90 (update-vault MCP-aware), #95 (stack MCP en anglais), #97 (garde de version Python format-md).

Après merge : `develop` → `main`, tag `v1.2.1`, notes GitHub.
