### PR TITLE
feat(scan-raw): audit --strict-coverage du déficit de couverture des snapshots (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions are milestones, not strict semver. Breaking changes to `BOOTSTRAP.md` o
 
 ## [v1.2.2] — unreleased
 
+### Added
+
+- **`scan-raw.sh --strict-coverage` audit**: implicit directory coverage (one declared file covers its siblings) keeps routine scans quiet by design, but it makes `0 NEW` read as "everything was declared", which it never meant. The new opt-in flag appends `UNDECLARED <path>  (dir-covered-by: <slug>)` lines (text) and an `undeclared[]` array + count (`--format=json`) for snapshot files covered only by directory inheritance — never declared via `source_path`/`covered_paths` and never read as byte-identical content under a covered lineage version (the content-coverage refinement of #88). Scope: snapshot directories (`.sync-meta.json`) only. Default output is byte-identical; the flag rejects `--force` (which rewrites verdict reasons) and `--pending` (a manifest scope, not an audit surface). Documented in `docs/tracked-repos-immutable-snapshots.md`. (#105)
+
 ### Fixed
 
 - **`README.md` tool-count disambiguation**: L144 attributed the read-subset count (12) to the MCP server as a whole, 47 lines before the correct server-surface count (14) at L191 — a leftover of the #91 resync, which corrected the canonical section only. The sentence now reads "12 read tools of the 14 exposed", so both counts appear where they are correct (14 = server surface, 12 = read subset / headless CLI). Historical occurrences (v1.1.0 migration file, v1.1.0-era CHANGELOG entries) are untouched: 12 was accurate before `list_domains()` and `ingest()` shipped in v1.1.1. Documentation-only. (#107)

--- a/docs/tracked-repos-immutable-snapshots.md
+++ b/docs/tracked-repos-immutable-snapshots.md
@@ -92,6 +92,8 @@ Each source declares its own `dest`. If you track several categories of repos (e
 
 A tracked repo's HEAD SHA advances on **every** commit, so `/sync-repos` creates a new `<dest>/<shortsha>/` even when the documented `paths:` did not change. `scan-raw` covers those files **by content** (sha256), scoped to the same `(dest, relative-path)` lineage via each snapshot's `.sync-meta.json`. Consequence: a full `/ingest` sweep after a no-op or partial re-snapshot reports `NEW` only for files whose **content** actually changed — realising the "no noise if nothing moved" principle above. Hashes are cached (`cache/.hash-cache.json`, keyed by mtime+size) so immutable snapshots are hashed once. Disk duplication of identical snapshots remains (a future purge could consolidate them); it no longer costs anything at scan time.
 
+A `0 NEW` default run does **not** mean every snapshot file was declared: a single declared file also covers all its siblings through implicit directory inheritance (`dir-implicit`), by design — without it, every snapshot would flood `/ingest` with `NEW` lines. To see the real coverage deficit, run the opt-in audit `bash scripts/wiki-maint/scan-raw.sh --strict-coverage`: it appends `UNDECLARED <path>  (dir-covered-by: <slug>)` lines (and an `undeclared[]` array under `--format=json`) for snapshot files granted coverage only by directory inheritance — never declared via `source_path`/`covered_paths` and never read as byte-identical content under a covered lineage version. Default output is unchanged; the audit rejects `--force` and `--pending`.
+
 ## Files shipped
 
 - [`tracked-repos.config.json`](../../tracked-repos.config.json) — manifest (empty by default at bootstrap, populate as you go).

--- a/scripts/wiki-maint/scan-raw.py
+++ b/scripts/wiki-maint/scan-raw.py
@@ -486,7 +486,7 @@ def find_undeclared(results, vault_root, cache, snapshot_dirs, content_index):
             empty = os.path.getsize(abs_p) == 0
         except OSError:
             continue
-        if not empty and content_index.get((key[0], key[1], cache.get(abs_p))):
+        if not empty and content_index and content_index.get((key[0], key[1], cache.get(abs_p))):
             continue
         out.append((rel, v.covered_by))
     return sorted(out, key=lambda kv: kv[0].encode("utf-8"))
@@ -586,7 +586,7 @@ def build_json(files, results, idx, ns, vault_root, warnings, undeclared=None):
         orphans = [{"path": p, "covered_by": s} for p, s in find_orphans(vault_root, idx)]
         doc["orphans"] = orphans
         counts["orphans"] = len(orphans)
-    if getattr(ns, "strict_coverage", False):
+    if ns.strict_coverage:
         doc["undeclared"] = [{"path": p, "dir_covered_by": s} for p, s in (undeclared or [])]
         counts["undeclared"] = len(doc["undeclared"])
     return doc
@@ -656,10 +656,10 @@ def main(argv):
     # non-pending: reuse the index already built at the top of main()
     files, results, _ = run(vault_root, ns, idx, cache)
     apply_content_coverage(results, vault_root, cache, snapshot_dirs, content_index)
-    cache.save()
     orphan_pairs = find_orphans(vault_root, idx) if ns.orphans else []
     undeclared = (find_undeclared(results, vault_root, cache, snapshot_dirs, content_index)
                   if ns.strict_coverage else [])
+    cache.save()
     if ns.format == "json":
         doc = build_json(files, results, idx, ns, vault_root, warnings, undeclared=undeclared)
         print(json.dumps(doc, ensure_ascii=False, indent=2))
@@ -672,7 +672,7 @@ def main(argv):
     for path, slug in orphan_pairs:
         print(f"{'ORPHAN':<8} {path}  (covered-by: {slug})")
     for path, slug in undeclared:
-        print(f"{'UNDECLARED':<8} {path}  (dir-covered-by: {slug})")
+        print(f"UNDECLARED {path}  (dir-covered-by: {slug})")
     emit_summary(results, len(orphan_pairs), ns.orphans, len(undeclared), ns.strict_coverage)
     return 0
 

--- a/scripts/wiki-maint/scan-raw.py
+++ b/scripts/wiki-maint/scan-raw.py
@@ -237,6 +237,10 @@ def parse_args(argv):
                         help="list paths declared via source_path/covered_paths whose raw file is gone")
     parser.add_argument("--pending", action="store_true",
                         help="scope = entries of cache/.pending-ingest (read-only)")
+    parser.add_argument("--strict-coverage", action="store_true",
+                        help="audit: list snapshot files covered only by "
+                             "implicit directory inheritance (never declared, "
+                             "never content-read); incompatible with --force/--pending")
     parser.add_argument("--format", choices=("text", "json"), default="text",
                         help="output format (default: text)")
     parser.add_argument("paths", nargs="*", help="files or folders (default: all of raw/)")
@@ -465,6 +469,29 @@ def apply_content_coverage(results, vault_root, cache, snapshot_dirs, content_in
             results[i] = (rel, Verdict("SKIP", slug, "content"))
 
 
+def find_undeclared(results, vault_root, cache, snapshot_dirs, content_index):
+    """--strict-coverage audit: snapshot files whose only coverage is
+    implicit-dir inheritance — never declared via source_path/covered_paths
+    and never read as byte-identical content under a covered lineage
+    version. Empty files are always flagged (content never covers them)."""
+    out = []
+    for rel, v in results:
+        if v.reason != "dir-implicit":
+            continue
+        key = lineage_key(rel, snapshot_dirs)
+        if key is None:
+            continue
+        abs_p = os.path.join(vault_root, rel)
+        try:
+            empty = os.path.getsize(abs_p) == 0
+        except OSError:
+            continue
+        if not empty and content_index.get((key[0], key[1], cache.get(abs_p))):
+            continue
+        out.append((rel, v.covered_by))
+    return sorted(out, key=lambda kv: kv[0].encode("utf-8"))
+
+
 def run(vault_root: str, ns, idx=None, cache=None):
     files, warnings = collect_files(vault_root, ns.paths)
     for w in warnings:
@@ -525,17 +552,19 @@ def emit_stderr_warnings(warnings):
             print(f"WARN: composite-mismatch {w['slug']}", file=sys.stderr)
 
 
-def emit_summary(results, orphan_count, show_orphans):
+def emit_summary(results, orphan_count, show_orphans, undeclared_count=0, show_undeclared=False):
     n = sum(v.status == "NEW" for _, v in results)
     m = sum(v.status == "MODIFIED" for _, v in results)
     k = sum(v.status == "SKIP" for _, v in results)
     line = f"{n} new · {m} modified · {k} skipped"
     if show_orphans:
         line += f" · {orphan_count} orphans"
+    if show_undeclared:
+        line += f" · {undeclared_count} undeclared"
     print(line, file=sys.stderr)
 
 
-def build_json(files, results, idx, ns, vault_root, warnings):
+def build_json(files, results, idx, ns, vault_root, warnings, undeclared=None):
     file_entries = []
     counts = {"new": 0, "modified": 0, "skipped": 0, "orphans": 0}
     for rel, v in results:
@@ -557,6 +586,9 @@ def build_json(files, results, idx, ns, vault_root, warnings):
         orphans = [{"path": p, "covered_by": s} for p, s in find_orphans(vault_root, idx)]
         doc["orphans"] = orphans
         counts["orphans"] = len(orphans)
+    if getattr(ns, "strict_coverage", False):
+        doc["undeclared"] = [{"path": p, "dir_covered_by": s} for p, s in (undeclared or [])]
+        counts["undeclared"] = len(doc["undeclared"])
     return doc
 
 
@@ -587,6 +619,10 @@ def main(argv):
     ns = parse_args(argv)
     if ns.pending and ns.paths:
         print("usage: --pending takes no positional path", file=sys.stderr)
+        return 2
+    if ns.strict_coverage and (ns.force or ns.pending):
+        print("usage: --strict-coverage cannot be combined with --force or --pending",
+              file=sys.stderr)
         return 2
     vault_root = os.environ.get("VAULT_ROOT") or str(Path(__file__).resolve().parents[2])
     cache = HashCache(vault_root)
@@ -622,8 +658,10 @@ def main(argv):
     apply_content_coverage(results, vault_root, cache, snapshot_dirs, content_index)
     cache.save()
     orphan_pairs = find_orphans(vault_root, idx) if ns.orphans else []
+    undeclared = (find_undeclared(results, vault_root, cache, snapshot_dirs, content_index)
+                  if ns.strict_coverage else [])
     if ns.format == "json":
-        doc = build_json(files, results, idx, ns, vault_root, warnings)
+        doc = build_json(files, results, idx, ns, vault_root, warnings, undeclared=undeclared)
         print(json.dumps(doc, ensure_ascii=False, indent=2))
         return 0
     if not files:
@@ -633,7 +671,9 @@ def main(argv):
         print(format_text_line(v, rel))
     for path, slug in orphan_pairs:
         print(f"{'ORPHAN':<8} {path}  (covered-by: {slug})")
-    emit_summary(results, len(orphan_pairs), ns.orphans)
+    for path, slug in undeclared:
+        print(f"{'UNDECLARED':<8} {path}  (dir-covered-by: {slug})")
+    emit_summary(results, len(orphan_pairs), ns.orphans, len(undeclared), ns.strict_coverage)
     return 0
 
 

--- a/scripts/wiki-maint/test_scan_raw.py
+++ b/scripts/wiki-maint/test_scan_raw.py
@@ -996,7 +996,7 @@ class StrictCoverageTest(unittest.TestCase):
             self.assertEqual(
                 strict.stdout,
                 base.stdout
-                + "UNDECLARED raw/repos/proj/abc1234/docs/b.md  (dir-covered-by: proj-doc)\n")
+                + "UNDECLARED raw/repos/proj/abc1234/docs/b.md  (dir-covered-by: proj-doc)\n")  # no padding on UNDECLARED
             self.assertIn("1 undeclared", strict.stderr)
             # JSON: key present only under the flag
             base_j = json.loads(subprocess.run(
@@ -1012,6 +1012,78 @@ class StrictCoverageTest(unittest.TestCase):
                              [{"path": "raw/repos/proj/abc1234/docs/b.md",
                                "dir_covered_by": "proj-doc"}])
             self.assertEqual(strict_j["counts"]["undeclared"], 1)
+
+    def test_orphans_and_undeclared_combined_and_path_scoped(self):
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            sd = self._vault(tmp)
+            # Create an orphan: a declared file that no longer exists on disk
+            (sd / "orphan-doc.md").write_text(
+                "---\nsource_path: raw/repos/proj/abc1234/nonexistent.md\n---\n",
+                encoding="utf-8",
+            )
+            env = {**os.environ, "VAULT_ROOT": str(tmp)}
+            # Test combined --orphans --strict-coverage
+            r = subprocess.run(
+                ["python3", str(HERE / "scan-raw.py"), "--orphans", "--strict-coverage"],
+                capture_output=True, text=True, env=env)
+            self.assertEqual(r.returncode, 0)
+            # Verify output order: ORPHAN line followed by UNDECLARED line
+            lines = r.stdout.strip().split("\n")
+            orphan_lines = [l for l in lines if l.startswith("ORPHAN")]
+            undeclared_lines = [l for l in lines if l.startswith("UNDECLARED")]
+            self.assertEqual(len(orphan_lines), 1)
+            self.assertEqual(len(undeclared_lines), 1)
+            orphan_idx = lines.index(orphan_lines[0])
+            undeclared_idx = lines.index(undeclared_lines[0])
+            self.assertLess(orphan_idx, undeclared_idx, "ORPHAN should appear before UNDECLARED")
+            # Verify summary mentions both
+            self.assertIn("1 orphans", r.stderr)
+            self.assertIn("1 undeclared", r.stderr)
+            # Test path-scoped audit: --strict-coverage raw/repos/proj/abc1234/docs
+            r_scoped = subprocess.run(
+                ["python3", str(HERE / "scan-raw.py"), "--strict-coverage",
+                 "raw/repos/proj/abc1234/docs"],
+                capture_output=True, text=True, env=env)
+            self.assertEqual(r_scoped.returncode, 0)
+            # The UNDECLARED line should still appear (scoping preserves content_index)
+            self.assertIn("UNDECLARED raw/repos/proj/abc1234/docs/b.md", r_scoped.stdout)
+
+    def test_empty_undeclared_sibling_is_flagged(self):
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            snap = tmp / "raw" / "repos" / "proj" / "abc1234"
+            (snap / "docs").mkdir(parents=True)
+            (snap / ".sync-meta.json").write_text("{}", encoding="utf-8")
+            # One declared non-empty file and one empty undeclared sibling
+            (snap / "docs" / "a.md").write_text("anchor\n", encoding="utf-8")
+            (snap / "docs" / "empty.txt").write_text("", encoding="utf-8")
+            # Create another snapshot with an identical empty file (declared)
+            old = tmp / "raw" / "repos" / "proj" / "0000000"
+            (old / "docs").mkdir(parents=True)
+            (old / ".sync-meta.json").write_text("{}", encoding="utf-8")
+            (old / "docs" / "empty.txt").write_text("", encoding="utf-8")
+            d = tmp / "wiki" / "sources"
+            d.mkdir(parents=True)
+            (d / "proj-doc.md").write_text(
+                "---\nsource_path: raw/repos/proj/abc1234/docs/a.md\n---\n",
+                encoding="utf-8",
+            )
+            (d / "proj-old.md").write_text(
+                "---\nsource_path: raw/repos/proj/0000000/docs/empty.txt\n---\n",
+                encoding="utf-8",
+            )
+            # Run audit
+            idx = scan_raw.build_index(str(d))
+            cache = scan_raw.HashCache(str(tmp))
+            snapshot_dirs = scan_raw.find_snapshot_dirs(str(tmp))
+            content_index = scan_raw.build_content_index(idx, str(tmp), cache, snapshot_dirs)
+            files, results, _ = scan_raw.run(str(tmp), _ns(), idx, cache)
+            scan_raw.apply_content_coverage(results, str(tmp), cache, snapshot_dirs, content_index)
+            undeclared = scan_raw.find_undeclared(results, str(tmp), cache, snapshot_dirs, content_index)
+            # The empty sibling should be flagged (content never covers empty files)
+            self.assertEqual(undeclared,
+                             [("raw/repos/proj/abc1234/docs/empty.txt", "proj-doc")])
 
 
 def _ns():

--- a/scripts/wiki-maint/test_scan_raw.py
+++ b/scripts/wiki-maint/test_scan_raw.py
@@ -886,5 +886,144 @@ class ContentCoverageTest(unittest.TestCase):
             self.assertEqual(st["raw/tracked-repos/next/def5678/empty.txt"], "NEW")
 
 
+class StrictCoverageTest(unittest.TestCase):
+    """--strict-coverage audit (issue #105): list snapshot files covered
+    only by implicit-dir inheritance, never declared, never content-read."""
+
+    def _vault(self, tmp):
+        """Snapshot raw/repos/proj/abc1234/ with one declared anchor
+        (docs/a.md) and one undeclared sibling (docs/b.md)."""
+        snap = tmp / "raw" / "repos" / "proj" / "abc1234"
+        (snap / "docs").mkdir(parents=True)
+        (snap / ".sync-meta.json").write_text("{}", encoding="utf-8")
+        (snap / "docs" / "a.md").write_text("anchor\n", encoding="utf-8")
+        (snap / "docs" / "b.md").write_text("sibling\n", encoding="utf-8")
+        d = tmp / "wiki" / "sources"
+        d.mkdir(parents=True)
+        (d / "proj-doc.md").write_text(
+            "---\nsource_path: raw/repos/proj/abc1234/docs/a.md\n---\n",
+            encoding="utf-8",
+        )
+        return d
+
+    def _audit(self, tmp, sources_dir):
+        idx = scan_raw.build_index(str(sources_dir))
+        cache = scan_raw.HashCache(str(tmp))
+        snapshot_dirs = scan_raw.find_snapshot_dirs(str(tmp))
+        content_index = scan_raw.build_content_index(idx, str(tmp), cache, snapshot_dirs)
+        files, results, _ = scan_raw.run(str(tmp), _ns(), idx, cache)
+        scan_raw.apply_content_coverage(results, str(tmp), cache, snapshot_dirs, content_index)
+        return scan_raw.find_undeclared(results, str(tmp), cache, snapshot_dirs, content_index)
+
+    def test_dir_implicit_sibling_is_undeclared(self):
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            sd = self._vault(tmp)
+            self.assertEqual(self._audit(tmp, sd),
+                             [("raw/repos/proj/abc1234/docs/b.md", "proj-doc")])
+
+    def test_fully_declared_snapshot_reports_nothing(self):
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            sd = self._vault(tmp)
+            (sd / "proj-doc.md").write_text(
+                "---\nsource_path:\n"
+                "  - raw/repos/proj/abc1234/docs/a.md\n"
+                "  - raw/repos/proj/abc1234/docs/b.md\n---\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(self._audit(tmp, sd), [])
+
+    def test_dir_implicit_outside_snapshot_not_listed(self):
+        # No .sync-meta.json anywhere: out of the audit's scope.
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            deep = tmp / "raw" / "notes" / "a" / "b" / "c"
+            deep.mkdir(parents=True)
+            (deep / "anchor.md").write_text("x\n", encoding="utf-8")
+            (deep / "sibling.md").write_text("y\n", encoding="utf-8")
+            d = tmp / "wiki" / "sources"
+            d.mkdir(parents=True)
+            (d / "s.md").write_text(
+                "---\nsource_path: raw/notes/a/b/c/anchor.md\n---\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(self._audit(tmp, d), [])
+
+    def test_content_covered_sibling_not_listed(self):
+        # The sibling's bytes were read under a previously covered snapshot
+        # of the same dest: not a coverage deficit (deviation from the
+        # issue's letter, aligned with its spirit + #88).
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            sd = self._vault(tmp)
+            old = tmp / "raw" / "repos" / "proj" / "0000000"
+            (old / "docs").mkdir(parents=True)
+            (old / ".sync-meta.json").write_text("{}", encoding="utf-8")
+            (old / "docs" / "b.md").write_text("sibling\n", encoding="utf-8")
+            (sd / "proj-old.md").write_text(
+                "---\nsource_path: raw/repos/proj/0000000/docs/b.md\n---\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(self._audit(tmp, sd), [])
+
+    def test_flag_combinations_rejected(self):
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            self._vault(tmp)
+            env = {**os.environ, "VAULT_ROOT": str(tmp)}
+            for combo in (["--strict-coverage", "--force"],
+                          ["--strict-coverage", "--pending"]):
+                r = subprocess.run(
+                    ["python3", str(HERE / "scan-raw.py"), *combo],
+                    capture_output=True, text=True, env=env)
+                self.assertEqual(r.returncode, 2, combo)
+                self.assertIn("--strict-coverage", r.stderr)
+
+    def test_text_and_json_output_and_default_byte_identical(self):
+        with tempfile.TemporaryDirectory() as dd:
+            tmp = Path(dd)
+            self._vault(tmp)
+            env = {**os.environ, "VAULT_ROOT": str(tmp)}
+            base = subprocess.run(["python3", str(HERE / "scan-raw.py")],
+                                  capture_output=True, text=True, env=env)
+            strict = subprocess.run(
+                ["python3", str(HERE / "scan-raw.py"), "--strict-coverage"],
+                capture_output=True, text=True, env=env)
+            # default output: no UNDECLARED anywhere
+            self.assertNotIn("UNDECLARED", base.stdout + base.stderr)
+            # strict: same verdict lines, plus the appended audit line
+            self.assertEqual(
+                strict.stdout,
+                base.stdout
+                + "UNDECLARED raw/repos/proj/abc1234/docs/b.md  (dir-covered-by: proj-doc)\n")
+            self.assertIn("1 undeclared", strict.stderr)
+            # JSON: key present only under the flag
+            base_j = json.loads(subprocess.run(
+                ["python3", str(HERE / "scan-raw.py"), "--format=json"],
+                capture_output=True, text=True, env=env).stdout)
+            strict_j = json.loads(subprocess.run(
+                ["python3", str(HERE / "scan-raw.py"), "--strict-coverage",
+                 "--format=json"],
+                capture_output=True, text=True, env=env).stdout)
+            self.assertNotIn("undeclared", base_j)
+            self.assertNotIn("undeclared", base_j["counts"])
+            self.assertEqual(strict_j["undeclared"],
+                             [{"path": "raw/repos/proj/abc1234/docs/b.md",
+                               "dir_covered_by": "proj-doc"}])
+            self.assertEqual(strict_j["counts"]["undeclared"], 1)
+
+
+def _ns():
+    """Namespace for tests."""
+    class NS:
+        force = False
+        orphans = False
+        pending = False
+        paths = []
+        format = "text"
+    return NS()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Résumé

**Issue #105** — la couverture implicite par répertoire (`dir-implicit` : un fichier déclaré couvre tous ses siblings) garde les scans silencieux par design, mais un `0 NEW` se lit comme « tout est couvert », ce qui n'est pas son sens. Nouveau flag opt-in `--strict-coverage` révélant le vrai déficit, **défaut byte-identique**.

## Changements

- **`find_undeclared()`** : `UNDECLARED` = verdict `dir-implicit` + sous un dossier snapshot (`.sync-meta.json`) + absent du `content_index` (jamais déclaré via `source_path`/`covered_paths`, jamais lu byte-identique sous une version couverte de la même lineage). Fichiers vides toujours flagués.
- **Sorties** : texte `UNDECLARED <path>  (dir-covered-by: <slug>)` appendé après les ORPHAN ; résumé stderr `· N undeclared` ; JSON `undeclared[]` + `counts.undeclared` — le tout **uniquement sous le flag**.
- **Garde** : `--strict-coverage` × `--force`/`--pending` → erreur usage (exit 2). `--force` réécrit les raisons en `forced` et aurait rendu l'audit silencieusement vide.
- **`cache.save()` déplacé après l'audit** (relevé en revue finale, vérifié empiriquement) : sinon chaque hash calculé par l'audit était jeté et l'audit re-hashait toute sa population à chaque run.
- **Docs** : `docs/tracked-repos-immutable-snapshots.md` énonce explicitement que `0 NEW` ≠ couverture complète ; CHANGELOG `### Added` sous `v1.2.2 — unreleased`.

## Écarts assumés vs la lettre de l'issue (validés)

1. Fichiers **content-covered** exclus de l'audit : leurs bytes ont réellement été lus sous un snapshot précédent (esprit de l'issue + content-coverage #88).
2. Rejet explicite de `--force`/`--pending` plutôt qu'un résultat faux ou vide.

## Critères de l'issue

- ✅ Liste les fichiers couverts uniquement par héritage de répertoire, jamais déclarés
- ✅ Runs par défaut byte-identiques (test pin byte-for-byte, JSON sans nouvelle clé)
- ✅ Snapshot entièrement déclaré → rien
- ✅ Documenté (« a 0 NEW default run does not imply full coverage »)

## Validation

`unittest` : **120/120** ✅ (112 + 8 : 6 TDD + 2 pins de revue) · `format-md --check` : 36 clean ✅ · `validate-wiki` : clean ✅
Revue finale whole-branch + vague de fix re-reviewée (5/5 addressed, cache vérifié peuplé post-run).

Réf. #105 (à fermer manuellement après merge — PR vers `develop`).