### PR TITLE
fix(docs): désambiguïse le compte d'outils MCP du README (12 read / 14 exposés) (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ---
 
+## [v1.2.2] — unreleased
+
+### Fixed
+
+- **`README.md` tool-count disambiguation**: L144 attributed the read-subset count (12) to the MCP server as a whole, 47 lines before the correct server-surface count (14) at L191 — a leftover of the #91 resync, which corrected the canonical section only. The sentence now reads "12 read tools of the 14 exposed", so both counts appear where they are correct (14 = server surface, 12 = read subset / headless CLI). Historical occurrences (v1.1.0 migration file, v1.1.0-era CHANGELOG entries) are untouched: 12 was accurate before `list_domains()` and `ingest()` shipped in v1.1.1. Documentation-only. (#107)
+
 ## [v1.2.1] — 2026-07-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Every wiki page carries two extra frontmatter fields:
 - `summary_l0` — single line, ≤140 chars. Telegraphic. Used as a TOC entry when an agent scans a list of pages.
 - `summary_l1` — 2-5 sentences (~50-150 words). Used when the agent decides whether to load the full body.
 
-This lets agents (and you, via `/query`) navigate the wiki without paying the full body cost on every page they consider. Starting in v1.1.0, the MCP server pushes this further by exposing a **hierarchical orient → drill → preview → read** pattern across 12 tools (~96% token reduction vs flat dumps on large domains). See [docs/mcp-tiered-loading.md](docs/mcp-tiered-loading.md) for the full pattern.
+This lets agents (and you, via `/query`) navigate the wiki without paying the full body cost on every page they consider. Starting in v1.1.0, the MCP server pushes this further by exposing a **hierarchical orient → drill → preview → read** pattern across **12 read tools of the 14 exposed** (~96% token reduction vs flat dumps on large domains). See [docs/mcp-tiered-loading.md](docs/mcp-tiered-loading.md) for the full pattern.
 
 ## Scripts layout
 


### PR DESCRIPTION
## Résumé

**Issue #107** — `README.md` L144 attribuait le compte du sous-ensemble lecture (**12**) au serveur MCP entier (surface réelle : **14 outils**), 47 lignes avant le compte correct en L191. Un lecteur suivant L144 concluait que le serveur expose 12 outils au total — l'ambiguïté s'était déjà propagée dans un vault aval (un diagramme correct a failli être « corrigé »).

## Changements

- **README.md L144** : `across 12 tools` → `across **12 read tools of the 14 exposed**` (désambiguïsation, pas de remplacement de chiffre — formulation proposée par l'issue).
- **CHANGELOG.md** : nouvelle section `## [v1.2.2] — unreleased` → `### Fixed` avec l'entrée correspondante.

## Hors périmètre (assumé)

Occurrences correctes dans leur périmètre, intouchées : README L191 (14 = surface serveur), `docs/mcp-tiered-loading.md` (L9 = 14, L146 = 12 read/CLI), `scripts/migrations/v1.1.0.md:89` et entrées CHANGELOG d'époque (12 était exact avant v1.1.1). Reste connu : la migration v1.1.0 publiée dit toujours « 12 tools » — candidat à une issue de suivi séparée.

## Validation

- Greps du test plan de l'issue : 3/3 ✅ (aucune phrase n'attribue « 12 tools » au serveur ; les deux comptes présents là où ils sont corrects ; `docs/` propre)
- La revue a vérifié le compte réel dans `mcp-wiki.py` : 14 `@mcp.tool` dont 12 read ✅
- `format-md.py --check` : 36 fichiers clean ✅ · `validate-wiki.py` : clean ✅ · `unittest` : 108/108 ✅

Réf. #107 (à fermer manuellement après merge — PR vers `develop`).