### PR TITLE
ci: job unittests pour les suites Python (#119)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,22 @@ jobs:
       - run: python3 -m pip install --quiet pyyaml
       - run: python3 scripts/wiki-maint/validate-wiki.py
 
+  unittests:
+    name: unittests
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      # fastmcp so the MCP server suite runs for real (27 skips otherwise);
+      # pyyaml mirrors the wiki-integrity job. jq (test_sync_repos.py) ships
+      # on ubuntu-latest runners.
+      - run: python3 -m pip install --quiet pyyaml fastmcp
+      - run: python3 -m unittest discover -s scripts/wiki-maint -p "test_*.py"
+      - run: python3 -m unittest discover -s scripts/mcp -p "test_*.py"
+
   link-check-report:
     name: link-check-report
     if: github.event_name == 'schedule'

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The CI (`.github/workflows/lint.yml`) blocks only on **repairable, meaningful** 
 - **`format-check`** — Prettier, Obsidian-safe (via `scripts/wiki-maint/format-md.py`): markdown stays clean by construction without breaking `[[wikilink|alias]]` or code-span pipes in tables.
 - **`markdownlint`** — semantic rules only (MD056, MD042, MD051, MD024); cosmetic rules delegated to Prettier.
 - **`wiki-integrity`** — `scripts/wiki-maint/validate-wiki.py`: broken `[[wikilinks]]`, internal links, frontmatter conformance, and leftover git conflict markers. Skips `raw/`.
+- **`unittests`** — the Python test suites under `scripts/wiki-maint/` and `scripts/mcp/` (`unittest discover`; `fastmcp` installed so the MCP server tests run for real, not as skips).
 - **`link-check-report`** — weekly, **non-blocking** (lychee): external links surfaced as a report, never failing the push.
 
 Run `/format` to normalise a pre-formatter vault; generation commands (`/ingest`, `/save`, `/evolve-agent`) format their output automatically.


### PR DESCRIPTION
Issue #119 — la suite (142+ tests) ne tournait que sur la machine du mainteneur : une régression mergeait vert. Nouveau job sur push/PR (exclu du schedule hebdo) : Python 3.12, pyyaml + fastmcp installés (les 27 tests MCP tournent réellement), unittest discover sur scripts/wiki-maint/ et scripts/mcp/ — inclut le smoke test du guard (#125). README mis à jour.