### PR TITLE
fix(scan-raw): exclut les entrées legacy sources: de la détection d'orphelins (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 ### Fixed
 
 - **`README.md` tool-count disambiguation**: L144 attributed the read-subset count (12) to the MCP server as a whole, 47 lines before the correct server-surface count (14) at L191 — a leftover of the #91 resync, which corrected the canonical section only. The sentence now reads "12 read tools of the 14 exposed", so both counts appear where they are correct (14 = server surface, 12 = read subset / headless CLI). Historical occurrences (v1.1.0 migration file, v1.1.0-era CHANGELOG entries) are untouched: 12 was accurate before `list_domains()` and `ingest()` shipped in v1.1.1. Documentation-only. (#107)
+- **`scripts/wiki-maint/scan-raw.py` orphan detection no longer flags legacy `sources:` entries**: `--orphans` tested every legacy `sources:` frontmatter item — documented as a wiki-to-wiki cross-reference (`[[sources/<slug>]]`), never a disk path — with `os.path.exists()`, so every such entry was reported as a missing raw file (100% false positives on vaults using the field, drowning any real orphan). Legacy entries are now excluded from orphan detection only: they still grant coverage (`SKIP`), still feed the double-coverage lint, and a genuinely deleted file declared via `source_path`/`covered_paths` is still reported. (#103)
 
 ## [v1.2.1] — 2026-07-26
 

--- a/scripts/wiki-maint/scan-raw.py
+++ b/scripts/wiki-maint/scan-raw.py
@@ -234,7 +234,7 @@ def parse_args(argv):
     parser.add_argument("--force", action="store_true",
                         help="reclassify every SKIP as MODIFIED")
     parser.add_argument("--orphans", action="store_true",
-                        help="also list indexed paths whose raw file is gone")
+                        help="list paths declared via source_path/covered_paths whose raw file is gone")
     parser.add_argument("--pending", action="store_true",
                         help="scope = entries of cache/.pending-ingest (read-only)")
     parser.add_argument("--format", choices=("text", "json"), default="text",

--- a/scripts/wiki-maint/scan-raw.py
+++ b/scripts/wiki-maint/scan-raw.py
@@ -140,7 +140,8 @@ def parse_source_page(text: str) -> dict:
                 if mode == "sp" and first_sp is None:
                     first_sp = item
 
-    # pass 2: legacy `sources:`
+    # pass 2: legacy `sources:` (wiki-to-wiki refs or pre-covered_paths raw
+    # paths — indexed for coverage/claims, excluded from orphan detection)
     in_sources = False
     for line in fm:
         if line.startswith("sources:"):
@@ -152,11 +153,11 @@ def parse_source_page(text: str) -> dict:
                 continue
             item = _strip_item(line)
             if item:
-                indexed.append(item)
                 legacy.append(item)
 
     return {
         "indexed_paths": indexed,
+        "legacy_paths": legacy,
         "first_source_path": first_sp,
         "source_sha256": sha,
         "source_sha256_composite": composite,
@@ -187,13 +188,15 @@ def build_index(sources_dir: str) -> Index:
             continue
         meta = parse_source_page(text)
 
-        for raw_path in meta["indexed_paths"]:
+        pass1 = meta["indexed_paths"]
+        for i, raw_path in enumerate(pass1 + meta["legacy_paths"]):
             key = normalize_path(raw_path)
             idx.path_to_slug[key] = slug
             idx.claims.setdefault(key, [])
             if slug not in idx.claims[key]:
                 idx.claims[key].append(slug)
-            idx.all_indexed.append((key, slug))
+            if i < len(pass1):
+                idx.all_indexed.append((key, slug))
 
             # implicit-dir index (parent dir, depth >= 4 slashes)
             idir = raw_path.rsplit("/", 1)[0] + "/" if "/" in raw_path else ""

--- a/scripts/wiki-maint/test_scan_raw.py
+++ b/scripts/wiki-maint/test_scan_raw.py
@@ -378,6 +378,47 @@ class ClassifyTest(unittest.TestCase):
             self.assertEqual(sorted(idx.claims[key]), ["legacy-page", "modern-page"])
             v = scan_raw.classify("raw/notes/old.md", str(raw), idx, force=False)
             self.assertEqual(v.status, "SKIP")
+            self.assertEqual(v.covered_by, "modern-page")
+
+    def test_legacy_entries_feed_dir_and_meta_indexes(self):
+        # issue #103 caveat: legacy `sources:` entries still feed dir_to_slug
+        # and meta_to_slug indexes (implicit dir coverage, transcript meta maps);
+        # only orphan detection ignores them.
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            # Create the legacy-only page with transcript and deep dir entries
+            d = tmp / "wiki" / "sources"
+            d.mkdir(parents=True)
+            (d / "legacy-vid.md").write_text(
+                "---\nsources:\n"
+                '  - raw/transcripts/vid.md\n'
+                '  - raw/deep/a/b/c/anchor.md\n'
+                "---\n",
+                encoding="utf-8",
+            )
+            # Create actual files on disk so classify() can work
+            vid_file = tmp / "raw" / "transcripts" / "vid.md"
+            vid_file.parent.mkdir(parents=True, exist_ok=True)
+            vid_file.write_text("x\n", encoding="utf-8")
+            sibling_file = tmp / "raw" / "deep" / "a" / "b" / "c" / "sibling.md"
+            sibling_file.parent.mkdir(parents=True, exist_ok=True)
+            sibling_file.write_text("x\n", encoding="utf-8")
+
+            idx = scan_raw.build_index(str(d))
+
+            # Check meta_to_slug index: legacy transcript entries feed it
+            meta_key = scan_raw.normalize_path("raw/videos-meta/vid.meta.md")
+            self.assertEqual(idx.meta_to_slug[meta_key], "legacy-vid")
+
+            # Check dir_to_slug index: legacy deep-dir entries feed it
+            # (depth >= 4 slashes: raw/deep/a/b/c/ has 5 slashes)
+            dir_key = scan_raw.normalize_path("raw/deep/a/b/c/")
+            self.assertEqual(idx.dir_to_slug[dir_key], "legacy-vid")
+
+            # Sibling file under the dir should classify as SKIP via dir coverage
+            v = scan_raw.classify("raw/deep/a/b/c/sibling.md", str(sibling_file), idx, force=False)
+            self.assertEqual(v.status, "SKIP")
+            self.assertEqual(v.reason, "dir-implicit")
 
 
 class StrictFrontmatterDivergenceTest(unittest.TestCase):

--- a/scripts/wiki-maint/test_scan_raw.py
+++ b/scripts/wiki-maint/test_scan_raw.py
@@ -246,8 +246,8 @@ class FrontmatterTest(unittest.TestCase):
                 "source_sha256: abc123\n"
                 "---\n")
         meta = scan_raw.parse_source_page(text)
-        self.assertEqual(meta["indexed_paths"],
-                         ["raw/a.md", "raw/b.md", "raw/c.md", "raw/legacy.md"])
+        self.assertEqual(meta["indexed_paths"], ["raw/a.md", "raw/b.md", "raw/c.md"])
+        self.assertEqual(meta["legacy_paths"], ["raw/legacy.md"])
         self.assertEqual(meta["first_source_path"], "raw/a.md")
         self.assertEqual(meta["source_sha256"], "abc123")
         self.assertEqual(meta["covered_paths"], ["raw/c.md"])
@@ -255,6 +255,7 @@ class FrontmatterTest(unittest.TestCase):
     def test_no_frontmatter_yields_nothing(self):
         meta = scan_raw.parse_source_page("no fm here\nsource_path: raw/x.md\n")
         self.assertEqual(meta["indexed_paths"], [])
+        self.assertEqual(meta["legacy_paths"], [])
 
 
 class BuildIndexTest(unittest.TestCase):
@@ -360,6 +361,24 @@ class ClassifyTest(unittest.TestCase):
         self.assertEqual(scan_raw.format_text_line(V("MODIFIED", "s", "forced"), "raw/a.md"),
                          "MODIFIED raw/a.md  (covered-by: s, forced)")
 
+    def test_legacy_only_coverage_and_claims_preserved(self):
+        # issue #103 caveat: legacy `sources:` entries stay in path_to_slug
+        # (coverage) and claims (double-coverage lint); only orphan
+        # detection ignores them.
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            raw = tmp / "raw" / "notes" / "old.md"
+            raw.parent.mkdir(parents=True, exist_ok=True)
+            raw.write_text("x\n", encoding="utf-8")
+            idx = self._idx(tmp, {
+                "legacy-page": "---\nsources:\n  - raw/notes/old.md\n---\n",
+                "modern-page": "---\ncovered_paths:\n  - raw/notes/old.md\n---\n",
+            })
+            key = scan_raw.normalize_path("raw/notes/old.md")
+            self.assertEqual(sorted(idx.claims[key]), ["legacy-page", "modern-page"])
+            v = scan_raw.classify("raw/notes/old.md", str(raw), idx, force=False)
+            self.assertEqual(v.status, "SKIP")
+
 
 class StrictFrontmatterDivergenceTest(unittest.TestCase):
     """The one intentional default-verdict divergence (spec §5.2): a source_path
@@ -410,6 +429,47 @@ class OrphansTest(unittest.TestCase):
                                capture_output=True, text=True,
                                env=dict(os.environ, VAULT_ROOT=str(tmp)))
             self.assertIn("ORPHAN   raw/gone.md  (covered-by: gone)", r.stdout)
+
+    def test_legacy_sources_wikilinks_are_not_orphans(self):
+        # issue #103: [[wikilink]] entries in legacy `sources:` are wiki refs,
+        # never disk paths — they must not be reported as missing raw files.
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            d = tmp / "wiki" / "sources"
+            d.mkdir(parents=True)
+            (d / "page.md").write_text(
+                "---\n"
+                "source_path: raw/notes/real.md\n"
+                "sources:\n"
+                '  - "[[sources/some-source]]"\n'
+                "  - https://example.com/article\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            (tmp / "raw" / "notes").mkdir(parents=True)
+            (tmp / "raw" / "notes" / "real.md").write_text("x\n", encoding="utf-8")
+            idx = scan_raw.build_index(str(d))
+            self.assertEqual(scan_raw.find_orphans(str(tmp), idx), [])
+
+    def test_deleted_pass1_path_still_reported_even_if_also_legacy(self):
+        # A genuinely deleted raw file declared via covered_paths must stay
+        # reported, even when the same path also appears in legacy `sources:`.
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            d = tmp / "wiki" / "sources"
+            d.mkdir(parents=True)
+            (d / "dual.md").write_text(
+                "---\n"
+                "covered_paths:\n"
+                "  - raw/gone/deleted.md\n"
+                "sources:\n"
+                "  - raw/gone/deleted.md\n"
+                "---\n",
+                encoding="utf-8",
+            )
+            idx = scan_raw.build_index(str(d))
+            self.assertEqual(scan_raw.find_orphans(str(tmp), idx),
+                             [("raw/gone/deleted.md", "dual")])
 
 
 class JsonFormatTest(unittest.TestCase):


### PR DESCRIPTION
## Résumé

**Issue #103** — `scan-raw.py --orphans` testait chaque entrée legacy `sources:` du frontmatter (des références wiki-vers-wiki `[[sources/<slug>]]`, jamais des chemins disque) avec `os.path.exists()` : 100 % de faux positifs sur tout vault utilisant le champ, noyant tout orphelin réel.

## Changements

- **`parse_source_page()`** : le pass 2 (legacy `sources:`) n'alimente plus `indexed_paths` ; nouvelle clé `legacy_paths` (un seul consommateur non-test : `build_index`).
- **`build_index()`** : itère `pass1 + legacy` pour tous les index existants (`path_to_slug`, `claims`, `dir_to_slug`, `meta_to_slug` — ordre et sémantique inchangés), mais ne gate `all_indexed` (orphan detection) que sur les items pass-1. Le caveat de l'issue est respecté : `claims` (double-coverage) intact.
- Cas duel (chemin dans `covered_paths` ET legacy `sources:`) : toujours orphan-checké via son occurrence pass-1.
- Help text `--orphans` mis en cohérence.
- CHANGELOG : bullet sous `v1.2.2 — unreleased`.

## Tests (TDD)

- 3 tests RED→GREEN : clé `legacy_paths` (×2), wikilinks non-orphelins.
- 3 pins de régression : chemin pass-1 supprimé toujours reporté (y compris cas duel), couverture `SKIP` + `claims` préservés pour chemins legacy, parité `dir_to_slug`/`meta_to_slug` (ajouté suite à la revue finale).

## Validation

`unittest` wiki-maint : **112/112** ✅ (108 + 4 nouveaux) · mcp : 117 ✅ · `format-md --check` : 36 clean ✅ · `validate-wiki` : clean ✅

## Restes connus (hors périmètre)

- `.claude/commands/lint.md:16` demande encore la vérification disque des `sources:` (même classe de faux positifs, côté LLM) → issue de suivi proposée.
- Perte assumée, documentée au CHANGELOG : vaults pré-`covered_paths` dont `sources:` portait de vrais chemins raw.

Réf. #103 (à fermer manuellement après merge — PR vers `develop`).